### PR TITLE
Fix text falling out in the main popup

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -301,6 +301,11 @@ div.canvasTerminalHolder > div.terminal-window-holder div.inside {
   border-radius: 0 0 5px 5px;
 }
 
+div.inside  pre {
+  white-space: normal;
+  line-height: 24px;
+}
+
 #controls {
   max-width: 400px;
 }


### PR DESCRIPTION
As for me, it will look better without a border for `code`, but it's up to you :wink: