### PR TITLE
Update strings.js typo error with Italian 'hide-goal-button'

### DIFF
--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -1792,7 +1792,7 @@ exports.strings = {
     'vi': 'Ẩn mục tiêu',
     'sl_SI': 'Skrij Cilj',
     'pl' : 'Ukryj cel',
-    'it_IT': "Nasconti obiettivo",
+    'it_IT': "Nascondi obiettivo",
     'ta_IN': 'இலக்கை மறை'
   },
   ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There was a typo error in Italian translation of 'hide-goal-button'. It was "Nasconti obiettivo" but it should be "Nascondi obiettivo"