### PR TITLE
change master to main in CLI output when checking out via click

### DIFF
--- a/src/js/visuals/visBranch.js
+++ b/src/js/visuals/visBranch.js
@@ -467,7 +467,12 @@ var VisBranch = VisBase.extend({
       return;
     }
 
-    var commandStr = 'git checkout ' + this.get('branch').get('id');
+    var branchName = this.get('branch').get('id');
+    if (branchName.match(/\bmaster\b/)) {
+      branchName = branchName.replace(/\bmaster\b/, 'main');
+    }
+
+    var commandStr = 'git checkout ' + branchName;
     var Main = require('../app');
     Main.getEventBaton().trigger('commandSubmitted', commandStr);
   },


### PR DESCRIPTION
This adds a regex to replace 'master' with 'main' in the command line output when checking out main by clicking on the tag with the branch name.

Resolves issue #821.

FYI: @pcottle - as we discussed in the issue comments, I wasn't able to build the app to test this change