### PR TITLE
Fix editorconfig comment format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
-root = true  # Top-most editorconfig file
+# Top-most editorconfig file
+root = true
 
 [*]
 indent_style = space


### PR DESCRIPTION
## Summary
- Move comment to its own line instead of inline comment in `.editorconfig`

## Test plan
- [x] Verify the editorconfig still works correctly