### PR TITLE
chore: use `every` instead of `uniq`

### DIFF
--- a/src/js/graph/treeCompare.js
+++ b/src/js/graph/treeCompare.js
@@ -98,11 +98,9 @@ TreeCompare.compareAllBranchesWithinTrees = function(treeA, treeB) {
     treeB.branches
   );
 
-  var result = true;
-  _.uniq(allBranches, function(info, branch) {
-    result = result && this.compareBranchWithinTrees(treeA, treeB, branch);
-  }, this);
-  return result;
+  return Object.keys(allBranches).every(function(branch) {
+    return this.compareBranchWithinTrees(treeA, treeB, branch);
+  }.bind(this));
 };
 
 TreeCompare.compareAllTagsWithinTrees = function(treeA, treeB) {

--- a/src/js/stores/LevelStore.js
+++ b/src/js/stores/LevelStore.js
@@ -3,8 +3,6 @@
 var AppConstants = require('../constants/AppConstants');
 var AppDispatcher = require('../dispatcher/AppDispatcher');
 var EventEmitter = require('events').EventEmitter;
-
-var _ = require('underscore');
 var assign = require('object-assign');
 var levelSequences = require('../../levels').levelSequences;
 var sequenceInfo = require('../../levels').sequenceInfo;


### PR DESCRIPTION
You use `_.uniq` but don't return value of `_.uniq`.

You use that function to check `result` value so my recommendation is to use `every`, it will break if the value of callback `false` to avoid call other callback when `result` is `false`

And I remove one line call `underscore` but don't call `_`