### PR TITLE
Bug: reverse meaning in French

### DIFF
--- a/src/levels/intro/merging.js
+++ b/src/levels/intro/merging.js
@@ -564,7 +564,7 @@ exports.level = {
               "Faisons un merge  de `master` dans `bugFix`:"
             ],
             "afterMarkdowns": [
-              "Puisque `bugFix` était un descendant de `master`, git n'avait aucun travail à effectuer; il a simplement déplacé `bugFix` au même commit auquel `master` est attaché.",
+              "Puisque `bugFix` était un ancêtre de `master`, git n'avait aucun travail à effectuer; il a simplement déplacé `bugFix` au même commit auquel `master` est attaché.",
               "",
               "Maintenant tous les commits sont de la même couleur, ce qui indique que chaque branche contient tout le contenu du dépôt ! Woohoo!"
             ],


### PR DESCRIPTION
bugFix is the parent of master, not its child. master is "descendant"
of bugFix, not the reverse.
I use "ancêtre", as other latin langage translaton, instead.
"parent" exists in French but is ambiguous, and have broader
and narrower contextual meanings (respectively, any relative, eg. cousins,
or just father and mother).