### PR TITLE
fix(css): fix offset top of select level (in firefox)

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -72,6 +72,10 @@ body,
   display: -ms-flexbox;
 }
 
+.contentHolder {
+  display: flex;
+}
+
 body,
 .flex1 {
   -webkit-box-flex: 1;


### PR DESCRIPTION
In firefox, we can't see all of dialog select level (#474 )
![old](https://user-images.githubusercontent.com/19208123/49596941-0b0fa300-f9ae-11e8-82c4-a10cbc20b074.png)


After fixed it:
![Preview result](https://user-images.githubusercontent.com/19208123/49596460-f4b51780-f9ac-11e8-83cd-577885c68092.png)
