### PR TITLE
Use `yarn grunt` instead of the global `grunt`

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,8 +2,8 @@ ports:
 - port: 8000
   onOpen: open-preview
 tasks:
-- init: yarn install && yarn global add grunt-cli
+- init: yarn install
   command: >
-    grunt fastBuild &&
-    printf "\nWelcome to Learn Git Branching\nTo rebuild the app, simply run 'grunt fastBuild' and reload index.html.\n\n" &&
+    yarn grunt fastBuild &&
+    printf "\nWelcome to Learn Git Branching\nTo rebuild the app, simply run 'yarn grunt fastBuild' and reload index.html.\n\n" &&
     python3 -m http.server 8000 2>/dev/null

--- a/README.md
+++ b/README.md
@@ -85,13 +85,13 @@ yarn install
 
 git checkout -b newAwesomeFeature
 vim ./src/js/git/index.js # some changes
-grunt fastBuild # skips tests and linting, faster build
+yarn grunt fastBuild # skips tests and linting, faster build
 
 # after building you can open up your browser to the index.html
 # file generated and see your changes
 
 vim ./src/js/git/index.js # more changes
-grunt build # runs tests and lint
+yarn grunt build # runs tests and lint
 
 git commit -am "My new sweet feature!"
 git push


### PR DESCRIPTION
This change fixes the the Gitpod demo by setting the `yarn` global prefix to `/workspace/.yarn`, and adding it to the `PATH` env variable.

Follow-up to https://github.com/pcottle/learnGitBranching/issues/574#issuecomment-490173208.

Note: The `before` step runs both during Gitpod's first workspace start (`before && init && command`) and subsequent restarts (`before && command`). More info [here](https://www.gitpod.io/docs/44_Config_Start_Tasks/#code-classlanguage-textbeforecode-command).

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/learnGitBranching/blob/patch-1/src/js/git/index.js)