### PR TITLE
LICENSE.md: format title

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+## MIT License
 
 Copyright (c) 2012 Peter Cottle
 


### PR DESCRIPTION
Now that the license file is a markdown file, the license title can be marked accordingly, to make it more conspicuous and convenient.