### PR TITLE
Fixes typo in lesson 1.3 alert steps modal

### DIFF
--- a/src/levels/intro/3.js
+++ b/src/levels/intro/3.js
@@ -63,6 +63,7 @@ exports.level = {
             "To complete this level, do the following steps:",
             "",
             "* Make a new branch called `bugFix`",
+            "* Checkout the `bugFix` branch with `git checkout bugFix`",
             "* Commit once",
             "* Go back to `master` with `git checkout`",
             "* Commit another time",


### PR DESCRIPTION
I noticed there's a typo in the 1.3 alert modal.  If you follow the
directions to the T, it won't pass because it commits to the wrong
branch.

It needs to say make a new branch called `bugFix`,
then `git checkout bugFix`, then commit.

Tests Pass:
13 tests, 13 assertions, 0 failures
I couldn't get it to build to test the text displaying in browser, so
that still needs to be tested.

Screenshot with commands in working order:
![screenshot](http://f.cl.ly/items/2a3l0w3s3S0L3Q1U2H3R/screen_1_3.png)
