### PR TITLE
commands.js: add --force alias to the -f option (fix #472)

### DIFF
--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -413,6 +413,7 @@ var commandConfig = {
       '-d',
       '-D',
       '-f',
+      '--force',
       '-a',
       '-r',
       '-u',
@@ -458,8 +459,9 @@ var commandConfig = {
         return;
       }
 
-      if (commandOptions['-f']) {
-        args = commandOptions['-f'].concat(generalArgs);
+      if (commandOptions['-f'] || commandOptions['--force']) {
+        args = commandOptions['-f'] || commandOptions['--force'];
+        args = args.concat(generalArgs);
         command.twoArgsImpliedHead(args, '-f');
 
         // we want to force a branch somewhere


### PR DESCRIPTION
Modeled after the current implementation of `branch -d` / `branch -D`

Note: since I'm not familiar with the code, this PR is an experimental submission to address #472; if it's successful, it will hopefully illuminate a viable path for me or others to submit follow-up PRs adding the remaining missing aliases, for consistency, as discussed in that issue thread.