### PR TITLE
Added "es-ES" locale

### DIFF
--- a/src/js/stores/LocaleStore.js
+++ b/src/js/stores/LocaleStore.js
@@ -15,6 +15,7 @@ var langLocaleMap = {
   ja: 'ja',
   ko: 'ko',
   es: 'es_AR',
+  "es-ES": 'es_ES',
   fr: 'fr_FR',
   de: 'de_DE',
   pt: 'pt_BR',


### PR DESCRIPTION
The modification in the PR will be used when the browser locale (ordered variable) has been set in a way like this (or similar):

`>>> console.log(navigator.languages);`
`>>> Array(4) [ "es-ES", "es", "en-US", "en" ]`