### PR TITLE
Fix for #406: scroll for the terminal in Firefox

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -558,6 +558,7 @@ p.commandLine span.prompt {
 }
 
 #commandLineHistory {
+  height: 100%;
   margin: 10px;
   border-radius: 5px;
   box-shadow: 1px 0px 15px rgba(100, 100, 100, 1);


### PR DESCRIPTION
Seems like Firefox requires the height property in order to display the scroll.