### PR TITLE
Fix multiple paragraph tags of 'log' and 'show'

### DIFF
--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -2922,30 +2922,27 @@ var Commit = Backbone.Model.extend({
   },
 
   getLogEntry: function() {
-    // for now we are just joining all these things with newlines which
-    // will get placed by paragraph tags. Not really a fan of this, but
-    // it's better than making an entire template and all that jazz
     return [
       'Author: ' + this.get('author'),
       'Date: ' + this.get('createTime'),
-      '<br/>',
+      '',
       this.get('commitMessage'),
-      '<br/>',
+      '',
       'Commit: ' + this.get('id')
-    ].join('\n' ) + '\n';
+    ].join('<br/>') + '\n';
   },
 
   getShowEntry: function() {
     // same deal as above, show log entry and some fake changes
     return [
-      this.getLogEntry(),
+      this.getLogEntry().replace('\n', ''),
       'diff --git a/bigGameResults.html b/bigGameResults.html',
       '--- bigGameResults.html',
       '+++ bigGameResults.html',
       '@@ 13,27 @@ Winner, Score',
       '- Stanfurd, 14-7',
       '+ Cal, 21-14'
-    ].join('\n') + '\n';
+    ].join('<br/>') + '\n';
   },
 
   validateAtInit: function() {


### PR DESCRIPTION
## Problem
'\n' causes the `git log` and `git show` messages showing with paragraph tags every line

<img width="1265" alt="origin" src="https://user-images.githubusercontent.com/59446563/103135804-02ee4180-46f6-11eb-893c-3bf26f607968.png">

## What has changed
Replace '\n' with '\<br/>' (without affecting the original display) so as to get rid of '\<p>' tags with every line, and avoid to directly write the template in the function.

<img width="1280" alt="fix" src="https://user-images.githubusercontent.com/59446563/103135600-595a8080-46f4-11eb-8384-f746862dbef8.png">

As a result, one commit log is shown in one paragraph tag for now.


