### PR TITLE
Support -t/--track flag for git switch

### DIFF
--- a/__tests__/remote.spec.js
+++ b/__tests__/remote.spec.js
@@ -258,6 +258,13 @@ describe('Git Remotes', function() {
     );
   });
 
+  it('sets up remote tracking with "git switch -t -c" just like "git checkout -b"', function() {
+    return expectTreeAsync(
+      'git clone; git switch -t -c foo o/main; git commit; go main; git push origin foo',
+      '{"branches":{"main":{"target":"C1","id":"main","remoteTrackingBranchID":"o/main"},"o/main":{"target":"C2","id":"o/main","remoteTrackingBranchID":null},"foo":{"target":"C2","id":"foo","remoteTrackingBranchID":"o/main"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"},"C2":{"parents":["C1"],"id":"C2"}},"HEAD":{"target":"main","id":"HEAD"},"originTree":{"branches":{"main":{"target":"C2","id":"main","remoteTrackingBranchID":null}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"},"C2":{"parents":["C1"],"id":"C2"}},"HEAD":{"target":"main","id":"HEAD"}}}'
+    );
+  });
+
   it('will push to a new remote branch if tracking was previously set up but remote branch was merged on origin', function() {
     return expectTreeAsync(
       `git clone;

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -1048,11 +1048,25 @@ var commandConfig = {
       '--create',
       '-C',
       '--force-create',
+      '-t',
+      '--track',
       '-'
     ],
     execute: function(engine, command) {
       var generalArgs = command.getGeneralArgs();
       var commandOptions = command.getOptionsMap();
+
+      // "-t" / "--track" asks the new branch to track its start-point. It takes
+      // no value of its own, but the option parser is greedy: if the flag sits
+      // right before the start-point ref (e.g. "git switch -c side -t o/main")
+      // that ref gets attached to it, so hand any such value back to the
+      // general args before we read them. The actual tracking is then set up by
+      // engine.branch() below, which links to a remote start-point automatically
+      // (the same path "git checkout -b <branch> <remote>" already uses).
+      let trackOption = commandOptions['-t'] ? commandOptions['-t'] : commandOptions['--track'];
+      if (trackOption && trackOption.length) {
+        generalArgs = generalArgs.concat(trackOption);
+      }
 
       let createOption = commandOptions['-c'] ? commandOptions['-c'] : commandOptions['--create'];
       if (createOption) {


### PR DESCRIPTION
Add -t and --track options to 'git switch' so that 'git switch -t -c <branch> <start-point>' works as the equivalent of 'git checkout -b <branch> <start-point>', setting up remote tracking for the new branch. Previously the flag was rejected as unsupported.

Adds a test asserting 'git switch -t -c foo o/main' produces the same tree (with remote tracking) as the existing 'git checkout -b' case.

Fixes #1369