### PR TITLE
show solution writes into the command box, plus gc/level fixes

### DIFF
--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -200,6 +200,13 @@ describe('Git', function() {
     );
   });
 
+  it('reuses freed commit indices after gc (#1233)', function() {
+    return expectTreeAsync(
+      'git reset C0; git gc; git commit',
+      '{"branches":{"main":{"target":"C1","id":"main"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"}}'
+    );
+  });
+
   it('Branches', function() {
     return expectTreeAsync(
       'git branch side C0',

--- a/__tests__/sandboxCommands.spec.js
+++ b/__tests__/sandboxCommands.spec.js
@@ -1,0 +1,105 @@
+var SandboxCommands = require('../src/js/sandbox/commands');
+var GitCommands = require('../src/js/git/commands');
+
+describe('Sandbox Commands', function() {
+  describe('help {command}', function() {
+    var getHelpTuple = function() {
+      return SandboxCommands.instantCommands.filter(function(tuple) {
+        return tuple[2] === 'help {command}';
+      })[0];
+    };
+
+    it('is registered as an instant command', function() {
+      expect(getHelpTuple()).toBeTruthy();
+    });
+
+    it('documents git commands with description, options and docs link', function() {
+      var lines = SandboxCommands.getCommandHelpLines('commit');
+      var joined = lines.join('\n');
+      expect(joined).toContain('git commit');
+      expect(joined).toContain('git-scm.com/docs/git-commit');
+      expect(joined).toContain('--amend');
+    });
+
+    it('works with an explicit "git" prefix too', function() {
+      var lines = SandboxCommands.getCommandHelpLines('git commit');
+      expect(lines.join('\n')).toContain('git commit');
+    });
+
+    it('skips the docs link for custom teaching commands', function() {
+      var lines = SandboxCommands.getCommandHelpLines('fakeTeamwork');
+      var joined = lines.join('\n');
+      expect(joined).toContain('git fakeTeamwork');
+      expect(joined).not.toContain('git-scm.com');
+    });
+
+    it('documents sandbox commands like importTreeNow', function() {
+      var lines = SandboxCommands.getCommandHelpLines('importTreeNow');
+      var joined = lines.join('\n');
+      expect(joined).toContain('importTreeNow');
+      expect(joined).toContain('Import a tree immediately');
+    });
+
+    it('documents instant commands like echo', function() {
+      var lines = SandboxCommands.getCommandHelpLines('echo');
+      expect(lines.join('\n')).toContain('echo out a string');
+    });
+
+    it('returns null for unknown commands', function() {
+      expect(SandboxCommands.getCommandHelpLines('lolwat')).toBe(null);
+    });
+
+    it('does not intercept the reserved help forms', function() {
+      var regex = getHelpTuple()[0];
+      expect(regex.test('help')).toBe(false);
+      expect(regex.test('help general')).toBe(false);
+      expect(regex.test('help level')).toBe(false);
+      expect(regex.test('help goal')).toBe(false);
+      expect(regex.test('help builder')).toBe(false);
+      expect(regex.test('?')).toBe(false);
+
+      expect(regex.test('help commit')).toBe(true);
+      expect(regex.test('help git commit')).toBe(true);
+      expect(regex.test('help undo')).toBe(true);
+    });
+
+    it('registers a "git help {command}" form too', function() {
+      var tuple = SandboxCommands.instantCommands.filter(function(t) {
+        return t[0].test('git help commit');
+      })[0];
+      expect(tuple).toBeTruthy();
+    });
+
+    it('leaves bare "git" and "git help" to the general git help', function() {
+      var generalHelp = GitCommands.instantCommands.filter(function(t) {
+        return t[0].test('git help');
+      })[0];
+      expect(generalHelp).toBeTruthy();
+      expect(generalHelp[0].test('git')).toBe(true);
+      // but the specific form should no longer be swallowed by it
+      expect(generalHelp[0].test('git help commit')).toBe(false);
+    });
+  });
+
+  describe('show solution', function() {
+    // NOTE: we can't require('../level') here -- it pulls in JSX views that the
+    // jasmine harness doesn't transpile -- so we exercise the level regexMap
+    // through the same genParseCommand helper the real parse waterfall uses.
+    var util = require('../src/js/util');
+    var levelRegexMap = require('../src/js/level/levelRegexMap').regexMap;
+    var levelParse = util.genParseCommand(levelRegexMap, 'processLevelCommand');
+
+    it('parses as a level command routed to processLevelCommand', function() {
+      var result = levelParse('show solution');
+      expect(result).toBeTruthy();
+      expect(result.toSet.eventName).toBe('processLevelCommand');
+      expect(result.toSet.method).toBe('show solution');
+    });
+
+    it('is documented as writing the solution into the command box', function() {
+      var lines = SandboxCommands.getCommandHelpLines('show solution');
+      expect(lines).toBeTruthy();
+      expect(lines.join('\n')).toContain('command box');
+    });
+  });
+});

--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -7,6 +7,8 @@ var util = require('../util');
 var intl = require('../intl');
 var LocaleStore = require('../stores/LocaleStore');
 var LocaleActions = require('../actions/LocaleActions');
+// used by the beforeunload handler below to warn about a level in progress
+var GlobalStateStore = require('../stores/GlobalStateStore');
 
 /**
  * Globals

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -1113,7 +1113,9 @@ var commandConfig = {
 };
 
 var instantCommands = [
-  [/^(git help($|\s)|git$)/, function() {
+  // "git help {command}" is handled over in the sandbox commands, so only
+  // grab the bare forms here
+  [/^git +help *$|^git *$/, function() {
     var lines = [
       intl.str('git-version'),
       '<br/>',

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -48,12 +48,32 @@ function GitEngine(options) {
 
 GitEngine.prototype.initUniqueID = function() {
   // backbone or something uses _ .uniqueId, so we make our own here
-  this.uniqueId = (function() {
-    var n = 0;
-    return function(prepend) {
-      return prepend ? prepend + n++ : n++;
-    };
-  })();
+  var n = 0;
+  this.uniqueId = function(prepend) {
+    return prepend ? prepend + n++ : n++;
+  };
+  // let callers rewind the counter -- e.g. after gc prunes commits, so the
+  // next commit reuses the freed-up index instead of leaking a stale one
+  // (see issue #1233)
+  this.setUniqueIDCounter = function(newValue) {
+    n = newValue;
+  };
+};
+
+// Rewind the commit-index counter to just past the highest-numbered commit
+// still in the tree. Called after pruning so that, for example, resetting and
+// garbage-collecting a `C0 <- C1(main)` tree lets the next commit be C1 again
+// rather than C2 (issue #1233).
+GitEngine.prototype.recalcUniqueIDCounter = function() {
+  var maxIndex = -1;
+  this.commitCollection.each(function(commit) {
+    // strip any rebase/amend apostrophes; we only care about the numeric slot
+    var match = /^C(\d+)/.exec(commit.get('id'));
+    if (match) {
+      maxIndex = Math.max(maxIndex, parseInt(match[1], 10));
+    }
+  });
+  this.setUniqueIDCounter(maxIndex + 1);
 };
 
 GitEngine.prototype.handleModeChange = function(vcs, callback) {
@@ -1886,6 +1906,10 @@ GitEngine.prototype.pruneTree = function(doPrintWarning = true) {
       visNode.removeAll();
     }
   }, this);
+
+  // now that some commits are gone, rewind the index counter so freed-up
+  // commit numbers get reused on the next commit (issue #1233)
+  this.recalcUniqueIDCounter();
 
   return true;
 };

--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -1970,6 +1970,10 @@ exports.strings = {
     "tr_TR": "Seviye için adı girin",
     "hu_HU": "Add meg a szint nevét"
   },
+  "no-solution-defined": {
+    "__desc__": "Shown when the user runs `show solution` but the current level has no solution defined to place in the command box",
+    "en_US": "This level doesn't have a solution to show!"
+  },
   "solution-empty": {
     "__desc__": "If you define a solution without any commands, aka a level that is solved without doing anything",
     "en_US": "Your solution is empty!! Something is amiss",

--- a/src/js/level/index.js
+++ b/src/js/level/index.js
@@ -26,14 +26,9 @@ var LevelToolbarView = require('../react_views/LevelToolbarView.jsx');
 
 var TreeCompare = require('../graph/treeCompare');
 
-var regexMap = {
-  'help level': /^help level$/,
-  'start dialog': /^start dialog$/,
-  'show goal': /^(show goal|goal|help goal)$/,
-  'hide goal': /^hide goal$/,
-  'show solution': /^show solution($|\s)/,
-  'objective': /^(objective|assignment)$/
-};
+// regex map lives in its own JSX-free module so it can be required by the parse
+// waterfall / tests without loading the level's React views
+var regexMap = require('./levelRegexMap').regexMap;
 
 var parse = util.genParseCommand(regexMap, 'processLevelCommand');
 
@@ -269,53 +264,20 @@ class Level extends Sandbox {
   }
 
   showSolution(command, deferred) {
-    var toIssue = this.level.solutionCommand;
-    var issueFunc = function() {
-      this.isShowingSolution = true;
-      this.wasResetAfterSolved = true;
-      Main.getEventBaton().trigger(
-        'commandSubmitted',
-        toIssue
-      );
-      log.showLevelSolution(this.getEnglishName());
-    }.bind(this);
-
-    var commandStr = command.get('rawStr');
-    if (!this.testOptionOnString(commandStr, 'noReset')) {
-      toIssue = 'reset --forSolution; ' + toIssue;
-    }
-    if (this.testOptionOnString(commandStr, 'force')) {
-      issueFunc();
+    // Rather than running the solution, write it into the command box so the
+    // student can read (and edit) it, then run it themselves when ready.
+    var solution = this.level.solutionCommand;
+    if (!solution) {
+      command.setResult(intl.str('no-solution-defined'));
       command.finishWith(deferred);
       return;
     }
 
-    // if the level doesn't have an ID, its a GIST import and
-    // we don't need to worry about the solved map regardless
-    if(this.level.id && !LevelStore.isLevelSolved(this.level.id)){
-      // allow them for force the solution
-      var confirmDefer = createDeferred();
-      var dialog = intl.getDialog(require('../dialogs/confirmShowSolution'))[0];
-      var confirmView = new ConfirmCancelTerminal({
-        markdowns: dialog.options.markdowns,
-        deferred: confirmDefer
-      });
-
-      confirmDefer.promise
-      .then(issueFunc)
-      .catch(function() {
-        command.setResult("");
-      })
-      .then(function() {
-      // either way we animate, so both options can share this logic
-      setTimeout(function() {
-          command.finishWith(deferred);
-        }, confirmView.getAnimationTime());
-      });
-    } else {
-      issueFunc();
-      command.finishWith(deferred);
-    }
+    // trim stray leading/trailing semicolons for a clean, runnable command
+    solution = solution.replace(/^;|;$/g, '');
+    Main.getEvents().trigger('commandBox_setText', solution);
+    log.showLevelSolution(this.getEnglishName());
+    command.finishWith(deferred);
   }
 
   toggleObjective() {

--- a/src/js/level/levelRegexMap.js
+++ b/src/js/level/levelRegexMap.js
@@ -1,0 +1,13 @@
+// The regex map for level commands, split out from level/index.js so it can be
+// required without pulling in the level's React/JSX views (handy for the parse
+// waterfall and for tests). Keep in sync with the method map in level/index.js.
+var regexMap = {
+  'help level': /^help level$/,
+  'start dialog': /^start dialog$/,
+  'show goal': /^(show goal|goal|help goal)$/,
+  'hide goal': /^hide goal$/,
+  'show solution': /^show solution($|\s)/,
+  'objective': /^(objective|assignment)$/
+};
+
+exports.regexMap = regexMap;

--- a/src/js/sandbox/commands.js
+++ b/src/js/sandbox/commands.js
@@ -15,6 +15,40 @@ var GitError = Errors.GitError;
 var Warning = Errors.Warning;
 var CommandResult = Errors.CommandResult;
 
+// Commands that are learning tools with no official docs
+var customGitCommands = ['fakeTeamwork', 'mergeMR'];
+
+// Descriptions for the sandbox / level commands defined in the regex maps
+// below (and in ../level). These power `help {command}` and also show up
+// in `show commands`, so commands like `importTreeNow` are no longer
+// undocumented (see issue #1234)
+var sandboxCommandDescriptions = {
+  'help': 'Show the help dialog. Run `help {command}` to get documentation on a specific command',
+  'reset': 'Undo all commands entered so far and restore the initial tree',
+  'reset solved': 'Reset the solved state of the current level',
+  'delay': 'Set a delay (in milliseconds) that runs after each command, e.g. `delay 1000`',
+  'clear': 'Clear the entire command history',
+  'exit level': 'Exit the current level and return to the sandbox',
+  'sandbox': 'Exit the current level and return to the sandbox',
+  'level': 'Jump into a level, e.g. `level intro1`, or open the level selection view',
+  'levels': 'Open the level selection view',
+  'build level': 'Start the level builder to create your own level',
+  'export tree': 'Export the current tree as a JSON blob you can save and import later',
+  'import tree': 'Import a tree from a JSON blob (opens a text input)',
+  'importTreeNow': 'Import a tree immediately from the JSON blob given after the command',
+  'import level': 'Import a level from a JSON blob (opens a text input)',
+  'importLevelNow': 'Import a level immediately from the JSON blob given after the command',
+  'undo': 'Undo the last command',
+  'share permalink': 'Generate a shareable permalink of the current tree',
+  'show goal': 'Show the goal tree for the current level',
+  'hide goal': 'Hide the goal tree',
+  'show solution': 'Write the current level\'s solution into the command box (without running it) so you can read, edit, or run it yourself',
+  'objective': 'Show the objective of the current level',
+  'start dialog': 'Replay the intro dialog of the current level',
+  'help level': 'Show help for the current level',
+  'help builder': 'Show help for the level builder'
+};
+
 var instantCommands = [
   // Add a third and fourth item in the tuple if you want this to show
   // up in the `show commands` function
@@ -27,6 +61,14 @@ var instantCommands = [
     throw new CommandResult({
       msg: intl.str('cd-command')
     });
+  }],
+  // "help general", "help level", "help goal" and "help builder" are
+  // handled elsewhere, so don't grab those here
+  [/^help +(?!general$|level$|goal$|builder$)(.+)$/, function(bits) {
+    showHelpForCommand(bits[1].trim());
+  }, 'help {command}', 'show documentation for the given command'],
+  [/^git +help +(.+)$/, function(bits) {
+    showHelpForCommand(bits[1].trim());
   }],
   [/^(locale|locale reset)$/, function(bits) {
     LocaleActions.changeLocale(
@@ -144,6 +186,8 @@ var instantCommands = [
         }
       });
     });
+    // pull in the descriptions for sandbox / level commands as well
+    Object.assign(commandToDescriptions, sandboxCommandDescriptions);
     var selectedInstantCommands = {};
     instantCommands.map(
       tuple => {
@@ -163,16 +207,14 @@ var instantCommands = [
       intl.str('show-all-commands'),
       '<br/>'
     ];
-    // Commands that are learning tools with no official docs
-    var customCommands = ['fakeTeamwork', 'mergeMR'];
     Object.keys(allCommands)
       .forEach(function(command) {
         if (selectedInstantCommands[command]) {
           lines.push('<br/>');
-        }        
+        }
         // Add command name with documentation link for git commands (skip custom commands)
         var commandParts = command.split(' ');
-        if (commandParts[0] === 'git' && commandParts[1] && customCommands.indexOf(commandParts[1]) === -1) {
+        if (commandParts[0] === 'git' && commandParts[1] && customGitCommands.indexOf(commandParts[1]) === -1) {
           var gitCommand = commandParts[1];
           var docUrl = 'https://git-scm.com/docs/git-' + gitCommand;
           lines.push('<b>' + command + '</b> - <a href="' + docUrl + '" target="_blank" style="color: #87CEEB">📖 Docs</a>');
@@ -245,7 +287,88 @@ var getAllCommands = function() {
   return allCommands;
 };
 
+// shared handler for `help {command}` and `git help {command}`
+var showHelpForCommand = function(target) {
+  var lines = getCommandHelpLines(target);
+  if (!lines) {
+    throw new CommandProcessError({
+      msg: intl.todo(
+        'No documentation found for "' + target + '"; ' +
+        'run `show commands` to see all available commands'
+      )
+    });
+  }
+
+  throw new CommandResult({
+    msg: lines.join('\n')
+  });
+};
+
+// builds the documentation lines for `help {command}`; returns null
+// if we have nothing to say about the given command
+var getCommandHelpLines = function(target) {
+  var vcsRegexMap = Commands.commands.getRegexMap();
+  var descriptionMap = Commands.commands.getDescriptionMap();
+  var optionMap = Commands.commands.getOptionMap();
+
+  // "help git commit" and "help commit" should both work
+  var vcsList = Object.keys(vcsRegexMap);
+  var specifiedVcs = null;
+  var method = target;
+  var split = target.split(/\s+/);
+  if (split.length > 1 && vcsList.indexOf(split[0]) !== -1) {
+    specifiedVcs = split[0];
+    method = split.slice(1).join(' ');
+  }
+
+  var lines = null;
+  vcsList.forEach(function(vcs) {
+    if (specifiedVcs && vcs !== specifiedVcs) {
+      return;
+    }
+    if (!vcsRegexMap[vcs][method]) {
+      return;
+    }
+
+    lines = lines || [];
+    var fullName = vcs + ' ' + method;
+    // same documentation link treatment as `show commands`
+    if (vcs === 'git' && customGitCommands.indexOf(method) === -1) {
+      var docUrl = 'https://git-scm.com/docs/git-' + method;
+      lines.push('<b>' + fullName + '</b> - <a href="' + docUrl + '" target="_blank" style="color: #87CEEB">📖 Docs</a>');
+    } else {
+      lines.push('<b>' + fullName + '</b>');
+    }
+    var description = descriptionMap[vcs][method];
+    if (description) {
+      lines.push('&nbsp;&nbsp;&nbsp;&nbsp;<i>' + description + '</i>');
+    }
+    Object.keys(optionMap[vcs][method] || {})
+      .filter(option => option.length > 1)
+      .forEach(option => lines.push('&nbsp;&nbsp;&nbsp;&nbsp;' + option));
+  });
+  if (lines) {
+    return lines;
+  }
+
+  // maybe it's a sandbox / level command instead
+  var description = sandboxCommandDescriptions[target];
+  instantCommands.forEach(function(tuple) {
+    if (tuple[2] === target && tuple[3]) {
+      description = tuple[3];
+    }
+  });
+  if (description) {
+    return [
+      '<b>' + target + '</b>',
+      '&nbsp;&nbsp;&nbsp;&nbsp;<i>' + description + '</i>'
+    ];
+  }
+  return null;
+};
+
 exports.getAllCommands = getAllCommands;
+exports.getCommandHelpLines = getCommandHelpLines;
 exports.instantCommands = instantCommands;
 exports.parse = util.genParseCommand(regexMap, 'processSandboxCommand');
 

--- a/src/js/views/commandViews.js
+++ b/src/js/views/commandViews.js
@@ -57,6 +57,7 @@ class CommandPromptView {
     this.focus();
 
     Main.getEvents().on('rollupCommands', this.rollupCommands, this);
+    Main.getEvents().on('commandBox_setText', (value) => this.setInputText(value));
 
     Main.getEventBaton().stealBaton('keydown', this.onKeyDown, this);
     Main.getEventBaton().stealBaton('keyup', this.onKeyUp, this);
@@ -242,6 +243,19 @@ class CommandPromptView {
 
   setTextField(value) {
     this.$('#commandTextField').val(value);
+  }
+
+  // Drop some text into the command box and focus it, without submitting --
+  // used by the level `show solution` command (see level/index.js)
+  setInputText(value) {
+    this.setTextField(value);
+    var el = this.$('#commandTextField')[0];
+    if (el) {
+      el.focus();
+      el.selectionStart = el.selectionEnd = value.length;
+      this.updatePrompt(el);
+    }
+    this.showCursor();
   }
 
   clear() {

--- a/src/levels/rampup/reversingChanges.js
+++ b/src/levels/rampup/reversingChanges.js
@@ -101,8 +101,8 @@ exports.level = {
               "",
               "With reverting, you can push out your changes to share with others."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -163,8 +163,8 @@ exports.level = {
               "",
               "با revert کردن، می‌توانید تغییرات خود را push کنید تا با دیگران به اشتراک بگذارید."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -226,8 +226,8 @@ exports.level = {
               "",
               "Cuando usás revert, podés pushear ese cambio para compartirlo con otros."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -289,8 +289,8 @@ exports.level = {
               "",
               "Cuando utilices revert, puedes hacer push sobre ese cambio para compartirlo con otros."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -352,8 +352,8 @@ exports.level = {
               "",
               "Cuando utilices revert, puedes hacer push sobre ese cambio para compartirlo con otros."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -415,8 +415,8 @@ exports.level = {
               "",
               "Com o `revert`, você pode fazer `push` das suas mudanças para compartilhá-las com os outros."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -478,8 +478,8 @@ exports.level = {
               "",
               "Con `revert`, ti podes facer `push` dos teus cambios para compartilos cos outros."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -541,8 +541,8 @@ exports.level = {
               "",
               "Durch Reverten kannst du das Zurücknehmen von Änderungen mit anderen teilen."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -604,8 +604,8 @@ exports.level = {
               "",
               "こんな風にして、巻き戻した内容を他人と共有するためにはrevertを使います。"
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -667,8 +667,8 @@ exports.level = {
               "",
               "Avec revert, vous pouvez diffuser (push) vos modifications et les partager avec tout le monde."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -727,13 +727,13 @@ exports.level = {
               "",
               "为了撤销更改并**分享**给别人，我们需要使用 `git revert`。来看演示："
             ],
-            "command": "git revert HEAD",
+            "command": "git revert HEAD^",
             "afterMarkdowns": [
               "奇怪！在我们要撤销的提交记录后面居然多了一个新提交！这是因为新提交记录 `C2'` 引入了**更改** —— 这些更改能够刚好撤销 `C2` 提交的变更。",
               "",
               "通过 revert，你可以推送你的更改并与他人分享。"
             ],
-            "beforeCommand": "git commit"
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -790,13 +790,13 @@ exports.level = {
               "",
               "為了取消修改並且把這個狀態*分享*給別人，我們需要使用 `git revert`。舉個例子"
             ],
-            "command": "git revert HEAD",
+            "command": "git revert HEAD^",
             "afterMarkdowns": [
               "很奇怪吧！在我們要取消的 commit 後面居然多了一個新的 commit！這是因為新的 commit `C2'` 引入了*修改*——用來表示我們取消 `C2` 這個 commit 的修改。",
               "",
               "多虧了 revert，現在可以把你的修改分享給別人啦。"
             ],
-            "beforeCommand": "git commit"
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -858,8 +858,8 @@ exports.level = {
               "",
               "리버트를 하면 다른 사람들에게도 변경 내역을 밀어(push) 보낼 수 있습니다."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -921,8 +921,8 @@ exports.level = {
               "",
               "Cu `revert`, poți să partajezi modificările tale pentru a le împărtăși cu ceilalți."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -984,8 +984,8 @@ exports.level = {
               "",
               "При revert можеш спокойно да push-неш промените и да ги споделиш с други."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -1047,8 +1047,8 @@ exports.level = {
               "",
               "После `revert` можно сделать `push` и поделиться изменениями с остальными."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -1111,8 +1111,8 @@ exports.level = {
               "",
               "Після revert, ти зможеш зробити push щоб поділитися гілкою з іншими."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -1174,8 +1174,8 @@ exports.level = {
               "",
               "Dùng revert thì bạn có thể đẩy thay đổi mình lên và chia sẻ với người khác."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -1237,8 +1237,8 @@ exports.level = {
               "",
               "Z revertanjem lahko pushas in deliš svoje spremembe tudi z drugimi."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -1300,8 +1300,8 @@ exports.level = {
               "",
               "Dzięki `git revert` możesz wypchnąć swoje zmiany, by podzielić się nimi z innymi."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         }
       ]
@@ -1353,8 +1353,8 @@ exports.level = {
               "",
               "Con git revert, aggiungi i cambiamenti che possono essere poi condivisi con altri."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -1416,8 +1416,8 @@ exports.level = {
               "",
               "Revertleme ile değişikliklerinizi başkalarına paylaşmak için push edebilirsiniz."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {
@@ -1479,8 +1479,8 @@ exports.level = {
               "",
               "A revert segítségével megoszthatod a változtatásokat másokkal."
             ],
-            "command": "git revert HEAD",
-            "beforeCommand": "git commit"
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
           }
         },
         {


### PR DESCRIPTION
- level: `show solution` now writes the level's solution into the command box (without running it) so students can read, edit, or run it themselves, via a new commandBox_setText event + setInputText handler in the command prompt view. Split the level regexMap into levelRegexMap.js so it can be parsed/tested without loading the React views.
- git gc: rewind the commit-index counter after pruning so freed commit numbers get reused (e.g. reset + gc + commit yields C1, not C2) (#1233)
- rampup4: use `git revert HEAD^` in the revert demonstration so it has a practical effect, updated across all locales (#1226)
- help: document sandbox/level commands so `help {command}` and `show commands` cover them (e.g. importTreeNow); leave bare `git`/`git help` to the general git help
- fix: import GlobalStateStore in app/index.js; it was referenced in the beforeunload handler without an import, throwing a ReferenceError on unload
- tests: add gc-index regression test and sandbox/level command specs