### PR TITLE
Updated Demonstration Message for Intro4

### DIFF
--- a/generatedDocs/levels.html
+++ b/generatedDocs/levels.html
@@ -1337,7 +1337,7 @@ type <code>git checkout -b [yourbranchname]</code>.</p>
 <p>Here we have two branches yet again; note that the bugFix branch is currently selected (note the asterisk)</p>
 <p>We would like to move our work from bugFix directly onto the work from main. That way it would look like these two features were developed sequentially, when in reality they were developed in parallel.</p>
 <p>Let&#39;s do that with the <code>git rebase</code> command.</p>
-<pre class="level-solution">git rebase main</pre><p>Awesome! Now the work from our bugFix branch is right on top of main and we have a nice linear sequence of commits.</p>
+<pre class="level-solution">git rebase main</pre><p>Awesome! Now the work from our bugFix branch is right beneath main and we have a nice linear sequence of commits.</p>
 <p>Note that the commit C3 still exists somewhere (it has a faded appearance in the tree), and C3&#39; is the &quot;copy&quot; that we rebased onto main.</p>
 <p>The only problem is that main hasn&#39;t been updated either, let&#39;s do that now...</p>
 <p>Now we are checked out on the <code>main</code> branch. Let&#39;s go ahead and rebase onto <code>bugFix</code>...</p>

--- a/generatedDocs/levels.html
+++ b/generatedDocs/levels.html
@@ -1337,7 +1337,7 @@ type <code>git checkout -b [yourbranchname]</code>.</p>
 <p>Here we have two branches yet again; note that the bugFix branch is currently selected (note the asterisk)</p>
 <p>We would like to move our work from bugFix directly onto the work from main. That way it would look like these two features were developed sequentially, when in reality they were developed in parallel.</p>
 <p>Let&#39;s do that with the <code>git rebase</code> command.</p>
-<pre class="level-solution">git rebase main</pre><p>Awesome! Now the work from our bugFix branch is right beneath main and we have a nice linear sequence of commits.</p>
+<pre class="level-solution">git rebase main</pre><p>Awesome! Now the work from our bugFix branch is stacked "on top of main", since it points to main. In our visualization though, its shown below main since our commit trees flow downwards.</p>
 <p>Note that the commit C3 still exists somewhere (it has a faded appearance in the tree), and C3&#39; is the &quot;copy&quot; that we rebased onto main.</p>
 <p>The only problem is that main hasn&#39;t been updated either, let&#39;s do that now...</p>
 <p>Now we are checked out on the <code>main</code> branch. Let&#39;s go ahead and rebase onto <code>bugFix</code>...</p>

--- a/src/levels/intro/rebasing.js
+++ b/src/levels/intro/rebasing.js
@@ -76,7 +76,7 @@ exports.level = {
               "Let's do that with the `git rebase` command."
             ],
             "afterMarkdowns": [
-              "Awesome! Now the work from our bugFix branch is right beneath main and we have a nice linear sequence of commits.",
+              "Awesome! Now the work from our bugFix branch is stacked \"on top of main\", since it points to main. In our visualization though, its shown below main since our commit trees flow downwards.",
               "",
               "Note that the commit C3 still exists somewhere (it has a faded appearance in the tree), and C3' is the \"copy\" that we rebased onto main.",
               "",

--- a/src/levels/intro/rebasing.js
+++ b/src/levels/intro/rebasing.js
@@ -76,7 +76,7 @@ exports.level = {
               "Let's do that with the `git rebase` command."
             ],
             "afterMarkdowns": [
-              "Awesome! Now the work from our bugFix branch is right on top of main and we have a nice linear sequence of commits.",
+              "Awesome! Now the work from our bugFix branch is right beneath main and we have a nice linear sequence of commits.",
               "",
               "Note that the commit C3 still exists somewhere (it has a faded appearance in the tree), and C3' is the \"copy\" that we rebased onto main.",
               "",


### PR DESCRIPTION
While going through the Git lessons, I found a wording issue in the message displayed during the Intro 4 level, right after rebasing onto the **`main`** branch.

The original message said:

> “Awesome! Now the work from our bugFix branch is right on top of main...”

However, since the rebase places the **`bugFix`** commits beneath the latest **`main`** commits to maintain a linear history, I’ve updated the message for clarity:

> “Awesome! Now the work from our bugFix branch is right beneath main...”

This should better reflect the actual commit structure post-rebase.