### PR TITLE
Fixed some css wrong

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -562,6 +562,7 @@ p.commandLine span.prompt {
   margin: 10px;
   border-radius: 5px;
   box-shadow: 1px 0px 15px rgba(100, 100, 100, 1);
+  overflow: auto;
 }
 
 #commandLineHistory #terminal.scrolling {

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -253,7 +253,7 @@ body.hgMode .visBackgroundColor {
 
 #interfaceWrapper {
   min-width: 600px;
-  min-height: 600px;
+  min-height: 400px;
 }
 
 div.canvasTerminalHolder > div.terminal-window-holder > div.wrapper {
@@ -1256,4 +1256,3 @@ div.gitDemonstrationView {
   border-top-color: #9bcbeb;
   background: #9bcbeb;
 }
-

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -826,6 +826,7 @@ div.modalView.box.inFront.show {
 .modalView .terminal-window-holder {
   border-radius: 5px;
   max-width: 900px;
+  width: 90%;
 }
 
 .modalView .terminal-window {


### PR DESCRIPTION
Fix #478.
- When we scale browser to 125%
- Fixed  `#terminal`  will overlay `commandLineBar` if `#terminal` is long.
- Avoid display 900px in small screen