### PR TITLE
Translate command-not-supported to es_AR, es_MX and es_ES

### DIFF
--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -883,6 +883,9 @@ exports.strings = {
     'it_IT': 'Mi spiace, il comando "{command}" non è supportato.',
     'pl' : 'Polecenie "{command}" niestety nie jest obsługiwane.',
     'pt_BR': 'O comando "{command}" não é suportado!',
+    'es_AR': 'El comando "{command}" no es compatible, ¡disculpa!',
+    'es_MX': 'La orden "{command}" no es compatible, ¡disculpa!',
+    'es_ES': 'El comando "{command}" no está soportado, ¡disculpa!',
     'vi': 'Xin lỗi, lệnh "{command}" không được hỗ trợ!'
   },
   ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
There is no error message for git-error-command-not-supported, a common error that occurs when typing any command incorrectly.

- **Before fix** (missing translation message)
![image](https://github.com/pcottle/learnGitBranching/assets/93234250/1a562e04-8f0c-4eea-8d20-9471d4dfc185)

- **After fix**
![image](https://github.com/pcottle/learnGitBranching/assets/93234250/6e03f37a-be70-4a1b-9439-deffe0c277a1)
