### PR TITLE
Don't  check redundancy branch to compare tree

### DIFF
--- a/src/js/graph/treeCompare.js
+++ b/src/js/graph/treeCompare.js
@@ -92,13 +92,7 @@ TreeCompare.compareAllBranchesWithinTrees = function(treeA, treeB) {
   treeA = this.convertTreeSafe(treeA);
   treeB = this.convertTreeSafe(treeB);
 
-  var allBranches = Object.assign(
-    {},
-    treeA.branches,
-    treeB.branches
-  );
-
-  return Object.keys(allBranches).every(function(branch) {
+  return Object.keys(treeB.branches).every(function(branch) {
     return this.compareBranchWithinTrees(treeA, treeB, branch);
   }.bind(this));
 };


### PR DESCRIPTION
Fixed #697 

We don't need to check all branch of `treeA.branches` (have redundancy branch)

Resolve with:

    git checkout -b bugFi
    git checkout -b bugFiX

https://hong4rc.github.io/test/index.html?NODEMO&command=level%20intro2;git%20checkout%20-b%20bugFi;git%20checkout%20-b%20bugFix (resolved)

https://learngitbranching.js.org/index.html?NODEMO&command=level%20intro2;git%20checkout%20-b%20bugFi;git%20checkout%20-b%20bugFix (unresolved)