### PR TITLE
updated undo command to only track when a command changes the tree

### DIFF
--- a/src/js/sandbox/index.js
+++ b/src/js/sandbox/index.js
@@ -67,7 +67,8 @@ var Sandbox = Backbone.View.extend({
 
   initGitShim: function(options) {
     this.gitShim = new GitShim({
-      beforeCB: this.beforeCommandCB.bind(this)
+      beforeCB: this.beforeCommandCB.bind(this),
+      afterCB: this.afterCommandCB.bind(this)
     });
   },
 
@@ -113,12 +114,21 @@ var Sandbox = Backbone.View.extend({
   },
 
   beforeCommandCB: function(command) {
+    this._treeBeforeCommand = this.mainVis.gitEngine.printTree();
+  },
+
+  afterCommandCB: function(command) {
     this.pushUndo();
   },
 
   pushUndo: function() {
+    let currentTree = this.mainVis.gitEngine.printTree();
+    if(currentTree === this._treeBeforeCommand) {
+      return;
+    }
+
     // go ahead and push the three onto the stack
-    this.undoStack.push(this.mainVis.gitEngine.printTree());
+    this.undoStack.push(this._treeBeforeCommand);
   },
 
   undo: function(command, deferred) {


### PR DESCRIPTION
undo now only undo changing commands for example:
```
git commit (C1)
git commit (C2)
git log
git log
undo
```
will now revert the state of the tree back to C1
where as before each undo would correspond to a git log command first so you would need 3x undos.

This should have no affect on undos in levels as they override the sandbox behaviour and have their own logic for tracking if a command counts for golf (which seems to be the same condition only captured explicitly for each command)
