### PR TITLE
Fix Gitpod Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ git push
 
 Alternatively, you can also build and run the app in a pre-configured online workspace:
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/pcottle/learnGitBranching/blob/master/src/js/git/index.js)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/pcottle/learnGitBranching/blob/main/src/js/git/index.js)
 
 [//]: contributor-faces
 <a href="https://github.com/pcottle"><img src="https://avatars0.githubusercontent.com/u/1135007?v=4" title="pcottle" width="80" height="80"></a>


### PR DESCRIPTION
Click Gitpod link can't find the file,  `master` had changed to `main`

![image](https://user-images.githubusercontent.com/29678177/169630852-678acca8-be2b-4bbc-ba3a-98521bb6ab67.png)
