### PR TITLE
Resolves #1139: can use a direct permalink to a specific level

### DIFF
--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -237,6 +237,10 @@ var initDemo = function(sandbox) {
       'levels'
     ];
     commands = commands.join(';#').split('#'); // hax
+  } else if (params.hasOwnProperty('level')) {
+    commands = [
+      'level ' + unescape(params.level),
+    ];
   } else if (params.gist_level_id) {
     $.ajax({
       url: 'https://api.github.com/gists/' + params.gist_level_id,


### PR DESCRIPTION
This resolves the issue #1139 I just created, about permalink to levels.

I did not add unit tests as I didn't find anywhere query arguments are tested. But I've manually tested my changes through Gitpod (which is simply amazing !).

I also was thinking about a "share level" feature, but:
- this another feature
- this is out of scope of the initial issue
- this can have many implementations possible, and different UI design too
- this idea would need your validation first, before any change

Feel free to let me know what you think about all this.