### PR TITLE
fix: keep `localStorage`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -173,7 +173,7 @@ var gitDeployPushOrigin = function(done) {
     'git checkout master'
   );
   done();
-}
+};
 
 var fastBuild = series(clean, ifyBuild, style, buildIndexDev, jshint);
 
@@ -191,7 +191,7 @@ var deploy = series(
   gitDeployMergeMaster,
   build,
   gitDeployPushOrigin,
-  compliment,
+  compliment
 );
 
 var lint = series(jshint, compliment);

--- a/src/js/stores/LevelStore.js
+++ b/src/js/stores/LevelStore.js
@@ -35,6 +35,8 @@ if (!util.isBrowser()) {
       return keys[i] || null;
     }
   };
+} else {
+  var localStorage = window.localStorage;
 }
 
 try {


### PR DESCRIPTION
Related #661

I assign `var localStorage` inside if-block(not called) so `localStorage` doesn't refer to `window.localStorage`.

![image](https://user-images.githubusercontent.com/19208123/77865838-8e679e80-725a-11ea-8856-d67dd1c294a3.png)

BTW, fix the report by JSHint.
