### PR TITLE
Range operator

### DIFF
--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -317,6 +317,18 @@ describe('Git', function() {
           expect(commandMsg).toBe('C6\n');
         });
       });
+
+      it('range between branches', function() {
+        runCommand(SETUP + 'git rev-list left..right', function(commandMsg) {
+          expect(commandMsg).toBe('C5\nC4\n');
+        });
+      });
+
+      it('range between commits', function() {
+        runCommand(SETUP + 'git rev-list C3..C5', function(commandMsg) {
+          expect(commandMsg).toBe('C5\nC4\n');
+        });
+      });
     });
   });
 

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -3070,39 +3070,49 @@ var Tag = Ref.extend({
 
 function RevisionRange(engine, specifiers) {
   this.engine = engine;
-  this.included = {};
-  this.excluded = {};
+  this.tipsToInclude = [];
+  this.tipsToExclude = [];
+  this.includedRefs = {};
+  this.excludedRefs = {};
   this.revisions = [];
 
   this.processSpecifiers(specifiers);
 }
 
-RevisionRange.prototype.isExclusion = function(specifier) {
-  return specifier.startsWith('^');
+RevisionRange.prototype.processAsExclusion = function(specifier) {
+  if(!specifier.startsWith('^')) {
+    return false;
+  }
+  this.tipsToExclude.push(specifier.slice(1));
+  return true;
+};
+
+RevisionRange.prototype.processAsInclusion = function(specifier) {
+  this.tipsToInclude.push(specifier);
+  return true;
 };
 
 RevisionRange.prototype.processSpecifiers = function(specifiers) {
   var self = this;
-  var inclusions = [];
-  var exclusions = [];
+  var processors = [
+    this.processAsExclusion
+  ];
 
   specifiers.forEach(function(specifier) {
-    if(self.isExclusion(specifier)) {
-      exclusions.push(specifier.slice(1));
-    } else {
-      inclusions.push(specifier);
+    if(!processors.some(function(processor) { return processor.bind(self)(specifier); })) {
+      self.processAsInclusion(specifier);
     }
   });
 
-  exclusions.forEach(function(exclusion) {
+  this.tipsToExclude.forEach(function(exclusion) {
     self.addExcluded(Graph.getUpstreamSet(self.engine, exclusion));
   });
 
-  inclusions.forEach(function(inclusion) {
+  this.tipsToInclude.forEach(function(inclusion) {
     self.addIncluded(Graph.getUpstreamSet(self.engine, inclusion));
   });
 
-  var includedKeys = Array.from(Object.keys(self.included));
+  var includedKeys = Array.from(Object.keys(self.includedRefs));
 
   self.revisions = includedKeys.map(function(revision) {
     return self.engine.resolveStringRef(revision);
@@ -3112,14 +3122,14 @@ RevisionRange.prototype.processSpecifiers = function(specifiers) {
 };
 
 RevisionRange.prototype.isExcluded = function(revision) {
-  return this.excluded.hasOwnProperty(revision);
+  return this.excludedRefs.hasOwnProperty(revision);
 };
 
 RevisionRange.prototype.addExcluded = function(setToExclude) {
   var self = this;
   Object.keys(setToExclude).forEach(function(toExclude) {
     if(!self.isExcluded(toExclude)) {
-      self.excluded[toExclude] = true;
+      self.excludedRefs[toExclude] = true;
     }
   });
 };
@@ -3128,7 +3138,7 @@ RevisionRange.prototype.addIncluded = function(setToInclude) {
   var self = this;
   Object.keys(setToInclude).forEach(function(toInclude) {
     if(!self.isExcluded(toInclude)) {
-      self.included[toInclude] = true;
+      self.includedRefs[toInclude] = true;
     }
   });
 };

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -3079,6 +3079,18 @@ function RevisionRange(engine, specifiers) {
   this.processSpecifiers(specifiers);
 }
 
+var rangeRegex = /^(.*)\.\.(.*)$/;
+
+RevisionRange.prototype.processAsRange = function(specifier) {
+  var match = specifier.match(rangeRegex);
+  if(!match) {
+    return false;
+  }
+  this.tipsToExclude.push(match[1]);
+  this.tipsToInclude.push(match[2]);
+  return true;
+};
+
 RevisionRange.prototype.processAsExclusion = function(specifier) {
   if(!specifier.startsWith('^')) {
     return false;
@@ -3095,6 +3107,7 @@ RevisionRange.prototype.processAsInclusion = function(specifier) {
 RevisionRange.prototype.processSpecifiers = function(specifiers) {
   var self = this;
   var processors = [
+    this.processAsRange,
     this.processAsExclusion
   ];
 


### PR DESCRIPTION
This PR adds support for the range operator ("branchA..branchB") to the `log` and `rev-list` commands.

It also refactors revision specifier processing into a "pipeline" model, to make it easier to support new kinds of specifiers.

See #561 