### PR TITLE
switching use of master to main in git branch cmd

### DIFF
--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -793,8 +793,8 @@ GitEngine.prototype.printBranchesWithout = function(without) {
 
 GitEngine.prototype.printBranches = function(branches) {
   var result = '';
-  branches.forEach(function (branch) {
-    result += (branch.selected ? '* ' : '') + branch.id + '\n';
+  branches.forEach(branch => {
+    result += (branch.selected ? '* ' : '') + this.resolveName(branch.id).split('"')[1] + '\n';
   });
   throw new CommandResult({
     msg: result


### PR DESCRIPTION
fixes #804 and the overall issue of "git branch" command using "master" instead of "main"

*although I would note that an even better solution would be to gut the use of "master" from the repo so as to reduce confusion