### PR TITLE
Add GitHub Actions workflow for CI and GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,0 +1,74 @@
+name: CI and Deploy GitHub Pages
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Verify (tests + lint + build)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Use Yarn Classic
+        run: npm install -g yarn@1.22.22
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Run test/lint/build pipeline
+        run: yarn gulp build
+
+  deploy:
+    name: Deploy to github-pages
+    needs: verify
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: yarn
+
+      - name: Use Yarn Classic
+        run: npm install -g yarn@1.22.22
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build production assets
+        run: yarn gulp build
+
+      - name: Deploy current tree to github-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: github-pages
+          publish_dir: .
+          force_orphan: true


### PR DESCRIPTION
### Motivation

- Provide continuous integration on PRs and pushes to `main` and enable automated deployment to a `github-pages` branch for GitHub Pages hosting.
- Ensure consistent Node environment and dependency handling using Node.js 18 and Yarn Classic across CI and deploy runs.
- Prevent concurrent workflows for the same ref and allow manual runs via `workflow_dispatch`.

### Description

- Added `.github/workflows/pages-deploy.yml` to register a workflow that runs on `pull_request` and `push` to `main` and supports `workflow_dispatch`.
- Added a `verify` job that checks out the code, sets up Node.js 18, installs Yarn Classic, runs `yarn install --frozen-lockfile`, and executes `yarn gulp build` (tests + lint + build).
- Added a `deploy` job (dependent on `verify`) that runs only on pushes to `main`, builds production assets, and deploys the repository tree to the `github-pages` branch using `peaceiris/actions-gh-pages@v4` with `publish_dir` set to `.` and `force_orphan: true`.
- Configured workflow permissions (`contents: write`) and concurrency grouping with `pages-${{ github.ref }}` to cancel in-progress runs for the same ref.

### Testing

- CI is configured to run `yarn gulp build` (which includes tests, lint, and build) in the `verify` job for PRs and pushes to `main` to validate changes.
- No workflow runs were executed as part of this change in the repository at the time of the PR creation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d77306aa50832d983cfce9d1bcf285)