### PR TITLE
Add support for `git merge --squash {branch}`

### DIFF
--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -228,6 +228,13 @@ describe('Git', function() {
     );
   });
 
+  it('if squash is specified, will always make a squash merge commit', function() {
+    return expectTreeAsync(
+      'git commit; go -b side HEAD~1; git commit; git merge main; go main; git merge side --squash',
+      '{"branches":{"main":{"target":"C5","id":"main","remoteTrackingBranchID":null},"side":{"target":"C4","id":"side","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"},"C2":{"parents":["C1"],"id":"C2"},"C3":{"parents":["C1"],"id":"C3"},"C4":{"parents":["C2","C3"],"id":"C4"},"C5":{"parents":["C2"],"id":"C5"}},"HEAD":{"target":"main","id":"HEAD"}}'
+    );
+  });
+
   it('makes a tag', function() {
     return expectTreeAsync(
       'git tag v1',

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -564,7 +564,7 @@ var commandConfig = {
     ],
     execute: function(engine, command) {
       var commandOptions = command.getOptionsMap();
-      var generalArgs = command.getGeneralArgs().concat(commandOptions['--no-ff'] || []);
+      var generalArgs = command.getGeneralArgs().concat(commandOptions['--no-ff'] || []).concat(commandOptions['--squash'] || []);
       command.validateArgBounds(generalArgs, 1, 1);
 
       var newCommit = engine.merge(

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -559,7 +559,8 @@ var commandConfig = {
   merge: {
     regex: /^git +merge($|\s)/,
     options: [
-      '--no-ff'
+      '--no-ff',
+      '--squash'
     ],
     execute: function(engine, command) {
       var commandOptions = command.getOptionsMap();
@@ -568,7 +569,10 @@ var commandConfig = {
 
       var newCommit = engine.merge(
         generalArgs[0],
-        { noFF: !!commandOptions['--no-ff'] }
+        {
+          noFF: !!commandOptions['--no-ff'],
+          squash: !!commandOptions['--squash']
+        }
       );
 
       if (newCommit === undefined) {

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -2474,7 +2474,7 @@ GitEngine.prototype.merge = function(targetSource, options) {
     });
   }
 
-  if (this.isUpstreamOf(currentLocation, targetSource) && !options.noFF) {
+  if (this.isUpstreamOf(currentLocation, targetSource) && !options.noFF && !options.squash) {
     // just set the target of this current location to the source
     this.setTargetLocation(currentLocation, this.getCommitFromRef(targetSource));
     // get fresh animation to happen
@@ -2496,8 +2496,15 @@ GitEngine.prototype.merge = function(targetSource, options) {
   );
   // since we specify parent 1 as the first parent, it is the "main" parent
   // and the node will be displayed below that branch / commit / whatever
+  var commitParents = [parent1];
+  
+  if (!options.squash) {
+    // a squash commit doesn't include the reference to the second parent
+    commitParents.push(parent2);
+  }
+
   var mergeCommit = this.makeCommit(
-    [parent1, parent2],
+    commitParents,
     null,
     {
       commitMessage: msg


### PR DESCRIPTION
Being a popular option in Github to squash and merge, it would be interesting to add support for this option.

**Initial scenario**
After running `git checkout -b feat;git commit;git checkout main;`
```
C2 (feat)
C1 (main) *
```

**With `merge --no-ff`**
After running `git merge --no-ff feat`
```
C2 (feat) ─┐
C1 ────────┴─ C3 (main) *
```

**With `merge --squash`**
After running `git merge --squash feat`
```
C2 (feat)
C1 ────────── C3 (main) *
```
This equivalent to just `git commit -m "Squashed merge branch 'feat' into 'main'"` as the connection with the C2 node is lost, and further `git branch -D feat` will leave C2 being not connected and ready to prune. This will show how you destroy history by using squash.