### PR TITLE
More robust support for revision ranges

### DIFF
--- a/__tests__/base.js
+++ b/__tests__/base.js
@@ -1,3 +1,5 @@
+var Q = require('q');
+
 var HeadlessGit = require('../src/js/git/headless').HeadlessGit;
 var TreeCompare = require('../src/js/graph/treeCompare.js');
 
@@ -95,6 +97,27 @@ var expectLevelSolved = function(levelBlob) {
   expectLevelAsync(headless, levelBlob);
 };
 
+var runCommand = function(command, resultHandler) {
+  var headless = new HeadlessGit();
+  var deferred = Q.defer();
+  var msg = null;
+
+  deferred.promise.then(function(commands) {
+    msg = commands[commands.length - 1].get('error').get('msg');
+  });
+
+  runs(function() {
+    headless.sendCommand(command, deferred);
+  });
+  waitsFor(function() {
+    if(null == msg) {
+      return false;
+    }
+    resultHandler(msg);
+    return true;
+  }, 'commands should be finished', 500);
+};
+
 var TIME = 150;
 // useful for throwing garbage and then expecting one commit
 var ONE_COMMIT_TREE = '{"branches":{"master":{"target":"C2","id":"master"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"},"C2":{"parents":["C1"],"id":"C2"}},"HEAD":{"target":"master","id":"HEAD"}}';
@@ -105,6 +128,7 @@ module.exports = {
   TIME: TIME,
   expectTreeAsync: expectTreeAsync,
   expectLevelSolved: expectLevelSolved,
-  ONE_COMMIT_TREE: ONE_COMMIT_TREE
+  ONE_COMMIT_TREE: ONE_COMMIT_TREE,
+  runCommand: runCommand
 };
 

--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -276,6 +276,43 @@ describe('Git', function() {
 		);
   });
 
+  describe('RevList', function() {
+
+    it('requires at least 1 argument', function() {
+      runCommand('git rev-list', function(commandMsg) {
+        expect(commandMsg).toContain('at least 1');
+      });
+    });
+
+    describe('supports', function() {
+      var SETUP = 'git co -b left C0; gc; git merge master; git co -b right C0; gc; git merge master; git co -b all left; git merge right; ';
+
+      it('single included revision', function() {
+        runCommand(SETUP + 'git rev-list all', function(commandMsg) {
+          expect(commandMsg).toBe('C6\nC5\nC4\nC3\nC2\nC1\nC0\n');
+        });
+      });
+
+      it('single excluded revision', function() {
+        runCommand(SETUP + 'git rev-list all ^right', function(commandMsg) {
+          expect(commandMsg).toBe('C6\nC3\nC2\n');
+        });
+      });
+
+      it('multiple included revisions', function() {
+        runCommand(SETUP + 'git rev-list right left', function(commandMsg) {
+          expect(commandMsg).toBe('C5\nC4\nC3\nC2\nC1\nC0\n');
+        });
+      });
+
+      it('multiple excluded revisions', function() {
+        runCommand(SETUP + 'git rev-list all ^right ^left', function(commandMsg) {
+          expect(commandMsg).toBe('C6\n');
+        });
+      });
+    });
+  });
+
   describe('Log supports', function() {
     var SETUP = 'git co -b left C0; gc; git merge master; git co -b right C0; gc; git merge master; git co -b all left; git merge right; ';
 

--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -351,5 +351,29 @@ describe('Git', function() {
         expect(commandMsg).toContain('Commit: C6\n');
       });
     });
+
+    it('multiple included revisions', function() {
+      runCommand(SETUP + 'git log right left', function(commandMsg) {
+        expect(commandMsg).toContain('Commit: C0\n');
+        expect(commandMsg).toContain('Commit: C1\n');
+        expect(commandMsg).toContain('Commit: C2\n');
+        expect(commandMsg).toContain('Commit: C3\n');
+        expect(commandMsg).toContain('Commit: C4\n');
+        expect(commandMsg).toContain('Commit: C5\n');
+        expect(commandMsg).not.toContain('Commit: C6\n');
+      });
+    });
+
+    it('multiple excluded revisions', function() {
+      runCommand(SETUP + 'git log all ^right ^left', function(commandMsg) {
+        expect(commandMsg).not.toContain('Commit: C0\n');
+        expect(commandMsg).not.toContain('Commit: C1\n');
+        expect(commandMsg).not.toContain('Commit: C2\n');
+        expect(commandMsg).not.toContain('Commit: C3\n');
+        expect(commandMsg).not.toContain('Commit: C4\n');
+        expect(commandMsg).not.toContain('Commit: C5\n');
+        expect(commandMsg).toContain('Commit: C6\n');
+      });
+    });
   });
 });

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -592,19 +592,8 @@ var commandConfig = {
     execute: function(engine, command) {
       var generalArgs = command.getGeneralArgs();
 
-      if (generalArgs.length == 2) {
-        // do fancy git log branchA ^branchB
-        if (generalArgs[1][0] == '^') {
-          engine.logWithout(generalArgs[0], generalArgs[1]);
-        } else {
-          throw new GitError({
-            msg: intl.str('git-error-options')
-          });
-        }
-      }
-
-      command.oneArgImpliedHead(generalArgs);
-      engine.log(generalArgs[0]);
+      command.impliedHead(generalArgs, 0);
+      engine.log(generalArgs);
     }
   },
 

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -574,6 +574,18 @@ var commandConfig = {
     }
   },
 
+  revlist: {
+    dontCountForGolf: true,
+    displayName: 'rev-list',
+    regex: /^git +rev-list($|\s)/,
+    execute: function(engine, command) {
+      var generalArgs = command.getGeneralArgs();
+      command.validateArgBounds(generalArgs, 1);
+
+      engine.revlist(generalArgs);
+    }
+  },
+
   log: {
     dontCountForGolf: true,
     regex: /^git +log($|\s)/,

--- a/src/js/git/headless.js
+++ b/src/js/git/headless.js
@@ -109,6 +109,8 @@ HeadlessGit.prototype.sendCommand = function(value, entireCommandPromise) {
   var chain = deferred.promise;
   var startTime = new Date().getTime();
 
+  var commands = [];
+
   util.splitTextCommand(value, function(commandStr) {
     chain = chain.then(function() {
       var commandObj = new Command({
@@ -117,6 +119,7 @@ HeadlessGit.prototype.sendCommand = function(value, entireCommandPromise) {
 
       var thisDeferred = Q.defer();
       this.gitEngine.dispatch(commandObj, thisDeferred);
+      commands.push(commandObj);
       return thisDeferred.promise;
     }.bind(this));
   }, this);
@@ -124,7 +127,7 @@ HeadlessGit.prototype.sendCommand = function(value, entireCommandPromise) {
   chain.then(function() {
     var nowTime = new Date().getTime();
     if (entireCommandPromise) {
-      entireCommandPromise.resolve();
+      entireCommandPromise.resolve(commands);
     }
   });
 

--- a/src/js/models/commandModel.js
+++ b/src/js/models/commandModel.js
@@ -126,18 +126,14 @@ var Command = Backbone.Model.extend({
   oneArgImpliedHead: function(args, option) {
     this.validateArgBounds(args, 0, 1, option);
     // and if it's one, add a HEAD to the back
-    if (args.length === 0) {
-      args.push('HEAD');
-    }
+    this.impliedHead(args, 0);
   },
 
   twoArgsImpliedHead: function(args, option) {
     // our args we expect to be between 1 and 2
     this.validateArgBounds(args, 1, 2, option);
     // and if it's one, add a HEAD to the back
-    if (args.length == 1) {
-      args.push('HEAD');
-    }
+    this.impliedHead(args, 1);
   },
 
   oneArgImpliedOrigin: function(args) {
@@ -149,6 +145,12 @@ var Command = Backbone.Model.extend({
 
   twoArgsForOrigin: function(args) {
     this.validateArgBounds(args, 0, 2);
+  },
+
+  impliedHead: function(args, min) {
+    if(args.length == min) {
+      args.push('HEAD');
+    }
   },
 
   // this is a little utility class to help arg validation that happens over and over again


### PR DESCRIPTION
This is the first step in adding greater support for revision ranges (see #561). Currently, only log supports revision ranges, it only supports specific kinds (single tip includes and excludes), and only in very limited formats ("git log include" or "git log include ^exclude"). With this PR, log now supports any number of single tip includes or excludes, in any order, as real git does.

This PR also introduces support for the "rev-list" command, which uses the same revision range capability. In addition to increased git compatibility, the rev-list command also provides much simpler output with which to test the output ordering of revision ranges.

Compatibility Note: this PR changes the output ordering of the log command. The previous ordering was essentially a breadth-first search. The new ordering follows the git default, which is based on commit date.
