### PR TITLE
[suggestion]change link with attribute target="_ blank"

### DIFF
--- a/src/levels/intro/branching.js
+++ b/src/levels/intro/branching.js
@@ -117,7 +117,7 @@ exports.level = {
               "*Note: In Git version 2.23, a new command called `git switch` was introduced to eventually replace `git checkout`, ",
               "which is somewhat overloaded as a command (it does a bunch of separate things). The lessons here will still use ",
               "`checkout` instead of `switch` because most people won't have access to `switch` yet, but support for the new command ",
-              "works in the app if you want to try it out! You can [learn more here](https://git-scm.com/docs/git-switch).* "
+              "works in the app if you want to try it out! You can <a href=\"https://git-scm.com/docs/git-switch\" target=\"_blank\">learn more here</a>.* "
             ]
           }
         },

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -634,7 +634,7 @@ li.rebaseEntry,
   border-right: 0;
   box-shadow: -1px -1px 5px rgba(0,0,0,0.3);
   font-weight: bold;
-  max-width: 520px;
+  max-width: 500px;
   clear: both;
 }
 
@@ -685,11 +685,12 @@ div.helperBar.show {
   -o-transform: translate3d(0,0,0);
   -ms-transform: translate3d(0,0,0);
   transform: translate3d(0,0,0);
-  height: 85px;
+  min-height: 85px;
 }
 
 div.helperBar.show.BaseHelperBar {
   height: auto;
+  min-height: auto;
 }
 
 #commandLineBar,


### PR DESCRIPTION
It's just a suggestion ... the link instead of opening in the same window to interrupt the "fun", opens here in a separate window. HTML was used because in Markdown, there is no option to open in a new window (I didn't find that information at least).