### PR TITLE
Remove module object-assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "flux": "^2.0.1",
     "jquery": "~1.7.3",
     "markdown": "~0.4.0",
-    "object-assign": "^2.0.0",
     "q": "~0.8.11",
     "react": "^0.13.1",
     "underscore": "~1.4.3"

--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -2,7 +2,6 @@ var Backbone = require('backbone');
 var EventEmitter = require('events').EventEmitter;
 var React = require('react');
 
-var assign = require('object-assign');
 var util = require('../util');
 var intl = require('../intl');
 var LocaleStore = require('../stores/LocaleStore');
@@ -11,7 +10,7 @@ var LocaleActions = require('../actions/LocaleActions');
 /**
  * Globals
  */
-var events = assign(
+var events = Object.assign(
   {},
   EventEmitter.prototype,
   {


### PR DESCRIPTION
We can use `Object.assign` with Node.js 4 or higher.