### PR TITLE
Generate alternate url for different locales so search engine could find them all.

### DIFF
--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -1,6 +1,7 @@
 var Backbone = require('backbone');
 var EventEmitter = require('events').EventEmitter;
 var React = require('react');
+var _ = require('underscore');
 
 var assign = require('object-assign');
 var util = require('../util');
@@ -84,6 +85,22 @@ var vcsModeRefresh = function(eventData) {
 
   $('body').toggleClass('gitMode', isGit);
   $('body').toggleClass('hgMode', !isGit);
+};
+
+var insertAlternateLinks = function(pageId) {
+  // For now pageId is null, which would link to the main page.
+  // In future if pageId is provided this method should link to a specific page
+
+  // The value of the hreflang attribute identifies the language (in ISO 639-1 format)
+  // and optionally a region (in ISO 3166-1 Alpha 2 format) of an alternate URL
+  var altLinks = _.map(LocaleStore.getSupportedLocales(), function(langCode) {
+    var url = "https://learngitbranching.js.org/?locale=" + langCode;
+    return '<link rel="alternate" hreflang="'+langCode+'" href="' + url +'" />';
+  });
+  var defaultUrl = "https://learngitbranching.js.org/?locale=" + LocaleStore.getDefaultLocale();
+  altLinks.push('<link rel="alternate" hreflang="x-default" href="' + defaultUrl +'" />');
+  $('head').prepend(altLinks);
+
 };
 
 var intlRefresh = function() {
@@ -249,6 +266,8 @@ var initDemo = function(sandbox) {
     tryLocaleDetect();
   }
 
+  insertAlternateLinks();
+
   if (params.command) {
     var command = unescape(params.command);
     sandbox.mainVis.customEvents.on('gitEngineReady', function() {
@@ -328,4 +347,3 @@ exports.getLevelDropdown = function() {
 };
 
 exports.init = init;
-

--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -1,7 +1,6 @@
 var Backbone = require('backbone');
 var EventEmitter = require('events').EventEmitter;
 var React = require('react');
-var _ = require('underscore');
 
 var assign = require('object-assign');
 var util = require('../util');
@@ -93,7 +92,8 @@ var insertAlternateLinks = function(pageId) {
 
   // The value of the hreflang attribute identifies the language (in ISO 639-1 format)
   // and optionally a region (in ISO 3166-1 Alpha 2 format) of an alternate URL
-  var altLinks = _.map(LocaleStore.getSupportedLocales(), function(langCode) {
+
+  var altLinks = LocaleStore.getSupportedLocales().map(function(langCode) {
     var url = "https://learngitbranching.js.org/?locale=" + langCode;
     return '<link rel="alternate" hreflang="'+langCode+'" href="' + url +'" />';
   });

--- a/src/js/stores/LocaleStore.js
+++ b/src/js/stores/LocaleStore.js
@@ -3,6 +3,7 @@
 var AppConstants = require('../constants/AppConstants');
 var AppDispatcher = require('../dispatcher/AppDispatcher');
 var EventEmitter = require('events').EventEmitter;
+var _ = require('underscore');
 
 var assign = require('object-assign');
 
@@ -29,6 +30,8 @@ var headerLocaleMap = {
   'zh-TW': 'zh_TW',
   'pt-BR': 'pt_BR'
 };
+
+var supportedLocalesList = _.values(langLocaleMap).concat(_.values(headerLocaleMap));
 
 function _getLocaleFromHeader(langString) {
   var languages = langString.split(',');
@@ -71,6 +74,10 @@ AppConstants.StoreSubscribePrototype,
 
   getLocale: function() {
     return _locale;
+  },
+
+  getSupportedLocales: function() {
+    return assign({}, supportedLocalesList);
   },
 
   dispatchToken: AppDispatcher.register(function(payload) {

--- a/src/js/stores/LocaleStore.js
+++ b/src/js/stores/LocaleStore.js
@@ -3,7 +3,6 @@
 var AppConstants = require('../constants/AppConstants');
 var AppDispatcher = require('../dispatcher/AppDispatcher');
 var EventEmitter = require('events').EventEmitter;
-var _ = require('underscore');
 
 var assign = require('object-assign');
 
@@ -31,7 +30,9 @@ var headerLocaleMap = {
   'pt-BR': 'pt_BR'
 };
 
-var supportedLocalesList = _.values(langLocaleMap).concat(_.values(headerLocaleMap));
+var supportedLocalesList = Object.values(langLocaleMap)
+                                 .concat(Object.values(headerLocaleMap))
+                                 .filter(function (value, index, self) { return self.indexOf(value) === index;});
 
 function _getLocaleFromHeader(langString) {
   var languages = langString.split(',');
@@ -77,7 +78,7 @@ AppConstants.StoreSubscribePrototype,
   },
 
   getSupportedLocales: function() {
-    return assign({}, supportedLocalesList);
+    return supportedLocalesList.slice();
   },
 
   dispatchToken: AppDispatcher.register(function(payload) {


### PR DESCRIPTION
According to [google documents](https://support.google.com/webmasters/answer/189077)  a site can notify google about alternative locales, using html files of the form:
`<link rel="alternate" hreflang="lang_code"... >` 

This pull request generates such links for each of the locales defined in the LocaleStore and inserts them to the top of <head> element where search engines can find it. (I hope google is smart enough to parse head again after js loads, otherwise this is kind of in vane.)
