### PR TITLE
Fix editorconfig comment format

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,5 @@
-root = true  # Top-most editorconfig file
+# Top-most editorconfig file
+root = true
 
 [*]
 indent_style = space


### PR DESCRIPTION
**Context**

When opening a file in Neovim (for example via Neo-tree), Neovim runs its built-in **EditorConfig** plugin to apply formatting rules.

**What went wrong**

In Neovim 0.11+, the EditorConfig parser is **strict** and follows the specification closely.  
Inline comments are not allowed, so this line is invalid:

```ini
root = true  # Top-most editorconfig file
```

Neovim reads the value as `true  # ...` instead of `true`, which causes the error:

```
root must be either "true" or "false"
```

**Solution**

Move the comment to its own line:

```ini
# Top-most editorconfig file
root = true
```

Neo-tree only triggers the file open; it is not the source of the error.
