### PR TITLE
make modal draggable

### DIFF
--- a/src/js/views/index.js
+++ b/src/js/views/index.js
@@ -327,6 +327,14 @@ var ModalTerminal = ContainedBase.extend({
     };
 
     this.render();
+
+    this.$terminal = this.$el.find('.terminal-window-holder').first();
+    this.$terminal.draggable({
+      cursor: 'move',
+      handle: '.toolbar',
+      containment: '#interfaceWrapper',
+      scroll: false
+    });
   },
 
   updateTitle: function(/*string*/ title) {


### PR DESCRIPTION
This chage allows you to move the modal that comes up when doing an interactive rebase.
I think this is useful when you want to work on a modal while looking at the goal. (ex. level2 move2)

- before
![スクリーンショット 2024-05-13 22 08 53](https://github.com/pcottle/learnGitBranching/assets/96858189/c185ac88-211a-46e8-a55b-8558c51edc1e)

- after
![スクリーンショット 2024-05-13 22 09 39](https://github.com/pcottle/learnGitBranching/assets/96858189/feda9208-682f-460e-b6c2-bc812999282d)
