### PR TITLE
Implement `git branch -m` branch renaming support

### DIFF
--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -200,6 +200,27 @@ describe('Git', function() {
     );
   });
 
+  it('Renames current branch with git branch -m <newname>', function() {
+    return expectTreeAsync(
+      'git checkout -b side; git branch -m topic',
+      '{"branches":{"main":{"target":"C1","id":"main"},"topic":{"target":"C1","id":"topic"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"topic","id":"HEAD"}}'
+    );
+  });
+
+  it('Renames a specified branch with git branch -m <oldname> <newname>', function() {
+    return expectTreeAsync(
+      'git branch side C0; git branch -m side topic',
+      '{"branches":{"main":{"target":"C1","id":"main"},"topic":{"target":"C0","id":"topic"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"}}'
+    );
+  });
+
+  it('Does not rename branch when the destination already exists', function() {
+    return expectTreeAsync(
+      'git branch side; git branch -m side main',
+      '{"branches":{"main":{"target":"C1","id":"main"},"side":{"target":"C1","id":"side"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"}}'
+    );
+  });
+
   it('Amends commits', function() {
     return expectTreeAsync(
       'git commit --amend',

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -456,6 +456,7 @@ var commandConfig = {
     options: [
       '-d',
       '-D',
+      '-m',
       '-f',
       '--force',
       '-a',
@@ -510,6 +511,18 @@ var commandConfig = {
 
         // we want to force a branch somewhere
         engine.forceBranch(args[0], args[1]);
+        return;
+      }
+
+      if (commandOptions['-m']) {
+        args = commandOptions['-m'].concat(generalArgs);
+        command.validateArgBounds(args, 1, 2, '-m');
+
+        if (args.length === 1) {
+          args.unshift(engine.getOneBeforeCommit('HEAD').get('id'));
+        }
+
+        engine.renameBranch(args[0], args[1]);
         return;
       }
 

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -2610,6 +2610,31 @@ GitEngine.prototype.branch = function(name, ref) {
   }
 };
 
+GitEngine.prototype.renameBranch = function(oldName, newName) {
+  oldName = this.crappyUnescape(oldName);
+  newName = this.validateBranchName(newName);
+
+  var branch = this.resolveID(oldName);
+  if (branch.get('type') !== 'branch' || branch.getIsRemote()) {
+    throw new GitError({
+      msg: intl.str('git-error-branch')
+    });
+  }
+
+  if (this.doesRefExist(newName)) {
+    throw new GitError({
+      msg: intl.str(
+        'bad-branch-name',
+        { branch: newName }
+      )
+    });
+  }
+
+  delete this.refs[oldName];
+  branch.set('id', newName);
+  this.refs[newName] = branch;
+};
+
 GitEngine.prototype.isRemoteBranchRef = function(ref) {
   var resolved = this.resolveID(ref);
   if (resolved.get('type') !== 'branch') {


### PR DESCRIPTION
### Motivation
- Add support for `git branch -m` so users can rename branches from the CLI, matching real git behavior for both the current branch and named branches.

### Description
- Add `-m` as a supported option for the `git branch` command and parse one- and two-argument forms in `src/js/git/commands.js` so `git branch -m <new>` renames the current branch and `git branch -m <old> <new>` renames a specified branch.
- Implement `GitEngine.prototype.renameBranch(oldName, newName)` in `src/js/git/index.js` to unescape/validate names, ensure the source is a local branch (not remote), reject destination name collisions, and update the engine `refs` map and branch `id` atomically.
- Add test coverage in `__tests__/git.spec.js` for renaming the checked-out branch, renaming a specified branch, and refusing to rename when the destination already exists.

### Testing
- Ran the test suite with `npm test -- --runInBand` and all specs passed: `Executed 290 of 290 specs SUCCESS`.
- The new branch rename tests in `__tests__/git.spec.js` were executed as part of the full test run and succeeded.
- No automated tests failed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed0a276ce8832d859ab7e95a27f42d)