### PR TITLE
increase margin-left for "shell input"

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -553,7 +553,7 @@ p.commandLine span.prompt {
 
 #commandLineBar p.command {
   margin: 0;
-  margin-left: 12px;
+  margin-left: 20px;
 }
 
 #commandLineBar #commandTextField {


### PR DESCRIPTION
Shells usually have a space character on their prompt after the "$" or "#"


![20px](https://user-images.githubusercontent.com/726447/94278338-11736400-ff21-11ea-81c2-ca2b675bf188.png)
