### PR TITLE
💄 Choose proper fonts for all 3 OSes

### DIFF
--- a/src/js/visuals/index.js
+++ b/src/js/visuals/index.js
@@ -240,7 +240,7 @@ GitVisuals.prototype.finishAnimation = function(speed) {
       opacity: 0,
       'font-weight': 500,
       'font-size': '32pt',
-      'font-family': 'Monaco, Courier, font-monospace',
+      'font-family': 'Menlo, Monaco, Consolas, \'Droid Sans Mono\', \'Courier New\', monospace',
       stroke: '#000',
       'stroke-width': 2,
       fill: '#000'

--- a/src/js/visuals/visBranch.js
+++ b/src/js/visuals/visBranch.js
@@ -410,7 +410,7 @@ var VisBranch = VisBase.extend({
     var text = paper.text(textPos.x, textPos.y, String(name));
     text.attr({
       'font-size': 14,
-      'font-family': 'Monaco, Courier, font-monospace',
+      'font-family': 'Menlo, Monaco, Consolas, \'Droid Sans Mono\', \'Courier New\', monospace',
       opacity: this.getTextOpacity()
     });
     this.set('text', text);

--- a/src/js/visuals/visNode.js
+++ b/src/js/visuals/visNode.js
@@ -451,7 +451,7 @@ var VisNode = VisBase.extend({
     text.attr({
       'font-size': this.getFontSize(this.get('id')),
       'font-weight': 'bold',
-      'font-family': 'Monaco, Courier, font-monospace',
+      'font-family': 'Menlo, Monaco, Consolas, \'Droid Sans Mono\', \'Courier New\', monospace',
       opacity: this.getOpacity()
     });
 

--- a/src/js/visuals/visTag.js
+++ b/src/js/visuals/visTag.js
@@ -254,7 +254,7 @@ var VisTag = VisBase.extend({
     var text = paper.text(textPos.x, textPos.y, String(name));
     text.attr({
       'font-size': 14,
-      'font-family': 'Monaco, Courier, font-monospace',
+      'font-family': 'Menlo, Monaco, Consolas, \'Droid Sans Mono\', \'Courier New\', monospace',
       opacity: this.getTextOpacity(),
       'text-anchor': 'start'
     });


### PR DESCRIPTION
Thanks for the great tool.

This PR tries to add proper default fonts for Windows and Linux. The font list is based on [what VSCode chooses](https://github.com/microsoft/vscode/blob/466da1c9013c624140f6d1473b23a870abc82d44/src/vs/editor/common/config/editorOptions.ts#L3464-L3466).
(I believe it is really rare for a terminal to use `Courier` as the default font.)