### PR TITLE
Added delete flag to 'push' command to delete remote branches

### DIFF
--- a/__tests__/remote.spec.js
+++ b/__tests__/remote.spec.js
@@ -156,6 +156,29 @@ describe('Git Remotes', function() {
     );
   });
 
+  it('can delete branches with --delete flag', function() {
+    expectTreeAsync(
+      'git branch foo; git clone; git push origin --delete',
+      '{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":"o/main"},"foo":{"target":"C1","id":"foo","remoteTrackingBranchID":"o/foo"},"o/main":{"target":"C1","id":"o/main","remoteTrackingBranchID":null},"o/foo":{"target":"C1","id":"o/foo","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"tags":{},"HEAD":{"target":"main","id":"HEAD"},"originTree":{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":null},"foo":{"target":"C1","id":"foo","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"tags":{},"HEAD":{"target":"main","id":"HEAD"}}}'
+    );
+    
+    expectTreeAsync(
+      'git branch foo; git clone; git push origin --delete main:foo',
+      '{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":"o/main"},"foo":{"target":"C1","id":"foo","remoteTrackingBranchID":"o/foo"},"o/main":{"target":"C1","id":"o/main","remoteTrackingBranchID":null},"o/foo":{"target":"C1","id":"o/foo","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"tags":{},"HEAD":{"target":"main","id":"HEAD"},"originTree":{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":null},"foo":{"target":"C1","id":"foo","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"tags":{},"HEAD":{"target":"main","id":"HEAD"}}}'
+    );
+
+    expectTreeAsync(
+      'git branch foo; git clone; git push --delete origin foo',
+      '{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":"o/main"},"foo":{"target":"C1","id":"foo","remoteTrackingBranchID":null},"o/main":{"target":"C1","id":"o/main","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"},"originTree":{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"}}}'
+    );
+
+    return expectTreeAsync(
+      'git branch foo; git clone; git push origin --delete foo',
+      '{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":"o/main"},"foo":{"target":"C1","id":"foo","remoteTrackingBranchID":null},"o/main":{"target":"C1","id":"o/main","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"},"originTree":{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"}}}'
+    );
+  });
+
+
   it('pushes new branch onto server', function() {
     return expectTreeAsync(
       'git clone; git commit; git push origin main:foo',

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -3,6 +3,7 @@ var intl = require('../intl');
 
 var Graph = require('../graph');
 var Errors = require('../util/errors');
+const { compact } = require('underscore');
 var CommandProcessError = Errors.CommandProcessError;
 var GitError = Errors.GitError;
 var Warning = Errors.Warning;
@@ -744,7 +745,9 @@ var commandConfig = {
   push: {
     regex: /^git +push($|\s)/,
     options: [
-      '--force'
+      '--force',
+      '--delete',
+      '-d'
     ],
     execute: function(engine, command) {
       if (!engine.hasOrigin()) {
@@ -758,14 +761,46 @@ var commandConfig = {
       var source;
       var sourceObj;
       var commandOptions = command.getOptionsMap();
+      var isDelete = commandOptions['-d'] || commandOptions['--delete'];
 
       // git push is pretty complex in terms of
       // the arguments it wants as well... get ready!
       var generalArgs = command.getGeneralArgs();
+      
+      // put the commandOption of delete back in the generalArgs
+      // as it is a flag option
+      if(isDelete) {
+        let option = commandOptions['-d'] || commandOptions['--delete'];
+        generalArgs = option[0] === 'origin'
+        ? option.concat(generalArgs)
+        : generalArgs.concat(option);
+      }
+
       command.twoArgsForOrigin(generalArgs);
       assertOriginSpecified(generalArgs);
-
       var firstArg = generalArgs[1];
+
+      if(isDelete) {
+        if(!firstArg) {
+          throw new GitError({
+            msg: intl.todo(
+              '--delete doesn\'t make sense without any refs'
+            )
+          });
+        }
+
+        if(isColonRefspec(firstArg)) {
+          throw new GitError({
+            msg: intl.todo(
+              '--delete only accepts plain target ref names'
+            )
+          });
+        }
+
+        // transform delete target ref to delete colon refspec
+        firstArg = ":"+firstArg;
+      }
+
       if (firstArg && isColonRefspec(firstArg)) {
         var refspecParts = firstArg.split(':');
         source = refspecParts[0];
@@ -773,7 +808,7 @@ var commandConfig = {
         if (source === "" && !engine.origin.resolveID(destination)) {
           throw new GitError({
             msg: intl.todo(
-              'cannot delete branch ' + options.destination + ' which doesnt exist'
+              'cannot delete branch ' + options.destination + ' which doesn\'t exist'
             )
           });
         }

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -3,7 +3,6 @@ var intl = require('../intl');
 
 var Graph = require('../graph');
 var Errors = require('../util/errors');
-const { compact } = require('underscore');
 var CommandProcessError = Errors.CommandProcessError;
 var GitError = Errors.GitError;
 var Warning = Errors.Warning;


### PR DESCRIPTION
Adds the delete flag as a method to delete remote branches
`git push origin -d foo`
uses the existing method of deleting remote branches by colon refspec