### PR TITLE
Teaching the "-b" option in lesson 2

### DIFF
--- a/src/levels/intro/branching.js
+++ b/src/levels/intro/branching.js
@@ -88,11 +88,20 @@ exports.level = {
               "This will put us on the new branch before committing our changes"
             ],
             "afterMarkdowns": [
-              "There we go! Our changes were recorded on the new branch"
-            ],
+              "There we go! Our changes were recorded on the new branch.",
+              ""
+             ],
             "command": "git checkout newImage; git commit",
             "beforeCommand": "git branch newImage"
           }
+        },
+         {
+            "type": "ModalAlert",
+            "options": {
+                "markdowns": [
+                  "Here's a shortcut: if you want to create a new branch AND check it out at the same time, you can simply type git checkout -b [yourbranchname].  "
+                ]
+            }
         },
         {
           "type": "ModalAlert",


### PR DESCRIPTION
Adds a modal that pops up in level2 and teaches the "-b" command that's required in order to get a perfect solution on level3. Allows the student who's paying attention to solve level1 in one step, beating the standard,
but doesn't get in the way of a student solving it the traditional way. However, the real argument for it is that you never want to put material on the test that you didn't talk about in class. It just seemed like a lost opportunity to make "-b" a requirement for level 3 perfection but never introduce it to the student.