### PR TITLE
fix(gitDemonstrationView): fix the unavailable exit function during demonstration

### DIFF
--- a/src/js/views/gitDemonstrationView.js
+++ b/src/js/views/gitDemonstrationView.js
@@ -77,7 +77,8 @@ class GitDemonstrationView extends ContainedBase {
       aliasMap: {
         enter: 'positive',
         right: 'positive',
-        left: 'negative'
+        left: 'negative',
+        esc: 'exit'
       },
       wait: true
     });
@@ -88,7 +89,16 @@ class GitDemonstrationView extends ContainedBase {
   }
 
   exit() {
-    alert('exittt');
+    this.releaseControl();
+    this.reset();
+
+    if (this.metaContainerView && typeof this.metaContainerView.finish === 'function') {
+      this.metaContainerView.finish();
+      return;
+    }
+
+    // Fallback: close just this view if no parent container is present
+    this.die();
   }
 
   receiveMetaNav(navView, metaContainerView) {
@@ -204,7 +214,9 @@ class GitDemonstrationView extends ContainedBase {
   }
 
   tearDown() {
-    this.mainVis.tearDown();
+    if (this.mainVis) {
+      this.mainVis.tearDown();
+    }
     ContainedBase.prototype.tearDown.call(this);
   }
 
@@ -236,8 +248,6 @@ class GitDemonstrationView extends ContainedBase {
   }
 
   die() {
-    if (!this.visFinished) { return; }
-
     ContainedBase.prototype.die.call(this);
   }
 


### PR DESCRIPTION
This pull request enhances the `GitDemonstrationView` class in `src/js/views/gitDemonstrationView.js` to improve user navigation and resource management. The most important changes include adding keyboard navigation support, refining the exit logic to properly clean up resources, and ensuring teardown of visualizations.

Navigation improvements:

* Added support for the `esc` key to trigger an exit action by updating the `aliasMap`, allowing users to exit the demonstration using the keyboard. ( The old exit action is unavailable in gitDemonstrationView, which can be considered as a small bug )


Exit and cleanup logic:

* Refined the `exit()` method to release control, reset the view, and call the parent container's `finish()` method if available, with a fallback to closing just this view. This ensures proper cleanup and flow when exiting.
* Updated the `tearDown()` method to check for and tear down the `mainVis` visualization before calling the base class teardown, improving resource management.
* Simplified the `die()` method by removing the check for `visFinished`, ensuring the base class's `die()` is always called.