### PR TITLE
Don't refer to grandparent commit as second parent

### DIFF
--- a/src/levels/rampup/2.js
+++ b/src/levels/rampup/2.js
@@ -48,7 +48,7 @@ exports.level = {
               "",
               "So saying `master^` is equivalent to \"the first parent of `master`\".",
               "",
-              "`master^^` is the second parent (or grandparent) of `master`",
+              "`master^^` is the grandparent (second-generation ancestor) of `master`",
               "",
               "Let's check out the commit above master here"
             ],


### PR DESCRIPTION
The term "second parent" has a specific meaning in git that is distinct
from a grandparent, so avoid referring to a grandparent (~2) as a second
parent (^2).
