### PR TITLE
Add console helpers for level progress import/export

### DIFF
--- a/__tests__/LevelStore.spec.js
+++ b/__tests__/LevelStore.spec.js
@@ -46,6 +46,53 @@ describe('this store', function() {
     expect(LevelStore.isLevelBest(firstLevel.id))
       .toEqual(false);
   });
+
+
+  it('can export and import solved progress', function() {
+    var sequenceMap = LevelStore.getSequenceToLevels();
+    var firstLevel = sequenceMap[
+      Object.keys(sequenceMap)[0]
+    ][0];
+    var secondLevel = sequenceMap[
+      Object.keys(sequenceMap)[0]
+    ][1];
+
+    LevelActions.setLevelSolved(firstLevel.id, true);
+    LevelActions.setLevelSolved(secondLevel.id, false);
+
+    var exportedProgress = LevelStore.exportLevelProgress();
+    LevelActions.resetLevelsSolved();
+
+    expect(LevelStore.isLevelSolved(firstLevel.id))
+      .toEqual(false);
+    LevelStore.importLevelProgress(exportedProgress);
+    expect(LevelStore.isLevelSolved(firstLevel.id))
+      .toEqual(true);
+    expect(LevelStore.isLevelBest(firstLevel.id))
+      .toEqual(true);
+    expect(LevelStore.isLevelSolved(secondLevel.id))
+      .toEqual(true);
+    expect(LevelStore.isLevelBest(secondLevel.id))
+      .toEqual(false);
+
+    LevelActions.resetLevelsSolved();
+  });
+
+  it('can import legacy solved progress', function() {
+    var sequenceMap = LevelStore.getSequenceToLevels();
+    var firstLevel = sequenceMap[
+      Object.keys(sequenceMap)[0]
+    ][0];
+
+    LevelStore.importLevelProgress(JSON.stringify({
+      [firstLevel.id]: true
+    }));
+
+    expect(LevelStore.isLevelSolved(firstLevel.id))
+      .toEqual(true);
+
+    LevelActions.resetLevelsSolved();
+  });
   
 
 });

--- a/src/js/stores/LevelStore.js
+++ b/src/js/stores/LevelStore.js
@@ -56,6 +56,54 @@ function _syncToStorage() {
   }
 }
 
+function _cloneSolvedMap() {
+  return JSON.parse(JSON.stringify(_solvedMap));
+}
+
+function _normalizeImportedSolvedMap(progress) {
+  if (!progress || typeof progress !== 'object' || Array.isArray(progress)) {
+    throw new Error('level progress must be a JSON object');
+  }
+
+  var normalized = {};
+  Object.keys(progress).forEach(function(levelID) {
+    var levelData = progress[levelID];
+
+    // Backwards compatibility with the old storage format.
+    if (levelData === true) {
+      normalized[levelID] = true;
+      return;
+    }
+
+    if (!levelData || typeof levelData !== 'object' || Array.isArray(levelData)) {
+      throw new Error('invalid progress data for level: ' + levelID);
+    }
+
+    normalized[levelID] = {
+      solved: levelData.solved === true,
+      best: levelData.best === true
+    };
+  });
+
+  return normalized;
+}
+
+function exportLevelProgress() {
+  return JSON.stringify(_cloneSolvedMap());
+}
+
+function importLevelProgress(progress) {
+  if (typeof progress === 'string') {
+    progress = JSON.parse(progress);
+  }
+
+  _solvedMap = _normalizeImportedSolvedMap(progress);
+  _syncToStorage();
+  LevelStore.emit(AppConstants.CHANGE_EVENT);
+
+  return _cloneSolvedMap();
+}
+
 function getAliasMap() {
   try {
     return JSON.parse(localStorage.getItem(ALIAS_STORAGE_KEY) || '{}') || {};
@@ -129,6 +177,9 @@ var LevelStore = Object.assign(
 EventEmitter.prototype,
 AppConstants.StoreSubscribePrototype,
 {
+  exportLevelProgress: exportLevelProgress,
+  importLevelProgress: importLevelProgress,
+
   getAliasMap: getAliasMap,
   addToAliasMap: addToAliasMap,
   removeFromAliasMap: removeFromAliasMap,

--- a/src/js/util/debug.js
+++ b/src/js/util/debug.js
@@ -58,4 +58,10 @@ $(document).ready(function() {
   window.debug_copyTree = function() {
     return toGlobalize.Main.getSandbox().mainVis.gitEngine.printAndCopyTree();
   };
+  window.exportLevelProgress = function() {
+    return toGlobalize.LevelStore.exportLevelProgress();
+  };
+  window.importLevelProgress = function(progress) {
+    return toGlobalize.LevelStore.importLevelProgress(progress);
+  };
 });


### PR DESCRIPTION
### Motivation
- Provide a simple local/browser-console utility to export and import the current solved-level progress so users can back up or restore progress. 
- Accept and normalize legacy storage shapes (boolean true) for compatibility with older saved formats.

### Description
- Add `LevelStore.exportLevelProgress()` and `LevelStore.importLevelProgress(progress)` to serialize the internal `_solvedMap`, validate/normalize imported data, persist it to `localStorage`, and emit the store change event. 
- Implement helper internals `_cloneSolvedMap()` and `_normalizeImportedSolvedMap()` to deep-clone the map and normalize legacy or malformed import shapes. 
- Expose `exportLevelProgress()` and `importLevelProgress(progress)` on `window` via `src/js/util/debug.js` for easy use from the browser console. 
- Add unit tests in `__tests__/LevelStore.spec.js` to cover round-trip export/import and legacy boolean-format imports.

### Testing
- Ran the full test suite with `yarn test`, which executed 292 specs and completed successfully. 
- Built the app with `yarn gulp build`, which completed successfully and includes the new helpers in the build artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04994ade48832d95d716737faf2f0b)