### PR TITLE
Allow single-character branch names

### DIFF
--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -403,6 +403,13 @@ describe('Git', function() {
     );
   });
 
+  it('allows single-character branch names', function() {
+    return expectTreeAsync(
+      'git branch b; git checkout -b x',
+      '{"branches":{"main":{"target":"C1","id":"main"},"b":{"target":"C1","id":"b"},"x":{"target":"C1","id":"x"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"x","id":"HEAD"}}'
+    );
+  });
+
   describe('RevList', function() {
 
     it('requires at least 1 argument', function() {

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -648,7 +648,7 @@ GitEngine.prototype.validateBranchName = function(name) {
   // And then just make sure it starts with alpha-numeric,
   // can contain a slash or dash, and then ends with alpha
   if (
-    !/^(\w+[.\/\-]?)+\w+$/.test(name) ||
+    !/^\w([.\/\-]?\w+)*$/.test(name) ||
     name.search('o/') === 0
   ) {
     throw new GitError({


### PR DESCRIPTION
`git branch b` and `git checkout -b x` currently fail with `That branch name "b" is not allowed!`, even though real git accepts single-character branch names.

The culprit is the name check in `validateBranchName`:

```js
/^(\w+[.\/\-]?)+\w+$/
```

The trailing `\w+$` sits outside the repeating group, so it always demands a word character beyond the one the group already consumed — effectively a two-character minimum. The comment above it only intends "starts and ends with a word char, separators allowed in between", so that trailing `\w+` is redundant. Replacing it with:

```js
/^\w([.\/\-]?\w+)*$/
```

anchors on a single leading word char and then allows zero-or-more "separator-plus-word-chars" groups. Single-character names now pass; every previously-valid name still passes (`foo`, `foo-bar`, `foo/bar/baz`, `feature.1`); and leading, trailing, or doubled separators are still rejected (a separator can't appear without trailing word chars in the same group). The separate commit-id / `HEAD` / `o/`-prefix bans are untouched.

This actually restores older behavior: before `32c80bdb` (#201, "allow dashes and slashes") the check was `^[a-zA-Z0-9]+$`, which accepted single-char names — the trailing `\w+$` introduced there imposed the two-char minimum as an unintended side-effect. This keeps the dash/slash support that commit added.

Added a test in `__tests__/git.spec.js` covering `git branch b; git checkout -b x`, and the full suite stays green.
