### PR TITLE
Check that there are no source file changes before building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ cache:
   directories:
     - "node_modules"
 script:
+  - ./checkgit.sh "Source files were modified before build; is yarn.lock out of sync with package.json?" || travis_terminate $?
   - yarn grunt
+  - ./checkgit.sh "Source files were modified by the build" || travis_terminate $?

--- a/checkgit.sh
+++ b/checkgit.sh
@@ -1,0 +1,6 @@
+GIT_STATUS=$(git status --porcelain | wc -l )
+if [[ GIT_STATUS -ne 0 ]]; then
+  echo "${1:-Source files were modified}"
+  git status
+  exit $GIT_STATUS
+fi;


### PR DESCRIPTION
If dependencies are changed (in package.json) without updating the yarn.lock
file, or if any other part of the build process starts producing unignored
files, the CI build will fail, so that the problem can be corrected before the
PR is merged.

See #575 