### PR TITLE
Fix space-group in <vcs> <command>

### DIFF
--- a/src/js/commands/index.js
+++ b/src/js/commands/index.js
@@ -127,7 +127,7 @@ var parse = function(str) {
         // before our "stuff" we can simply
         // split on space-groups and grab everything after
         // the second:
-        options = str.match(/('.*?'|".*?"|\S+)/g).slice(2).join(' ');
+        options = str.match(/('.*?'|".*?"|\S+)/g).slice(2);
       }
     });
   });
@@ -170,11 +170,8 @@ function CommandOptionParser(vcs, method, options) {
 }
 
 CommandOptionParser.prototype.explodeAndSet = function() {
-  // TODO -- this is ugly
-  // split on spaces, except when inside quotes
-  var exploded = this.rawOptions.match(/('.*?'|".*?"|\S+)/g) || [];
-  for (var i = 0; i < exploded.length; i++) {
-    var part = exploded[i];
+  for (var i = 0; i < this.rawOptions.length; i++) {
+    var part = this.rawOptions[i];
 
     if (part.slice(0,1) == '-') {
       // it's an option, check supportedMap
@@ -187,7 +184,7 @@ CommandOptionParser.prototype.explodeAndSet = function() {
         });
       }
 
-      var next = exploded[i + 1];
+      var next = this.rawOptions[i + 1];
       var optionArgs = [];
       if (next && next.slice(0,1) !== '-') {
         // only store the next argument as this


### PR DESCRIPTION
Fixed #506  when I have many space between <vcs> and <command>

We don't need `join` option and split it again.