### PR TITLE
remove Node.js v7 in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - "10"
   - "8"
-  - "7"
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
This project uses `contributor-faces`, it includes `gh-got`.

And `gh-got` require Node v8 so `travis-ci` will have the error.

So I have 2 option:

- Remove Nodejs v7 in `.travis.yml` (merge this pull request if you choose this way)
- Or install `contributor-faces` in your machine(require Node >= 8) and sometimes run `contributor-faces .` in your project to update list contributor(if you choose this way, you should reject this pull request and remove `contributor-faces` in `package.json`)

Or you can remove `contributor-faces` and use another way.