### PR TITLE
Accessibility : Inert attribute for content outside of modal

### DIFF
--- a/src/js/views/index.js
+++ b/src/js/views/index.js
@@ -252,7 +252,7 @@ var ModalView = Backbone.View.extend({
 
   show: function() {
     Array.from(document.body.children).forEach(function(child) {
-      if (child.className === 'modalView') return;
+      if (child.classList.contains('modalView')) return;
       child.setAttribute('inert', '');
     });
 
@@ -276,7 +276,7 @@ var ModalView = Backbone.View.extend({
 
     
     Array.from(document.body.children).forEach(function(child) {
-      if (child.className === 'modalView') return;
+      if (child.classList.contains('modalView')) return;
       child.removeAttribute('inert');
     });
   },

--- a/src/js/views/index.js
+++ b/src/js/views/index.js
@@ -251,6 +251,11 @@ var ModalView = Backbone.View.extend({
   },
 
   show: function() {
+    Array.from(document.body.children).forEach(function(child) {
+      if (child.className === 'modalView') return;
+      child.setAttribute('inert', '');
+    });
+
     this.toggleZ(true);
     // on reflow, change our class to animate. for whatever
     // reason if this is done immediately, chrome might combine
@@ -268,6 +273,12 @@ var ModalView = Backbone.View.extend({
         this.toggleZ(false);
       }
     }.bind(this), this.getAnimationTime());
+
+    
+    Array.from(document.body.children).forEach(function(child) {
+      if (child.className === 'modalView') return;
+      child.removeAttribute('inert');
+    });
   },
 
   getInsideElement: function() {


### PR DESCRIPTION
Part of #960 

In order to contribute to the issue of zcorpan, I corrected one of the points present in the to-do list :

> Content outside modal dialog boxes are not inert and so can be reached with screen readers. <dialog>.showModal() could help (or maybe the inert attribute).

In this PR, when a modal is opened, all children except .modalView have the attribute "inert" (as zcorpan suggested), which is removed when the modal is closed.
