### PR TITLE
Add working CI for containerizing the web app and pushing it to ghcr.io

### DIFF
--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      REPO_PREFIX: ghcr.io/${{ github.repository }}/main
+      REPO_PREFIX: ghcr.io/${{ github.repository }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -7,16 +7,12 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
 
     env:
-      REPO_PREFIX: ghcr.io/${{ github.repository }}
+      REPO_PREFIX: ghcr.io/${{ github.repository }}/main
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/containerize.yml
+++ b/.github/workflows/containerize.yml
@@ -1,0 +1,29 @@
+name: containerize
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    env:
+      REPO_PREFIX: ghcr.io/${{ github.repository }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: login-ghcr
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: build-docker-image
+        run: |
+          REPO_PREFIX_LOWER=$(echo "$REPO_PREFIX" | tr '[:upper:]' '[:lower:]')
+          docker build -t $REPO_PREFIX_LOWER:${{ github.sha }} -f Dockerfile .
+          docker push $REPO_PREFIX_LOWER:${{ github.sha }}
+          docker tag $REPO_PREFIX_LOWER:${{ github.sha }} $REPO_PREFIX_LOWER:latest
+          docker push $REPO_PREFIX_LOWER:latest


### PR DESCRIPTION
This adds proper working CI for containerizing the web app and pushing it to GitHub Container Repo, it will be displayed under Packages like so: 

<img width="330" height="142" alt="image" src="https://github.com/user-attachments/assets/36069214-ac93-4afa-9b32-9f2360fdfc82" />

Should fix #1220 

You can verify with my fork image built here: https://github.com/opariffazman/learnGitBranching/pkgs/container/learngitbranching-fork

Thanks!
