### PR TITLE
Create a level demonstrating ^2 modifier

### DIFF
--- a/src/levels/index.js
+++ b/src/levels/index.js
@@ -11,7 +11,8 @@ exports.levelSequences = {
     require('../../levels/rampup/1').level,
     require('../../levels/rampup/2').level,
     require('../../levels/rampup/3').level,
-    require('../../levels/rampup/4').level
+    require('../../levels/rampup/4').level,
+    require('../../levels/rampup/5').level
   ],
   rebase: [
     require('../../levels/rebase/1').level,

--- a/src/levels/rampup/5.js
+++ b/src/levels/rampup/5.js
@@ -1,0 +1,51 @@
+exports.level = {
+  "goalTreeString": "{\"branches\":{\"master\":{\"target\":\"C7\",\"id\":\"master\"},\"bugWork\":{\"target\":\"C2\",\"id\":\"bugWork\"}},\"commits\":{\"C0\":{\"parents\":[],\"id\":\"C0\",\"rootCommit\":true},\"C1\":{\"parents\":[\"C0\"],\"id\":\"C1\"},\"C2\":{\"parents\":[\"C1\"],\"id\":\"C2\"},\"C3\":{\"parents\":[\"C1\"],\"id\":\"C3\"},\"C4\":{\"parents\":[\"C3\"],\"id\":\"C4\"},\"C5\":{\"parents\":[\"C2\"],\"id\":\"C5\"},\"C6\":{\"parents\":[\"C4\",\"C5\"],\"id\":\"C6\"},\"C7\":{\"parents\":[\"C6\"],\"id\":\"C7\"}},\"HEAD\":{\"target\":\"master\",\"id\":\"HEAD\"}}",
+  "solutionCommand": "git branch bugWork master^^2^",
+  "startTree": "{\"branches\":{\"master\":{\"target\":\"C7\",\"id\":\"master\"}},\"commits\":{\"C0\":{\"parents\":[],\"id\":\"C0\",\"rootCommit\":true},\"C1\":{\"parents\":[\"C0\"],\"id\":\"C1\"},\"C2\":{\"parents\":[\"C1\"],\"id\":\"C2\"},\"C3\":{\"parents\":[\"C1\"],\"id\":\"C3\"},\"C4\":{\"parents\":[\"C3\"],\"id\":\"C4\"},\"C5\":{\"parents\":[\"C2\"],\"id\":\"C5\"},\"C6\":{\"parents\":[\"C4\",\"C5\"],\"id\":\"C6\"},\"C7\":{\"parents\":[\"C6\"],\"id\":\"C7\"}},\"HEAD\":{\"target\":\"master\",\"id\":\"HEAD\"}}",
+  "name": {
+    "en_US": "Multiple parents"
+  },
+  "hint": {
+    "en_US": "Use `git branch bugWork` with a target commit to create the missing reference."
+  },
+  "startDialog": {
+    "en_US": {
+      "childViews": [
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Like the `~` modifier, the `^` modifier also accepts an optional number after it. Rather than specifying a number of generations to go back, it specifies which parent reference to follow from a merge commit. The first parent is the one that was referenced by HEAD when the merge was done, and on this site will always be directly above the child.",
+              "",
+              "",
+              ""
+            ],
+            "afterMarkdowns": [
+              "",
+              "",
+              ""
+            ],
+            "command": "git checkout master^; git checkout master^2",
+            "beforeCommand": "git checkout HEAD^; git commit; git checkout master; git merge C2"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "The `^` and `~` modifiers may be combined. When this is done, they are processed from the left to the right.",
+              "",
+              ""
+            ],
+            "afterMarkdowns": [
+              "The first `~` goes back one generation to C6, adding `^2` follows the reference to C5, and the final `~2` then goes back two additional generations to reach the ultimate destination.",
+              ""
+            ],
+            "command": "git checkout HEAD~^2~2",
+            "beforeCommand": "git commit; git checkout C0; git commit; git commit; git commit; git checkout master; git merge C5; git commit"
+          }
+        }
+      ]
+    }
+  }
+};


### PR DESCRIPTION
This could use a looking over before merging.

May also want to put this level in a different location, I think it would fit a bit better as rampup4 moving that existing level to rampup5, but I suspect that might cause a small problem for people who already have a cookie indicating that they've completed that level.
