### PR TITLE
fix: `CommandView` don't need to unmount itself

### DIFF
--- a/src/js/react_views/CommandView.jsx
+++ b/src/js/react_views/CommandView.jsx
@@ -15,17 +15,11 @@ class CommandView extends React.Component{
 
   componentDidMount() {
     this.props.command.on('change', this.updateStateFromModel, this);
-    this.props.command.on('destroy', this.onModelDestroy, this);
     this.updateStateFromModel();
   }
 
   componentWillUnmount() {
     this.props.command.off('change', this.updateStateFromModel, this);
-    this.props.command.off('destroy', this.onModelDestroy, this);
-  }
-
-  onModelDestroy() {
-    ReactDOM.unmountComponentAtNode(ReactDOM.findDOMNode(this).parentNode);
   }
 
   updateStateFromModel() {


### PR DESCRIPTION
When you destroy command with [`toDestroy[i].destroy();`](https://github.com/pcottle/learnGitBranching/blob/699d5ffb71f197885a7a585b88ce11546d04d6c8/src/js/react_views/CommandHistoryView.jsx#L94), `CommandHistoryView`'s props will 
 change and render its child(`CommandView`)

In my opinion, we don't need to unmount it(react do it)
and pass this error
![image](https://user-images.githubusercontent.com/19208123/77873355-f5de1800-7273-11ea-86a9-ca570b27a950.png)
