### PR TITLE
Improve styles for interactive pop-up windows

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -260,6 +260,14 @@ body.hgMode .visBackgroundColor {
   min-height: 400px;
 }
 
+div.ui-draggable-handle {
+  cursor: grab;
+}
+
+div.ui-draggable-dragging div.ui-draggable-handle {
+  cursor: grabbing;
+}
+
 div.canvasTerminalHolder > div.terminal-window-holder > div.wrapper {
   height: 100%;
   box-shadow: 0 0 12px rgb(0,0,0);
@@ -431,6 +439,10 @@ div.toolbar > div.controls div.box.flex1 div {
 
 div.toolbar > div.controls div.box.flex1 div:hover {
 
+}
+
+div.ui-draggable div.controls div.box.flex1 div {
+  cursor: pointer;
 }
 
 div.controls div.box.flex1 div.close {


### PR DESCRIPTION
- The title bar of floating windows that can be dragged (e.g. the "Goal To Reach" ones) now shows a "grab" cursor when hovered, and a "grabbing" cursor when being dragged.
- The buttons in those windows, which are clickable, now show the `pointer` (hand) cursor, instead of the `default` (regular arrow) cursor.

This PR was inspired by #439 (but is, AFAIK, unrelated to it).