### PR TITLE
Update `grunt` version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "browserify": "^13.0.0",
-    "grunt": "~0.4.2",
+    "grunt": "^1.0.4",
     "grunt-browserify": "^4.0.1",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.2",


### PR DESCRIPTION
Fix error can't find `grunt`.

When I install with : `npm i` to install dependencies and devDependencies, It don't add bin for `grunt` (e7b7a8d removed `grunt-cli`).

If you install with Yarn, it is ok because `yarn.lock` have `grunt-cli` (if you remove yarn.lock and re-install, we will don't have `grunt-cli`).

`grunt` has bin file in new version so my recommend is update `grunt`.