### PR TITLE
fix: improve inaccurate German translation of commit color rules

### DIFF
--- a/src/levels/intro/merging.js
+++ b/src/levels/intro/merging.js
@@ -147,7 +147,7 @@ exports.level = {
             "afterMarkdowns": [
               "Wow! Hast du das gesehen? Zunächst mal zeigt `main` jetzt auf einen Commit mit zwei Vorgängern. Wenn du den beiden Pfeilen immer weiter folgst, kommst du an jedem Commit im Repository vorbei. Das heißt `main` enthält jetzt alles, was es im Repository gibt.",
               "",
-              "Siehst du außerdem wie sich die Farben der Commits verändert haben? Um die Vorgänge zu verdeutlichen hab ich etwas Farbe ins Spiel gebracht. Jeder Branch hat seine eindeutige Farbe. Jeder Merge Commit bekommt als Farbe eine Mischung aus den Farben seiner Vorgänger.",
+              "Siehst du außerdem wie sich die Farben der Commits verändert haben? Um die Vorgänge zu verdeutlichen hab ich etwas Farbe ins Spiel gebracht. Jeder Branch hat seine eindeutige Farbe. Jeder Commit bekommt eine Farbe, die eine Mischung aus den Farben aller Branches ist, die diesen Commit enthalten.",
               "",
               "Wir sehen also, dass die Farbe des Branch `main` in alle Commits gemischt wurde, die von `bugFix` aber nicht. Ändern wir das ..."
             ],


### PR DESCRIPTION
The English description is:

`Each commit turns a color that is the blended combination of all the branches that contain that commit.`

Which was inaccurately translated into:

`Jeder Merge Commit bekommt als Farbe eine Mischung aus den Farben seiner Vorgänger.`

The German translation implies that the new commit color is a combination of it's previous (parent) commit colors which is not the case. The new translation improves the intended meaning.