### PR TITLE
Fix Issue #149

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Here is the high level process of the build:
 
 Thus, if you build the app locally, all you have to do in order to run the app is just open up `index.html` in the root directory of the repo. Pretty simple
 
-## Building yourself / Contributing Functionality 
+## Building yourself / Contributing Functionality
 
 For contributing core functionality in the app, you'll probably want to test your changes
 at least once before submitting a pull request. That means you'll need the `grunt` build tool. It's a fairly
@@ -72,7 +72,7 @@ git checkout -b newAwesomeFeature
 # after building you can open up your browser to the index.html that is generated and see your changes
 grunt watch # will keep watch over files and fastBuild whenever they change. lot of CPU though
 # more changes
-grunt build # build runs the tests and lint as well
+./node_modules/grunt/bin/grunt build # build runs the tests and lint as well
 git commit -am "My new sweet feature!"
 git push
 # go online and request a pull

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.5.0",
   "devDependencies": {
     "grunt": "~0.3.17",
-    "jasmine-node": "~1.0.28",
+    "jasmine-node": "~1.11.0",
     "grunt-browserify": "0.1.1",
     "grunt-jslint": "~0.2.2-1",
-    "grunt-jasmine-node": "0.0.6",
+    "grunt-jasmine-node": "0.1.0",
     "grunt-hash": "0.2.2",
     "grunt-rm": "~0.0.3",
     "grunt-shell": "0.1.4",


### PR DESCRIPTION
I've upgraded `jasmine-node` and `grunt-jasmine-node` to the latest version.
Python 3.0+ didn't work before, but now it works well.
Now you can try to run `grunt build` to test it! :-D
