### PR TITLE
Add Azerbaijani (az) locale — intro sequence

### DIFF
--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -24,7 +24,8 @@ exports.strings = {
     "it_IT": "Wow! Hai concluso l'ultimo livello, grandioso!",
     "ta_IN": "ஆஹா! நீங்கள் கடைசி நிலையை முடித்துள்ளீர்கள், நன்று!",
     "tr_TR": "Wow! son seviyeyi tamamladın, tebrikler!",
-    "hu_HU": "Hűha! Befejezted az utolsó szintet, remek!"
+    "hu_HU": "Hűha! Befejezted az utolsó szintet, remek!",
+    "az": "Vay! Sonuncu bölümü bitirdin, əla!"
   },
   "finish-dialog-next": {
     "__desc__": "One of the lines in the next level dialog",
@@ -51,7 +52,8 @@ exports.strings = {
     "it_IT": "Ti andrebbe di passare al prossimo livello, *\"{nextLevel}\"*?",
     "ta_IN": "அடுத்த நிலை * \"{nextLevel}\" * க்கு செல்ல விரும்புகிறீர்களா?",
     "tr_TR": "Bir sonraki seviye olan *\"{nextLevel}\"* seviyesine geçmek ister misin?",
-    "hu_HU": "Szeretnél továbblépni a következő szintre: *\"{nextLevel}\"*?"
+    "hu_HU": "Szeretnél továbblépni a következő szintre: *\"{nextLevel}\"*?",
+    "az": "Növbəti bölümə — *\"{nextLevel}\"* — keçmək istəyirsən?"
   },
   "finish-dialog-win": {
     "__desc__": "One of the lines in the next level dialog when user entered same command as our best",
@@ -78,7 +80,8 @@ exports.strings = {
     "it_IT": "Grandioso! Hai eguagliato o migliorato la nostra soluzione.",
     "ta_IN": "அருமை! எங்கள் கொடுக்க பட்ட தீர்வை நிறைவு செய்து விட்டீர்கள்.",
     "tr_TR": "Mükemmel! ideal çözümle aynı veya daha iyi bir çözüm yaptınız.",
-    "hu_HU": "Fantasztikus! A megoldásod megegyezik a miénkkel."
+    "hu_HU": "Fantasztikus! A megoldásod megegyezik a miénkkel.",
+    "az": "Əla! Bizim həlli təkrarladın."
   },
    "finish-dialog-win-exceeded": {
     "__desc__": "One of the lines in the next level dialog when user entered less command than our best",
@@ -105,7 +108,8 @@ exports.strings = {
     "it_IT": "Grandioso! Hai eguagliato o migliorato la nostra soluzione.",
     "ta_IN": "அருமை! எங்கள் கொடுக்க பட்ட தீர்வை நிறைவு செய்து விட்டீர்கள்.",
     "tr_TR": "Mükemmel! ideal çözümle aynı veya daha iyi bir çözüm yaptınız.",
-    "hu_HU": "Fantasztikus! Túlszárnyaltad a megoldásunkat."
+    "hu_HU": "Fantasztikus! Túlszárnyaltad a megoldásunkat.",
+    "az": "Əla! Bizim həlli qabaqladın."
   },
   "finish-dialog-lose": {
     "__desc__": "When the user entered more commands than our best, encourage them to do better",
@@ -132,7 +136,8 @@ exports.strings = {
     "it_IT": "Prova a migliorarti facendolo solo con {best} comandi :D",
     "ta_IN": "நீங்கள் அதை குறைக்க முடியுமா என்று பாருங்கள் {best} :D",
     "tr_TR": "Bakalım bunu {best} adıma indirgeyebilir misin? :D",
-    "hu_HU": "Nézd meg, le tudod-e csökkenteni {best} lépésre :D"
+    "hu_HU": "Nézd meg, le tudod-e csökkenteni {best} lépésre :D",
+    "az": "Gör onu {best} əmrə qədər azalda bilərsənmi :D"
   },
   "hg-prune-tree": {
     "__desc__": "warning when pruning tree",
@@ -314,7 +319,8 @@ exports.strings = {
     "it_IT": "Sul ramo {branch}",
     "ta_IN": "{branch} கிளையில்",
     "tr_TR": "{branch} branch'indesiniz",
-    "hu_HU": "A(z) {branch} ágon"
+    "hu_HU": "A(z) {branch} ágon",
+    "az": "{branch} branch-ındasan"
   },
   "git-status-readytocommit": {
     "__desc__": "One of the lines for git status output",
@@ -340,7 +346,8 @@ exports.strings = {
     "it_IT": "Pronto al commit! (come sempre in questa demo)",
     "ta_IN": "`commit` செய்ய தயார்! (இந்த செயல் விளக்கத்தில் எப்போதும் செய்வதை போல)",
     "tr_TR": "Commit etmeye hazır! (bu demoda her zaman olduğu gibi)",
-    "hu_HU": "Készen áll a commit-ra! (mint mindig ebben a demóban)"
+    "hu_HU": "Készen áll a commit-ra! (mint mindig ebben a demóban)",
+    "az": "Commit etməyə hazır! (bu nümayişdə həmişə olduğu kimi)"
   },
   "git-dummy-msg": {
     "__desc__": "The dummy commit message for all commits. Feel free to put in a shoutout to your school / city / whatever!",
@@ -574,7 +581,8 @@ exports.strings = {
     "it_IT": "Fuso {target} in {current}",
     "ta_IN": "{target}ஐ {current} கிளையுடன் இணை",
     "tr_TR": "{target}i {current}e birleştir",
-    "hu_HU": "{target} merge-elése {current} ágba"
+    "hu_HU": "{target} merge-elése {current} ágba",
+    "az": "{target} {current}-ə birləşdirilir"
   },
   "git-error-rebase-none": {
     "__desc__": "One of the error messages for git",
@@ -652,7 +660,8 @@ exports.strings = {
     "it_IT": "Fast forwarding...",
     "ta_IN": "Fast forward...",
     "tr_TR": "Hızlı ileri alınıyor...",
-    "hu_HU": "Fast forwarding..."
+    "hu_HU": "Fast forwarding...",
+    "az": "Sürətli irəliləmə (fast-forward)..."
   },
   "git-result-uptodate": {
     "__desc__": "The message that explains the result of a git command",
@@ -678,7 +687,8 @@ exports.strings = {
     "it_IT": "Il ramo è già aggiornato",
     "ta_IN": "இந்த கிளை ஏற்கனவே புதுப்பித்த நிலையில் உள்ளது...",
     "tr_TR": "Dal zaten güncel",
-    "hu_HU": "Az ág már naprakész"
+    "hu_HU": "Az ág már naprakész",
+    "az": "Branch onsuz da günceldir"
   },
   "git-error-exist": {
     "__desc__": "One of the error messages for git",
@@ -1117,7 +1127,8 @@ exports.strings = {
     "it_IT": "Scegli un livello",
     "ta_IN": "ஒரு நிலையை தேர்வு செய்யுங்கள்",
     "tr_TR": "Bir level (Seviye) seç",
-    "hu_HU": "Válassz egy szintet"
+    "hu_HU": "Válassz egy szintet",
+    "az": "Bölüm seç"
   },
   "main-levels-tab": {
     "__desc__": "The name of main levels tab on the drop down view",
@@ -1787,7 +1798,8 @@ exports.strings = {
     "it_IT": "Hai già risolto questo livello, prova altri livelli con \"levels\" o torna alla sandbox con \"sandbox\"",
     "ta_IN": "நீங்கள் ஏற்கனவே இந்த நிலையை தீர்த்துள்ளீர்கள், \"நிலைகள்\" மூலம் பிற நிலைகளை முயற்சிக்கவும் அல்லது \"sandbox\" உடன் sandbox-க்குச் செல்லவும்",
     "tr_TR": "Bu seviyeyi zaten çözdünüz, \"levels\" komutuyla diğer seviyeleri deneyin veya \"sandbox\" komutuyla tekrar sandbox'a dönün.",
-    "hu_HU": "Ezt a szintet már megoldottad, próbálj más szinteket a \"levels\" paranccsal vagy térj vissza a homokozóba a \"sandbox\" paranccsal"
+    "hu_HU": "Ezt a szintet már megoldottad, próbálj más szinteket a \"levels\" paranccsal vagy térj vissza a homokozóba a \"sandbox\" paranccsal",
+    "az": "Bu bölümü artıq həll etmisən, \"levels\" ilə digər bölümləri yoxla və ya \"sandbox\" ilə sandbox-a qayıt"
   },
   "solved-level": {
     "__desc__": "When you solved a level",
@@ -1812,7 +1824,8 @@ exports.strings = {
     "it_IT": "Risolto!!!\n:D",
     "ta_IN": "தீர்க்கப்பட்டது!!!\n:D",
     "tr_TR": "Tebrikler!!!\n:D",
-    "hu_HU": "Megoldva!!!\n:D"
+    "hu_HU": "Megoldva!!!\n:D",
+    "az": "Həll edildi!!!\n:D"
   },
   "command-disabled": {
     "__desc__": "When you try a command that is disabled",
@@ -1890,7 +1903,8 @@ exports.strings = {
     "it_IT": "Non hai specificato una finestra di partenza, ne vuoi aggiungere una?",
     "ta_IN": "தொடக்க உரை எதுவும் நீங்கள் குறிப்பிடவில்லை, ஏதேனும் ஒன்றைச் சேர்க்க விரும்புகிறீர்களா?",
     "tr_TR": "Başlangıç diyaloğunu belirtmediniz, bir tane eklemek ister misiniz?",
-    "hu_HU": "Nem adtál meg indítási párbeszédet, szeretnél egyet hozzáadni?"
+    "hu_HU": "Nem adtál meg indítási párbeszédet, szeretnél egyet hozzáadni?",
+    "az": "Başlanğıc dialoqu təyin etməmisən, birini əlavə etmək istəyirsən?"
   },
   "want-hint": {
     "__desc__": "prompt to add a hint",
@@ -1916,7 +1930,8 @@ exports.strings = {
     "it_IT": "Non hai specificato un suggerimento, ne vuoi aggiungere uno?",
     "ta_IN": "நீங்கள் குறிப்பெதுவும் தரவில்லை, ஏதேனும் ஒன்றைச் சேர்க்க விரும்புகிறீர்களா?",
     "tr_TR": "Bir ipucu belirtmediniz, bir tane eklemek ister misiniz?",
-    "hu_HU": "Nem adtál meg tippet, szeretnél egyet hozzáadni?"
+    "hu_HU": "Nem adtál meg tippet, szeretnél egyet hozzáadni?",
+    "az": "İpucu təyin etməmisən, birini əlavə etmək istəyirsən?"
   },
   "prompt-hint": {
     "__desc__": "prompt for hint",
@@ -2103,7 +2118,8 @@ exports.strings = {
     "it_IT": "Mostra obiettivo",
     "ta_IN": "இலக்கைக் காட்டு",
     "tr_TR": "Hedefi Göster",
-    "hu_HU": "Cél megjelenítése"
+    "hu_HU": "Cél megjelenítése",
+    "az": "Hədəfi Göstər"
   },
   "hide-goal-button": {
     "__desc__": "button label to hide goal",
@@ -2130,7 +2146,8 @@ exports.strings = {
     "it_IT": "Nascondi obiettivo",
     "ta_IN": "இலக்கை மறை",
     "tr_TR": "Hedefi Gizle",
-    "hu_HU": "Cél elrejtése"
+    "hu_HU": "Cél elrejtése",
+    "az": "Hədəfi Gizlə"
   },
   "objective-button": {
     "__desc__": "button label to show objective",
@@ -2155,7 +2172,8 @@ exports.strings = {
     "pt_BR": "Instruções",
     "ta_IN": "வழிமுறைகள்",
     "tr_TR": "Talimatlar",
-    "hu_HU": "Utasítások"
+    "hu_HU": "Utasítások",
+    "az": "Təlimatlar"
   },
   "git-demonstration-title": {
     "__desc__": "title of git demonstration window",
@@ -2180,7 +2198,8 @@ exports.strings = {
     "it_IT": "Dimostrazione Git",
     "ta_IN": "கிட் செயல் விளக்கம்",
     "tr_TR": "Git Gösterimi",
-    "hu_HU": "Git bemutató"
+    "hu_HU": "Git bemutató",
+    "az": "Git Nümayişi"
   },
   "goal-to-reach": {
     "__desc__": "title of window that shoes the goal tree to reach",
@@ -2207,7 +2226,8 @@ exports.strings = {
     "it_IT": "Obiettivo da raggiungere",
     "ta_IN": "அடைய வேண்டிய இலக்கு",
     "tr_TR": "Ulaşılması Gereken Hedef",
-    "hu_HU": "Elérendő cél"
+    "hu_HU": "Elérendő cél",
+    "az": "Çatılası Hədəf"
   },
   "goal-only-main": {
     "__desc__": "the helper message for the window that shows the goal tree when the goal will only be compared using the main branch",
@@ -2234,7 +2254,8 @@ exports.strings = {
     "it_IT": "<span class=\"fwber\">Nota:</span> In questo livello sarà selezionato solo il ramo main. Gli altri rami ci sono solo come riferimento (mostrati come etichette tratteggiate). Come sempre, puoi nascondere questa finestra con \"hide goal\"",
     "ta_IN": "<span class=\"fwber\">குறிப்பு:</span> இந்த மட்டத்தில் பிரதான கிளை மட்டுமே சரிபார்க்கப்படும். மற்ற கிளைகள் வெறுமனே விளக்க குறிப்புக்காக மட்டுமே (கீழே விடுபட்ட மேற்கோள்களாக காட்டப்பட்டுள்ளது). எப்பொழுதும் போல், \"இலக்கை மறை\" மூலம் இந்த சாளரத்தை மறைக்கலாம்",
     "tr_TR": "<span class=\"fwber\">Not:</span> Bu seviyede yalnızca ana dal kontrol edilecektir. Diğer dallar yalnızca referans amaçlıdır (aşağıda kesikli etiketler olarak gösterilmektedir). Her zamanki gibi, bu diyaloğu \"hedefi gizle\" ile gizleyebilirsiniz.",
-    "hu_HU": "<span class=\"fwber\">Megjegyzés:</span> Ebben a szintben csak a main ág lesz ellenőrizve. A többi ág csak tájékoztatásul van (szaggatott vonallal jelölve alább). Mint mindig, elrejtheted ezt az ablakot a \"hide goal\" paranccsal"
+    "hu_HU": "<span class=\"fwber\">Megjegyzés:</span> Ebben a szintben csak a main ág lesz ellenőrizve. A többi ág csak tájékoztatásul van (szaggatott vonallal jelölve alább). Mint mindig, elrejtheted ezt az ablakot a \"hide goal\" paranccsal",
+    "az": "<span class=\"fwber\">Qeyd:</span> Bu bölümdə yalnız main branch-ı yoxlanılacaq. Digər branch-lar sadəcə istinad üçündür (aşağıda kəsik-kəsik etiketlərlə göstərilib). Həmişəki kimi, bu dialoqu \"hide goal\" ilə gizlədə bilərsən."
   },
   "hide-goal": {
     "__desc__": "the helper message for the window that shows the goal tree",
@@ -2261,7 +2282,8 @@ exports.strings = {
     "it_IT": "Puoi nascondere questa finestra con \"hide goal\"",
     "ta_IN": "இந்த சாளரத்தை \"இலக்கை மறை\" மூலம் மறைக்கலாம்",
     "tr_TR": "Bu pencereyi \"hedefi gizle\" ile gizleyebilirsiniz",
-    "hu_HU": "Elrejtheted ezt az ablakot a \"hide goal\" paranccsal"
+    "hu_HU": "Elrejtheted ezt az ablakot a \"hide goal\" paranccsal",
+    "az": "Bu pəncərəni \"hide goal\" ilə gizlədə bilərsən"
   },
   "hide-start": {
     "__desc__": "The helper message for the window that shows the start tree for a level",
@@ -2288,7 +2310,8 @@ exports.strings = {
     "it_IT": "Puoi nascondere questa finestra con \"hide start\"",
     "ta_IN": "இந்த சாளரத்தை \"தொடக்கத்தை மறை\" மூலம் மறைக்கலாம்",
     "tr_TR": "Bu pencereyi \"başlangıcı gizle\" ile gizleyebilirsiniz.",
-    "hu_HU": "Elrejtheted ezt az ablakot a \"hide start\" paranccsal"
+    "hu_HU": "Elrejtheted ezt az ablakot a \"hide start\" paranccsal",
+    "az": "Bu pəncərəni \"hide start\" ilə gizlədə bilərsən"
   },
   "level-builder": {
     "__desc__": "The name for the environment where you build levels",
@@ -2341,7 +2364,8 @@ exports.strings = {
     "it_IT": "Non esiste una finestra di partenza per questo livello!",
     "ta_IN": "இந்த நிலை பற்றி விளக்கிகாட்ட தொடக்க உரையாடல் எதுவும் இல்லை",
     "tr_TR": "Bu seviye için gösterilecek bir başlangıç penceresi yok!",
-    "hu_HU": "Nincs megjelenítendő indítási párbeszéd ehhez a szinthez!"
+    "hu_HU": "Nincs megjelenítendő indítási párbeszéd ehhez a szinthez!",
+    "az": "Bu bölüm üçün göstəriləcək başlanğıc dialoqu yoxdur!"
   },
   "no-hint": {
     "__desc__": "when no hint is available for a level",
@@ -2368,7 +2392,8 @@ exports.strings = {
     "it_IT": "Mmh, sembra non ci sia un suggerimento per questo livello :-/",
     "ta_IN": "ஹ்ம், இந்த நிலைக்கு ஒரு குறிப்பு எதுவும் இருப்பதாகத் தெரியவில்லை :-/",
     "tr_TR": "Hmm, bu seviye için bir ipucu görünmüyor :-/",
-    "hu_HU": "Hmm, úgy tűnik nincs tipp ehhez a szinthez :-/"
+    "hu_HU": "Hmm, úgy tűnik nincs tipp ehhez a szinthez :-/",
+    "az": "Hmm, bu bölüm üçün ipucu yoxdur deyəsən :-/"
   },
   "error-untranslated-key": {
     "__desc__": "This error happens when we are trying to translate a specific key and the locale version is mission",
@@ -2443,7 +2468,8 @@ exports.strings = {
     "ta_IN": "இரத்துசெய்",
     "vi": "Hủy",
     "tr_TR": "İptal",
-    "hu_HU": "Mégse"
+    "hu_HU": "Mégse",
+    "az": "Ləğv et"
   },
   "confirm-button": {
     "__desc__": "Confirm button label after completing a level",
@@ -2464,7 +2490,8 @@ exports.strings = {
     "ta_IN": "உறுதிப்படுத்தவும்",
     "vi": "Đồng ý",
     "tr_TR": "Tamam",
-    "hu_HU": "Megerősít"
+    "hu_HU": "Megerősít",
+    "az": "Təsdiqlə"
   },
   "level-label": {
     "__desc__": "Label in the top of the left-side menu. Remember to leave some space on the sides",
@@ -2483,7 +2510,8 @@ exports.strings = {
     "it_IT": " Livello ",
     "pl": " Poziom ",
     "tr_TR": " Seviye ",
-    "hu_HU": " Szint "
+    "hu_HU": " Szint ",
+    "az": " Bölüm "
   },
   "command-helper-bar-levels": {
     "__desc__": "Levels command label in the bottom command helper bar.",
@@ -2502,7 +2530,8 @@ exports.strings = {
     "it_IT": "Livelli",
     "pl": "Poziomy",
     "tr_TR": "Seviyeler",
-    "hu_HU": "Szintek"
+    "hu_HU": "Szintek",
+    "az": "Bölümlər"
   },
   "command-helper-bar-solution": {
     "__desc__": "Solution command label in the bottom command helper bar.",
@@ -2521,7 +2550,8 @@ exports.strings = {
     "pt_BR": "Solução",
     "pl": "Rozwiązanie",
     "tr_TR": "Çözüm",
-    "hu_HU": "Megoldás"
+    "hu_HU": "Megoldás",
+    "az": "Həll"
   },
   "command-helper-bar-reset": {
     "__desc__": "Reset command label in the bottom command helper bar.",
@@ -2539,7 +2569,8 @@ exports.strings = {
     "zh_CN": "重置",
     "pl": "Wyczyść",
     "tr_TR": "Sıfırla",
-    "hu_HU": "Visszaállítás"
+    "hu_HU": "Visszaállítás",
+    "az": "Sıfırla"
   },
   "command-helper-bar-undo": {
     "__desc__": "Undo command label in the bottom command helper bar.",
@@ -2558,7 +2589,8 @@ exports.strings = {
     "it_IT": "Annulla",
     "pl": "Cofnij",
     "tr_TR": "Geri al",
-    "hu_HU": "Visszavonás"
+    "hu_HU": "Visszavonás",
+    "az": "Geri al"
   },
   "command-helper-bar-objective": {
     "__desc__": "Objective command label in the bottom command helper bar.",
@@ -2577,7 +2609,8 @@ exports.strings = {
     "pt_BR": "Objetivo",
     "pl": "Cel",
     "tr_TR": "Hedef",
-    "hu_HU": "Cél"
+    "hu_HU": "Cél",
+    "az": "Hədəf"
   },
   "command-helper-bar-help": {
     "__desc__": "Help command label in the bottom command helper bar.",
@@ -2596,7 +2629,8 @@ exports.strings = {
     "it_IT": "Aiuto",
     "pl": "Pomoc",
     "tr_TR": "Yardım",
-    "hu_HU": "Segítség"
+    "hu_HU": "Segítség",
+    "az": "Kömək"
   },
   "error-command-currently-not-supported": {
     "__desc__": "Message that appears in git console when command is not supported in the current environment.",

--- a/src/js/react_views/IntlHelperBarView.jsx
+++ b/src/js/react_views/IntlHelperBarView.jsx
@@ -175,6 +175,12 @@ class IntlHelperBarView extends React.Component{
         this.fireCommand('locale hu_HU; levels');
       }.bind(this)
     }, {
+      text: 'Azərbaycanca',
+      testID: 'azerbaijani',
+      onClick: function() {
+        this.fireCommand('locale az; levels');
+      }.bind(this)
+    }, {
       icon: 'fa-solid fa-right-from-bracket',
       onClick: function() {
         this.props.onExit();

--- a/src/js/stores/LocaleStore.js
+++ b/src/js/stores/LocaleStore.js
@@ -32,6 +32,7 @@ var langLocaleMap = {
   fa: 'fa',
   hu: 'hu_HU',
   ar: 'ar',
+  az: 'az',
 };
 
 var headerLocaleMap = {

--- a/src/levels/intro/branching.js
+++ b/src/levels/intro/branching.js
@@ -26,7 +26,8 @@ exports.level = {
     "it_IT": "Creare rami in Git",
     "ta_IN": "கிட் கிளை நிருவாகம்",
     "tr_TR": "Git'te Branch işlemleri",
-    "hu_HU": "Elágazás Gitben"
+    "hu_HU": "Elágazás Gitben",
+    "az": "Git-də Branch-lar"
   },
   "hint": {
     "en_US": "Make a new branch with \"git branch <branch-name>\" and check it out with \"git checkout <branch-name>\"",
@@ -53,7 +54,8 @@ exports.level = {
     "it_IT": "Crea un nuovo ramo con \"git branch <branch-name>\" e selezionalo con \"git checkout <branch-name>\"",
     "ta_IN": "இப்போது \"git branch <branch-name>\" கட்டளையை கொண்டு புதிய கிளை ஒன்றை உருவாக்குக பின் \"git checkout <branch-name>\" கொண்டு அந்த கிளைக்கு தாவுக",
     "tr_TR": "Yeni bir branch oluşturmak için \"git branch <branch-name>\" komutunu kullanın ve \"git checkout <branch-name>\" komutu ile bu branch'e geçin.",
-    "hu_HU": "Hozz létre egy új branchet \"git branch <branch-name>\" paranccsal, és válts rá \"git checkout <branch-name>\" paranccsal"
+    "hu_HU": "Hozz létre egy új branchet \"git branch <branch-name>\" paranccsal, és válts rá \"git checkout <branch-name>\" paranccsal",
+    "az": "\"git branch <branch-adı>\" ilə yeni branch yarat və \"git checkout <branch-adı>\" ilə ona keç"
   },
   "disabledMap": {
     "git revert": true
@@ -2213,6 +2215,100 @@ exports.level = {
               "Egyébként van egy gyorsbillentyű: ha egyszerre akarsz egy új ",
               "branchet létrehozni ÉS ráváltani, egyszerűen",
               "írd be: `git checkout -b [branchneved]`."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Branch-ları",
+              "",
+              "Git-də branch-lar da inanılmaz dərəcədə yüngüldür. Onlar sadəcə müəyyən bir commit-ə işarə edən göstəricilərdir — başqa heç nə. Məhz buna görə bir çox Git həvəskarı bu şüarı təkrarlayır:",
+              "",
+              "```",
+              "erkən branch yarat, tez-tez branch yarat",
+              "```",
+              "",
+              "Çoxlu branch yaratmağın yaddaş baxımından heç bir əlavə yükü olmadığı üçün, işini bir neçə nəhəng branch-da saxlamaqdansa məntiqi hissələrə bölmək daha asandır.",
+              "",
+              "Branch-ları və commit-ləri qarışdırmağa başlayanda bu iki xüsusiyyətin necə birləşdiyini görəcəyik. Hələlik isə sadəcə onu yadda saxla ki, branch mahiyyətcə \"bu commit-in və onun bütün valideyn commit-lərinin işini daxil etmək istəyirəm\" deməkdir."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl branch-ların praktikada necə göründüyünə baxaq.",
+              "",
+              "Burada `newImage` adlı yeni bir branch yaradacağıq."
+            ],
+            "afterMarkdowns": [
+              "Budur, branch yaratmaqda bütün məsələ bundan ibarətdir! `newImage` branch-ı indi `C1` commit-inə işarə edir."
+            ],
+            "command": "git branch newImage",
+            "beforeCommand": ""
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl bu yeni branch-da bir az iş görməyə çalışaq. Aşağıdakı düyməyə bas."
+            ],
+            "afterMarkdowns": [
+              "Vay! `main` branch-ı hərəkət etdi, amma `newImage` branch-ı yerində qaldı! Bunun səbəbi odur ki, biz yeni branch-ın \"üstündə\" deyildik — məhz buna görə ulduz (*) `main`-in yanında idi."
+            ],
+            "command": "git commit",
+            "beforeCommand": "git branch newImage"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl git-ə branch-a keçmək istədiyimizi deyək:",
+              "",
+              "```",
+              "git checkout <ad>",
+              "```",
+              "",
+              "Bu, dəyişikliklərimizi commit etməzdən əvvəl bizi yeni branch-ın üstünə keçirəcək."
+            ],
+            "afterMarkdowns": [
+              "Budur! Dəyişikliklərimiz yeni branch-da qeydə alındı."
+            ],
+            "command": "git checkout newImage; git commit",
+            "beforeCommand": "git branch newImage"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "*Qeyd: Git 2.23 versiyasında `git checkout`-u tədricən əvəz etmək üçün `git switch` adlı yeni bir əmr təqdim edildi; ",
+              "`checkout` bir qədər həddindən artıq yüklənmişdir (arqumentlərdən asılı olaraq bir sıra fərqli işlər görür). Buradakı dərslər hələ də ",
+              "`switch` əvəzinə `checkout` işlədəcək, çünki `switch` əmri hələ də təcrübi sayılır və sintaksisi gələcəkdə dəyişə bilər. ",
+              "Bununla belə, bu tətbiqdə yeni `switch` əmrini yoxlaya, həmçinin ",
+              "<a href=\"https://git-scm.com/docs/git-switch\" target=\"_blank\">buradan daha çox öyrənə</a> bilərsən.* "
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Hazırsan! Artıq branch yaratmağa tam hazırsan. Bu pəncərə bağlandıqdan sonra ",
+              "`bugFix` adlı yeni bir branch yarat və həmin branch-a keç.",
+              "",
+              "Yeri gəlmişkən, bir qısayol: eyni anda həm yeni branch ",
+              "yaradıb HƏM DƏ ona keçmək istəyirsənsə, sadəcə ",
+              "`git checkout -b [branch-adın]` yaza bilərsən."
             ]
           }
         }

--- a/src/levels/intro/commits.js
+++ b/src/levels/intro/commits.js
@@ -24,7 +24,8 @@ exports.level = {
     "it_IT": "Introduzione ai commit in Git",
     "ta_IN": "கிட் கமிட்கள் ஒரு அறிமுகம்",
     "tr_TR": "Git Commit'e Giriş",
-    "hu_HU": "Bevezetés a Git commitokba"
+    "hu_HU": "Bevezetés a Git commitokba",
+    "az": "Git Commit-lərinə giriş"
   },
   "goalTreeString": "{\"branches\":{\"main\":{\"target\":\"C3\",\"id\":\"main\"}},\"commits\":{\"C0\":{\"parents\":[],\"id\":\"C0\",\"rootCommit\":true},\"C1\":{\"parents\":[\"C0\"],\"id\":\"C1\"},\"C2\":{\"parents\":[\"C1\"],\"id\":\"C2\"},\"C3\":{\"parents\":[\"C2\"],\"id\":\"C3\"}},\"HEAD\":{\"target\":\"main\",\"id\":\"HEAD\"}}",
   "solutionCommand": "git commit;git commit",
@@ -54,7 +55,8 @@ exports.level = {
     "it_IT": "Digita 'git commit' due volte per finire!",
     "ta_IN": "இந்த நிலையை நிரைவு செய்ய 'git commit' என்று இரண்டு முறை தட்டச்சு செய்க!",
     "tr_TR": "Bölümü bitirmek için sadece iki kere 'git commit' yazmanız yeterlidir.",
-    "hu_HU": "Csak írj be kétszer 'git commit'-ot a befejezéshez!"
+    "hu_HU": "Csak írj be kétszer 'git commit'-ot a befejezéshez!",
+    "az": "Bölümü bitirmək üçün sadəcə iki dəfə 'git commit' yaz!"
   },
   "disabledMap": {
     "git revert": true
@@ -1116,6 +1118,48 @@ exports.level = {
           "options": {
             "markdowns": [
               "Próbáld ki magad! Miután ez az ablak bezárul, csinálj két commitot a szint teljesítéséhez."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Commit-ləri",
+              "Git repozitoriyasında commit sənin qovluğundakı bütün (izlənən) faylların anlıq görüntüsünü qeyd edir. Bu, nəhəng bir kopyala-yapışdır kimidir, amma daha da yaxşısı!",
+              "",
+              "Ancaq Git commit-ləri mümkün qədər yüngül saxlamaq istəyir, ona görə də hər commit etdikdə bütün qovluğu kor-koranə kopyalamır. Mümkün olduqda o, commit-i dəyişikliklər dəsti — yəni repozitoriyanın bir versiyasından digərinə keçən \"delta\" — kimi sıxa bilir.",
+              "",
+              "Git həmçinin hansı commit-lərin nə vaxt edildiyinin tarixçəsini saxlayır. Məhz buna görə əksər commit-lərin üstündə əcdad commit-lər olur — biz bunu vizuallaşdırmada oxlarla göstəririk. Tarixçəni saxlamaq layihə üzərində işləyən hər kəs üçün əladır!",
+              "",
+              "Mənimsəniləsi çox şey var, amma hələlik commit-ləri layihənin anlıq görüntüləri kimi düşünə bilərsən. Commit-lər çox yüngüldür və onlar arasında keçid inanılmaz sürətlidir!"
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl bunun praktikada necə göründüyünə baxaq. Sağ tərəfdə (kiçik) bir git repozitoriyasının vizuallaşdırması var. Hazırda iki commit var — ilk başlanğıc commit-i `C0` və ondan sonra gələn, bəlkə də bəzi mənalı dəyişikliklər daşıyan `C1` commit-i.",
+              "",
+              "Yeni commit yaratmaq üçün aşağıdakı düyməyə bas."
+            ],
+            "afterMarkdowns": [
+              "Budur! Əla. Biz indicə repozitoriyada dəyişikliklər etdik və onları commit kimi saxladıq. İndicə etdiyimiz commit-in `C1` adlı valideyni var — bu, həmin commit-in hansı commit əsasında qurulduğunu göstərir."
+            ],
+            "command": "git commit",
+            "beforeCommand": ""
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "İndi özün yoxla! Bu pəncərə bağlandıqdan sonra bölümü tamamlamaq üçün iki commit et."
             ]
           }
         }

--- a/src/levels/intro/merging.js
+++ b/src/levels/intro/merging.js
@@ -26,7 +26,8 @@ exports.level = {
     "it_IT": "Fusione in Git",
     "ta_IN": "கிட்டில் இணைத்தல்",
     "tr_TR": "Git'te Merge işlemleri",
-    "hu_HU": "Merge Gitben"
+    "hu_HU": "Merge Gitben",
+    "az": "Git-də Merge (birləşdirmə)"
   },
   "hint": {
     "en_US": "Remember to commit in the order specified (bugFix before main)",
@@ -53,7 +54,8 @@ exports.level = {
     "it_IT": "Ricorda di effettuare i commit nell'ordine specificato (bugFix prima di main)",
     "ta_IN": "bugFix முன் main என்ற கொடுக்கப்பட்ட வரிசையில் கட்டலை இடுவதை கருத்தில் கொள்க",
     "tr_TR": "Belirlenen sırada commit etmeyi unutmayın (main'den önce bugFix)",
-    "hu_HU": "Ne felejtsd el a megadott sorrendben commitolni (bugFix main előtt)"
+    "hu_HU": "Ne felejtsd el a megadott sorrendben commitolni (bugFix main előtt)",
+    "az": "Göstərilən ardıcıllıqla commit etməyi unutma (əvvəl bugFix, sonra main)"
   },
   "disabledMap": {
     "git revert": true
@@ -1779,6 +1781,75 @@ exports.level = {
               "* Mergeld a `bugFix` branchet a `main`-be a `git merge` paranccsal",
               "",
               "*Ne feledd, az \"objective\" paranccsal bármikor újra megjelenítheted ezt a párbeszédablakot!*"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Branch-lar və Merge",
+              "",
+              "Əla! İndi commit etməyi və branch yaratmağı bilirik. İndi isə iki fərqli branch-dakı işi bir yerə birləşdirməyin nə isə bir yolunu öyrənməliyik. Bu, bizə ayrılıb yeni bir funksiya hazırlamağa, sonra da onu geri birləşdirməyə imkan verəcək.",
+              "",
+              "İşi birləşdirmək üçün nəzərdən keçirəcəyimiz ilk üsul `git merge`-dir. Git-də merge iki fərqli valideyni olan xüsusi bir commit yaradır. İki valideynli commit mahiyyətcə \"bu tərəfdəki valideynin və o biri tərəfdəki valideynin bütün işini, *həmçinin* onların bütün valideynlərini daxil etmək istəyirəm\" deməkdir.",
+              "",
+              "Vizuallarla daha asandır, gəl növbəti səhifədə baxaq."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Burada iki branch-ımız var; hər birinin bir unikal commit-i var. Bu o deməkdir ki, heç bir branch repozitoriyada gördüyümüz \"işin\" hamısını əhatə etmir. Gəl bunu merge ilə düzəldək.",
+              "",
+              "`bugFix` branch-ını `main`-ə `merge` edəcəyik."
+            ],
+            "afterMarkdowns": [
+              "Vay! Bunu gördün? Hər şeydən əvvəl, `main` indi iki valideyni olan bir commit-ə işarə edir. `main`-dən commit ağacı boyunca oxları izləsən, kökə qədər yoldakı hər commit-ə çatarsan. Bu o deməkdir ki, `main` artıq repozitoriyadakı bütün işi ehtiva edir.",
+              "",
+              "Həmçinin, commit-lərin rənglərinin necə dəyişdiyini gördün? Öyrənməyə kömək üçün bir az rəng uyğunlaşdırması əlavə etmişəm. Hər branch-ın unikal rəngi var. Hər commit onu ehtiva edən bütün branch-ların qarışıq rənginə boyanır.",
+              "",
+              "Beləliklə, burada görürük ki, `main` branch-ının rəngi bütün commit-lərə qarışıb, amma `bugFix`-in rəngi qarışmayıb. Gəl bunu düzəldək..."
+            ],
+            "command": "git merge bugFix",
+            "beforeCommand": "git checkout -b bugFix; git commit; git checkout main; git commit"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl `main`-i `bugFix`-ə merge edək:"
+            ],
+            "afterMarkdowns": [
+              "`bugFix` `main`-in əcdadı olduğu üçün git-in heç bir iş görməsinə ehtiyac qalmadı; o, sadəcə `bugFix`-i `main`-in bağlı olduğu commit-ə köçürdü.",
+              "",
+              "İndi bütün commit-lər eyni rəngdədir, bu da o deməkdir ki, hər branch repozitoriyadakı bütün işi ehtiva edir! Yaşasın!"
+            ],
+            "command": "git checkout bugFix; git merge main",
+            "beforeCommand": "git checkout -b bugFix; git commit; git checkout main; git commit; git merge bugFix"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü tamamlamaq üçün aşağıdakı addımları yerinə yetir:",
+              "",
+              "* `bugFix` adlı yeni bir branch yarat",
+              "* `git checkout bugFix` ilə `bugFix` branch-ına keç",
+              "* Bir dəfə commit et",
+              "* `git checkout` ilə `main`-ə qayıt",
+              "* Bir dəfə də commit et",
+              "* `git merge` ilə `bugFix` branch-ını `main`-ə merge et",
+              "",
+              "*Unutma, bu dialoqu istənilən vaxt \"objective\" əmri ilə yenidən göstərə bilərsən!*"
             ]
           }
         }

--- a/src/levels/intro/rebasing.js
+++ b/src/levels/intro/rebasing.js
@@ -26,7 +26,8 @@ exports.level = {
     "pl": "Wprowadzenie do Rebase",
     "ta_IN": "Rebase அறிமுகம்",
     "tr_TR": "Rebase İşlemine Giriş",
-    "hu_HU": "Rebase bevezetés"
+    "hu_HU": "Rebase bevezetés",
+    "az": "Rebase-ə giriş"
   },
   "hint": {
     "en_US": "Make sure you commit from bugFix first",
@@ -53,7 +54,8 @@ exports.level = {
     "pl": "Upewnij się, że masz już commit z bugFix",
     "ta_IN": "முதலில் bugFix இல் இருந்து commit செய்ய நீங்கள் உறுதி செய்யவும்",
     "tr_TR": "Önce bugFix'ten commit attığınıza emin olun",
-    "hu_HU": "Győződj meg róla, hogy először a bugFix branchből commitolsz"
+    "hu_HU": "Győződj meg róla, hogy először a bugFix branchből commitolsz",
+    "az": "Əvvəlcə bugFix-dən commit etdiyinə əmin ol"
   },
   "disabledMap": {
     "git revert": true
@@ -1664,6 +1666,73 @@ exports.level = {
               "* Válts vissza a bugFix-re és rebaseld a mainre",
               "",
               "Sok szerencsét!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Rebase",
+              "",
+              "Branch-lar arasında işi birləşdirməyin ikinci yolu *rebase*-dir. Rebase mahiyyətcə bir sıra commit-i götürür, onları \"kopyalayır\" və başqa bir yerə qoyur.",
+              "",
+              "Bu çaşdırıcı səslənsə də, rebase-in üstünlüyü ondadır ki, onunla commit-lərin səliqəli, xətti bir ardıcıllığını qurmaq olar. Yalnız rebase-ə icazə verilsə, repozitoriyanın commit jurnalı / tarixçəsi xeyli təmiz olar.",
+              "",
+              "Gəl onu iş başında görək..."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Yenə iki branch-ımız var; diqqət et ki, hazırda bugFix branch-ı seçilib (ulduza fikir ver).",
+              "",
+              "Biz işimizi bugFix-dən birbaşa main-dəki işin üzərinə köçürmək istəyirik. Bu halda, əslində paralel hazırlansalar da, bu iki funksiya ardıcıl hazırlanmış kimi görünəcək.",
+              "",
+              "Gəl bunu `git rebase` əmri ilə edək."
+            ],
+            "afterMarkdowns": [
+              "Əla! İndi bugFix branch-ımızdakı iş \"main-in üstünə\" yığılıb, çünki o, main-ə işarə edir. Vizuallaşdırmamızda isə commit ağaclarımız aşağıya doğru axdığı üçün o, main-in altında göstərilir.",
+              "",
+              "Diqqət et ki, C3 commit-i hələ də harasa mövcuddur (ağacda solğun görünür), C3' isə bizim main-in üzərinə rebase etdiyimiz \"kopyadır\".",
+              "",
+              "Yeganə problem odur ki, main də yenilənməyib, gəl indi bunu edək..."
+            ],
+            "command": "git rebase main",
+            "beforeCommand": "git commit; git checkout -b bugFix C1; git commit"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "İndi `main` branch-ının üstündəyik. Gəl `bugFix`-in üzərinə rebase edək..."
+            ],
+            "afterMarkdowns": [
+              "Budur! `main` `bugFix`-in əcdadı olduğu üçün git sadəcə `main` branch istinadını tarixçədə irəli apardı."
+            ],
+            "command": "git rebase bugFix",
+            "beforeCommand": "git commit; git checkout -b bugFix C1; git commit; git rebase main; git checkout main"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü tamamlamaq üçün aşağıdakıları et:",
+              "",
+              "* `bugFix` adlı yeni bir branch-a keç",
+              "* Bir dəfə commit et",
+              "* main-ə qayıt və bir daha commit et",
+              "* Yenidən bugFix-ə keç və main-in üzərinə rebase et",
+              "",
+              "Uğurlar!"
             ]
           }
         }


### PR DESCRIPTION
This adds a new `az` (Azerbaijani) locale, starting with the **Introduction Sequence** (commits, branching, merging, rebasing) and the UI chrome around those levels.

Azerbaijani wasn't among the existing locales, though several neighbours are (`tr_TR`, `ru_RU`, `fa`, `ar`). This is a first pilot PR scoped to the intro sequence; if it's welcome, I'll follow up with the Remote levels and the rest.

## Changes
- Language picker: "Azərbaycanca" entry (`IntlHelperBarView.jsx`)
- `LocaleStore.js`: browser-lang `az` → `az` for auto-detect + hreflang
- `levels/intro/*`: `az` name/hint/startDialog for all four intro levels
- `intl/strings.js`: `az` for the strings surfaced during intro play; anything untranslated falls back to `en_US`

Git commands are left in English; git terms are inflected with Azerbaijani suffixes. Verified locally: `gulp fastBuild` + jshint clean, 313/313 specs pass, and the intro sequence renders end-to-end at `?locale=az`.
