### PR TITLE
fix: nodes over window in short display

### DIFF
--- a/src/style/main.css
+++ b/src/style/main.css
@@ -340,6 +340,11 @@ div.canvasTerminalHolder > div.terminal-window-holder {
   overflow: visible !important;
 }
 
+
+div.canvasTerminalHolder > div.terminal-window-holder div.inside svg {
+  top: unset !important;
+}
+
 /* Toolbar */
 div.toolbar {
   /* borrowed from try.github.com along with a bunch of other things */


### PR DESCRIPTION
As the discussion in #1003, add a CSS rules to avoid the goal tree over the goal window in shorter display.