### PR TITLE
Use 'grunt fastBuild' in Gitpod to build the app faster

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,4 +3,4 @@ ports:
   onOpen: open-preview
 tasks:
 - init: npm install && npm install -g grunt-cli
-  command: grunt build && python3 -m http.server 8000
+  command: grunt fastBuild && python3 -m http.server 8000


### PR DESCRIPTION
Follow-up improvement to #546.

@pcottle I'm also happy to add an `echo` command as suggested in https://github.com/pcottle/learnGitBranching/pull/546#issuecomment-467761064 if you think that's a good idea.

Please take a look when you have time.