### PR TITLE
Fix css + I in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Alternatively, you can also build and run the app in a pre-configured online wor
 <a href="https://github.com/zhyu"><img src="https://avatars1.githubusercontent.com/u/1728523?v=4" title="zhyu" width="80" height="80"></a>
 <a href="https://github.com/mgarciaisaia"><img src="https://avatars1.githubusercontent.com/u/1190974?v=4" title="mgarciaisaia" width="80" height="80"></a>
 <a href="https://github.com/olsza"><img src="https://avatars1.githubusercontent.com/u/12556170?v=4" title="Olsza" width="80" height="80"></a>
+
 [//]: contributor-faces
 
 ## Helpful Folks

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ And the following heroes for assisting in translating:
 * Vasil Kulakov ("coyl") & Lyubov Agadjanyan ("shayenblue")
 * Aliaksei Berkau ("alexeiberkov")
 * Mizunashi Mana ("mizunashi-mana")
+* Olsza
 
 Also huge shoutout for everyone who has put up a pull request that was pulled! Check out the 30+ contributors we have in the [Contributors View](https://github.com/pcottle/learnGitBranching/graphs/contributors)
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Alternatively, you can also build and run the app in a pre-configured online wor
 <a href="https://github.com/tym-network"><img src="https://avatars1.githubusercontent.com/u/2879545?v=4" title="tym-network" width="80" height="80"></a>
 <a href="https://github.com/zhyu"><img src="https://avatars1.githubusercontent.com/u/1728523?v=4" title="zhyu" width="80" height="80"></a>
 <a href="https://github.com/mgarciaisaia"><img src="https://avatars1.githubusercontent.com/u/1190974?v=4" title="mgarciaisaia" width="80" height="80"></a>
-
+<a href="https://github.com/olsza"><img src="https://avatars1.githubusercontent.com/u/12556170?v=4" title="Olsza" width="80" height="80"></a>
 [//]: contributor-faces
 
 ## Helpful Folks

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -634,7 +634,7 @@ li.rebaseEntry,
   border-right: 0;
   box-shadow: -1px -1px 5px rgba(0,0,0,0.3);
   font-weight: bold;
-  max-width: 520px;
+  max-width: 500px;
   clear: both;
 }
 
@@ -685,11 +685,12 @@ div.helperBar.show {
   -o-transform: translate3d(0,0,0);
   -ms-transform: translate3d(0,0,0);
   transform: translate3d(0,0,0);
-  height: 85px;
+  min-height: 85px;
 }
 
 div.helperBar.show.BaseHelperBar {
   height: auto;
+  min-height: auto;
 }
 
 #commandLineBar,


### PR DESCRIPTION
I am sending a small amendment, where currently the "exit from the menu" icon is not visible in languages (I send current and corrected views)

Plus I added myself to the README;)

Actual:
![actual](https://user-images.githubusercontent.com/12556170/98349391-37108480-201a-11eb-9f4a-f679d9261ed7.png)

After the amendment:
![after](https://user-images.githubusercontent.com/12556170/98349394-37a91b00-201a-11eb-894a-905ba4a22e93.png)

PS. I restored the box width to the width before my corrections were uploaded ... that is from 520px to 500px
