### PR TITLE
Fix: Editing an existing level was broken

### DIFF
--- a/src/js/level/builder.js
+++ b/src/js/level/builder.js
@@ -54,7 +54,7 @@ var LevelBuilder = Level.extend({
     // if we are editing a level our behavior is a bit different
     var editLevelJSON;
     if (options.editLevel) {
-      LevelStore.getLevel(options.editLevel);
+      editLevelJSON = LevelStore.getLevel(options.editLevel);
       options.level = editLevelJSON;
     }
 


### PR DESCRIPTION
As discussed [here](https://github.com/pcottle/learnGitBranching/issues/187), editing an existing level was broken, e.g. `build level intro3`, resulted in an error `Uncaught Error: need goal tree and solution`. After debugging, the problem seemed to be that editLevelJSON was never assigned and when the level editor started, the level object was empty.