### PR TITLE
fix: autocomplete show right shadow content and support multiple command

### DIFF
--- a/src/js/views/commandViews.js
+++ b/src/js/views/commandViews.js
@@ -88,7 +88,9 @@ var CommandPromptView = Backbone.View.extend({
 
     if (e.keyCode === 9) {
       e.preventDefault();
-      el.value = shadowEl.innerHTML.replace(/&nbsp;/g, ' ');
+      if (shadowEl.innerHTML) {
+        el.value = shadowEl.innerHTML.replace(/&nbsp;/g, ' ');
+      }
     }
 
     this.updatePrompt(el);

--- a/src/js/views/commandViews.js
+++ b/src/js/views/commandViews.js
@@ -70,12 +70,17 @@ var CommandPromptView = Backbone.View.extend({
     var el = e.target;
 
     const shadowEl = document.querySelector('#shadow');
-    const uc = el.value.replace(/ {2,}/g, ' ');
+
+    const currentValue = el.value;
+    const allCommand = currentValue.split(';');
+    const lastCommand = allCommand[allCommand.length - 1]
+      .replace(/\s\s+/g, ' ').replace(/^\s/, '');
+
     shadowEl.innerHTML = '';
-    if(uc.length){
-      for(const c of allCommandsSorted){
-        if(c.indexOf(uc) === 0){
-          shadowEl.innerHTML = c;
+    if (lastCommand.length) {
+      for (const c of allCommandsSorted) {
+        if (c.startsWith(lastCommand)) {
+          shadowEl.innerHTML = (currentValue + c.replace(lastCommand, '')).replace(/ /g, '&nbsp;');
           break;
         }
       }
@@ -83,7 +88,7 @@ var CommandPromptView = Backbone.View.extend({
 
     if (e.keyCode === 9) {
       e.preventDefault();
-      el.value = shadowEl.innerHTML;
+      el.value = shadowEl.innerHTML.replace(/&nbsp;/g, ' ');
     }
 
     this.updatePrompt(el);


### PR DESCRIPTION
Typing: `git   <multi-space here>     comm` in terminal:
![image](https://user-images.githubusercontent.com/19208123/155687383-22dd6e77-5504-4ec7-bb10-07316e83c63b.png)
![image](https://user-images.githubusercontent.com/19208123/155688049-348cbc50-1846-455e-9fd6-4d974959a009.png)


Expected:
![image](https://user-images.githubusercontent.com/19208123/155687684-4ba5cc66-0f7b-4253-92ce-4ff40bb0374e.png)


Support multiple command (split by `;`):
![image](https://user-images.githubusercontent.com/19208123/155687869-99ca6ce0-7602-4503-a2cc-ea40b58b8742.png)


Currently, press  <kbd>tab</kbd> to replace the shadow content terminal, it must be not empty.