### PR TITLE
feat: make es_ES available from the languages menu

### DIFF
--- a/src/js/react_views/IntlHelperBarView.jsx
+++ b/src/js/react_views/IntlHelperBarView.jsx
@@ -58,6 +58,12 @@ class IntlHelperBarView extends React.Component{
       text: 'español',
       testID: 'spanish',
       onClick: function() {
+        this.fireCommand('locale es_ES; levels');
+      }.bind(this)
+    }, {
+      text: 'argentino',
+      testID: 'argentinian',
+      onClick: function() {
         this.fireCommand('locale es_AR; levels');
       }.bind(this)
     }, {


### PR DESCRIPTION
rename es_AR to argentino
 but leave it as the default for Spanish
 since es_ES is not fully translated

Fixes #528