### PR TITLE
fix: force `ls` and `cd` end with space

### DIFF
--- a/src/js/sandbox/commands.js
+++ b/src/js/sandbox/commands.js
@@ -15,12 +15,12 @@ var Warning = Errors.Warning;
 var CommandResult = Errors.CommandResult;
 
 var instantCommands = [
-  [/^ls/, function() {
+  [/^ls /, function() {
     throw new CommandResult({
       msg: intl.str('ls-command')
     });
   }],
-  [/^cd/, function() {
+  [/^cd /, function() {
     throw new CommandResult({
       msg: intl.str('cd-command')
     });


### PR DESCRIPTION
I type `lssss` in command line, it will think that is `ls`. it should be say `isn't supported`