### PR TITLE
fix: get `ls` and `cd` with right way

### DIFF
--- a/src/js/sandbox/commands.js
+++ b/src/js/sandbox/commands.js
@@ -15,12 +15,12 @@ var Warning = Errors.Warning;
 var CommandResult = Errors.CommandResult;
 
 var instantCommands = [
-  [/^ls/, function() {
+  [/^ls( |$)/, function() {
     throw new CommandResult({
       msg: intl.str('ls-command')
     });
   }],
-  [/^cd/, function() {
+  [/^cd( |$)/, function() {
     throw new CommandResult({
       msg: intl.str('cd-command')
     });


### PR DESCRIPTION
#608 

Before:
![image](https://user-images.githubusercontent.com/19208123/65567489-a810ec00-df80-11e9-9076-b10e254e57c3.png)

- Why don't use `\b`: `ls-test`

I checked `$` in end of line

After: 

![image](https://user-images.githubusercontent.com/19208123/65567769-91b76000-df81-11e9-828e-5058464b9ec3.png)
