### PR TITLE
Fixing ie support

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -66,7 +66,7 @@ div.modalTerminal p {
 html,
 body,
 .box {
-  display: flex;
+  display: flexbox;
   display: -moz-box;
   display: -webkit-box;
   display: -ms-flexbox;


### PR DESCRIPTION
I am trying to make this work well in IE 10 & 11 as well as Chrome and FF. Here are a first set of changes. This fixes:
- Overall display works (areas where desired, etc).

Does not fix:
- Layout of several elements is ignoring their right box. Several boxes are collapsing, with all of their contents laid out not as child elements within the box. This is most obvious on the levels select dialog, but also shows in the history display, goal window, etc.

I am looking for help here. Rather than spelunking, can you show me what parts of the styling are supposed to handle the layout / positioning for these areas?

Changes made:
- Correct the -ms- properties related to flexboxes. They were using the wrong names & values.
- Correct the non-prefixed properties related to flexboxes. They were not using the final standard values (they were using the webkit ones, which did not always match the final standard).
