### PR TITLE
Explicitly fail when unsupported range operator is specified

### DIFF
--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -142,6 +142,13 @@ describe('Git', function() {
     );
   });
 
+  it('Range operator is not supported', function() {
+    expectTreeAsync(
+      'git checkout -b side C0; git cherry-pick C1..C0',
+      '{"branches":{"master":{"target": "C1","id": "master"},"side":{"target":"C0","id": "side"}},"commits":{"C0":{"parents":[],"id": "C0","rootCommit": true},"C1":{"parents":["C0"],"id": "C1"}},"HEAD":{"id": "HEAD","target":"side"}}'
+    );
+  });
+
   it('Forces branches', function() {
     expectTreeAsync(
       'git checkout -b side; git branch -f side C0',

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -1665,7 +1665,7 @@ GitEngine.prototype.resolveStringRef = function(ref) {
   // Attempt to split ref string into a reference and a string of ~ and ^ modifiers.
   var startRef = null;
   var relative = null;
-  var regex = /^([a-zA-Z0-9]+)(([~\^]\d*)*)/;
+  var regex = /^([a-zA-Z0-9]+)(([~\^]\d*)*)$/;
   var matches = regex.exec(ref);
   if (matches) {
     startRef = matches[1];


### PR DESCRIPTION
Currently the range operator (e.g. "master..future") is misinterpreted as a relative ref, due to a regex which strips off everything from the dots onwards. As a result, "master..future" is interpreted as just "master". Because the regex is not strict, many other illegal forms are also misinterpreted as relative refs, such as "master&&&".

This PR adds "$" (zero-length line terminator) to the end of the regex, forcing the regex to match the whole argument. This way, if the argument is not actually a relative ref, it will not be interpreted as such. The result will be an error ("The ref master..future does not exist or is unknown"), which I think is preferable to the current behavior.

See #561 