### PR TITLE
Print helpful welcome message in Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,4 +3,7 @@ ports:
   onOpen: open-preview
 tasks:
 - init: npm install && npm install -g grunt-cli
-  command: grunt fastBuild && python3 -m http.server 8000
+  command: >
+    grunt fastBuild &&
+    printf "\nWelcome to Learn Git Branching\nTo rebuild the app, simply run 'grunt fastBuild' and reload index.html.\n\n" &&
+    python3 -m http.server 8000 2>/dev/null


### PR DESCRIPTION
This implements https://github.com/pcottle/learnGitBranching/pull/546#issuecomment-467761064 as requested in https://github.com/pcottle/learnGitBranching/pull/548#issuecomment-467972574.

Here is what it looks like (see the two additional lines printed in the Terminal):

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/learnGitBranching/blob/master/src/js/git/index.js)
<img width="1552" alt="screenshot 2019-02-28 at 12 51 14" src="https://user-images.githubusercontent.com/599268/53564685-d7c95400-3b57-11e9-81b3-c7820609a4be.png">

Please let me know if you like the wording, or how it can be improved.

Notes:
- I used `printf` instead of `echo` as it's generally safer with escaped characters and CLI options across various shells
- I've disabled `python3 -m http.server 8000`'s error output, as it was printing new lines on every served resource, thus quickly hiding the message

Another option could be to open two terminals side-by-side, and have e.g. the left terminal print the message, and the right terminal running the server. For example, the Firefox Devtools Profiler also did [something like that](https://github.com/firefox-devtools/profiler/blob/master/.gitpod.yml#L7-L8).