### PR TITLE
added git tag -d <tag> and  fixed error message

### DIFF
--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -811,8 +811,41 @@ var commandConfig = {
 
   tag: {
     regex: /^git +tag($|\s)/,
+    options: [
+      '-d'
+    ],
     execute: function(engine, command) {
       var generalArgs = command.getGeneralArgs();
+      var commandOptions = command.getOptionsMap();
+
+      if (commandOptions['-d']) {
+        var tagID = commandOptions['-d'];
+        var tagToRemove;
+
+        assertIsRef(engine, tagID);
+        
+        command.oneArgImpliedHead(tagID);
+        engine.tagCollection.each(function(tag) {
+          if(tag.get('id') == tagID){
+            tagToRemove = tag;
+          }
+        }, true);
+        
+        if(tagToRemove == undefined){
+          throw new GitError({
+            msg: intl.todo(
+              'No tag found, nothing to remove'
+            )
+          });
+        }
+
+        engine.tagCollection.remove(tagToRemove);
+        delete engine.refs[tagID];
+        
+        engine.gitVisuals.refreshTree();
+        return;
+      }
+
       if (generalArgs.length === 0) {
         var tags = engine.getTags();
         engine.printTags(tags);

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -686,7 +686,7 @@ GitEngine.prototype.validateAndMakeTag = function(id, target) {
     throw new GitError({
       msg: intl.str(
         'bad-tag-name',
-        { tag: name }
+        { tag: id }
       )
     });
   }

--- a/src/js/visuals/index.js
+++ b/src/js/visuals/index.js
@@ -701,6 +701,25 @@ GitVisuals.prototype.addTagFromEvent = function(tag, collection, index) {
   }
 };
 
+GitVisuals.prototype.removeTag = function(tag, collection, index) {
+  var action = function() {
+    var tagToRemove;
+    this.visTagCollection.each(function(visTag) {
+      if(visTag.get('tag') == tag){
+        tagToRemove = visTag;
+      }
+    }, true);
+    tagToRemove.remove();
+    this.removeVisTag(tagToRemove);
+  }.bind(this);
+
+  if (!this.gitEngine || !this.gitReady) {
+    this.defer(action);
+  } else {
+    action();
+  }
+};
+
 GitVisuals.prototype.addTag = function(tag) {
   var visTag = new VisTag({
     tag: tag,


### PR DESCRIPTION
Added the tag-deleting feature and fixed a bug, where the duplicate tag-name wouldn't show in the error message