### PR TITLE
Remove incorrect information about HEAD

### DIFF
--- a/src/levels/rampup/1.js
+++ b/src/levels/rampup/1.js
@@ -34,11 +34,11 @@ exports.level = {
             "markdowns": [
               "## HEAD",
               "",
-              "First we have to talk about \"HEAD.\" HEAD is the symbolic name for the currently checked out commit -- it's essentially what commit you're working on top of.",
+              "First we have to talk about \"HEAD\". HEAD is the symbolic name for the currently checked out commit -- it's essentially what commit you're working on top of.",
               "",
-              "The working directory will always match the current state of HEAD, so by moving HEAD, you actually change the contents of your directory.",
+              "HEAD always points to the most recent commit which is reflected in the working tree. Most git commands which make changes to the working tree will start by changing HEAD.",
               "",
-              "Normally HEAD points to a branch name (like `bugFix`). When you commit, both bugFix and HEAD move together"
+              "Normally HEAD points to a branch name (like bugFix). When you commit, the status of bugFix is altered and this change is visible through HEAD."
             ]
           }
         },


### PR DESCRIPTION
The statement that the working directory (aside: "working tree" would be
a more git-like term) will always match the current state of HEAD is
completely incorrect.  That would imply that changes to files get in
some way committed as files are saved.

Even the second part of the paragraph is incorrect.  Changing HEAD does
not necessarily change the contents of the working tree as in `git
reset` without the `--hard` option.
