### PR TITLE
Add Azerbaijani (az) locale — remote sequence

### DIFF
--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -399,7 +399,8 @@ exports.strings = {
     "it_IT": "E' gia la versione più recente!",
     "ta_IN": "ஏற்கனவே புதுப்பித்த நிலையில் உள்ளது!",
     "tr_TR": "Zaten güncel!",
-    "hu_HU": "Már naprakész!"
+    "hu_HU": "Már naprakész!",
+    "az": "Onsuz da ən son vəziyyətdədir!"
   },
   "git-error-origin-fetch-no-ff": {
     "__desc__": "One of the error messages for git",
@@ -425,7 +426,8 @@ exports.strings = {
     "it_IT": "Il tuo ramo origin non è sincronizzato con il ramo remoto, e fetch non può essere eseguito",
     "ta_IN": "உங்கள் மூலக் கிளை தொலைநிலைக் கிளையுடன் ஓருங்கினைக்கப்படவில்லை. `fetch` செய்ய முடியாது",
     "tr_TR": "Origin Branch'iniz, Remote branch ile uyumsuzdur ve `fetch` işlemi gerçekleştirilemez.",
-    "hu_HU": "Az origin ágad nincs szinkronban a távoli ággal, ezért a fetch nem hajtható végre"
+    "hu_HU": "Az origin ágad nincs szinkronban a távoli ággal, ezért a fetch nem hajtható végre",
+    "az": "origin branch-ın remote branch ilə sinxron deyil və fetch yerinə yetirilə bilmir"
   },
   "git-error-origin-push-no-ff": {
     "__desc__": "One of the error messages for git",
@@ -451,7 +453,8 @@ exports.strings = {
     "it_IT": "Il repository remoto è diverso dal tuo repository locale, quindi il caricamento non è un semplice fast forward (e per questo il tuo push è fallito). Per favore esegui pull per scaricare i nuovi cambiamenti dal repository remoto, incorporarli in questo ramo, e provare ancora. Puoi effettuarlo tramite i comandi git pull o git pull --rebase",
     "ta_IN": "தொலைநிலை களஞ்சியம் உங்கள் களஞ்சியத்திலிருந்து வேறுபட்டுள்ளது, எனவே உங்கள் மாற்றங்களை எளிமையான `fast forward` முறையில் பதிவேற்ற இயலாது (இதனால் உங்கள் `push` நிராகரிக்கப்பட்டது). தொலை களஞ்சியத்தில் புதிய மாற்றங்களை `pull` செய்து, அவற்றை இந்த கிளையில் இணைத்து, மீண்டும் முயற்சிக்கவும். நீங்கள் அவ்வாறு `git pull` அல்லது `git pull --rebase` கட்டளை கொண்டு செய்யலாம்",
     "tr_TR": "Uzak depo, yerel deponuzdan sapmış durumda, bu yüzden değişikliklerinizi basit bir fast forward ile yüklemek mümkün değil (bu nedenle push işleminiz reddedildi). Lütfen uzak depodaki yeni değişiklikleri çekin, bunları bu dalda birleştirin ve tekrar deneyin. Bunu git pull veya git pull --rebase komutlarıyla yapabilirsiniz.",
-    "hu_HU": "A távoli tárhely eltért a helyi tárhelytől, ezért a változtatások feltöltése nem egyszerű fast forward (és ezért a push-od vissza lett utasítva). Kérlek pull-old le az új változtatásokat a távoli tárhelyből, építsd be őket ebbe az ágba, és próbáld újra. Ezt megteheted a git pull vagy git pull --rebase paranccsal"
+    "hu_HU": "A távoli tárhely eltért a helyi tárhelytől, ezért a változtatások feltöltése nem egyszerű fast forward (és ezért a push-od vissza lett utasítva). Kérlek pull-old le az új változtatásokat a távoli tárhelyből, építsd be őket ebbe az ágba, és próbáld újra. Ezt megteheted a git pull vagy git pull --rebase paranccsal",
+    "az": "remote repozitoriya sənin lokal repozitoriyandan ayrılıb, ona görə də dəyişikliklərini yükləmək sadə sürətli irəliləmə (fast-forward) deyil (və beləliklə push-un rədd edildi). Zəhmət olmasa remote repozitoriyadakı yeni dəyişiklikləri çəkib endir, onları bu branch-a daxil et və yenidən cəhd et. Bunu git pull və ya git pull --rebase ilə edə bilərsən"
   },
   "git-error-remote-branch": {
     "__desc__": "One of the error messages for git",
@@ -477,7 +480,8 @@ exports.strings = {
     "it_IT": "Non puoi eseguire questo comando su un ramo remoto",
     "ta_IN": "அந்த கட்டளையை நீங்கள் தொலைநிலை கிளையில் இயக்க முடியாது",
     "tr_TR": "Bu komutu uzak bir dalda çalıştırmak mümkün değil",
-    "hu_HU": "Ezt a parancsot nem hajthatod végre egy távoli ágon"
+    "hu_HU": "Ezt a parancsot nem hajthatod végre egy távoli ágon",
+    "az": "Həmin əmri remote branch-da yerinə yetirə bilməzsən"
   },
   "git-error-origin-required": {
     "__desc__": "One of the error messages for git",
@@ -503,7 +507,8 @@ exports.strings = {
     "it_IT": "E' necessario definire origin per questo comando",
     "ta_IN": "அந்த கட்டளைக்கு ஒரு துவக்க மூலம் தேவை",
     "tr_TR": "Bu komut için bir origin gereklidir",
-    "hu_HU": "Ehhez a parancshoz szükséges egy origin"
+    "hu_HU": "Ehhez a parancshoz szükséges egy origin",
+    "az": "Həmin əmr üçün origin tələb olunur"
   },
   "git-error-origin-exists": {
     "__desc__": "One of the error messages for git",
@@ -529,7 +534,8 @@ exports.strings = {
     "it_IT": "Origin già esistente! Non puoi crearne uno nuovo",
     "ta_IN": "துவக்க மூலம் ஒன்று ஏற்கனவே உள்ளது! நீங்கள் மீன்டும் ஒன்றை உருவாக்க முடியாது",
     "tr_TR": "Bir origin zaten mevcut! Yeni bir tane oluşturamazsınız",
-    "hu_HU": "Már létezik egy origin! Nem hozhatsz létre újat"
+    "hu_HU": "Már létezik egy origin! Nem hozhatsz létre újat",
+    "az": "origin onsuz da mövcuddur! Yenisini yarada bilməzsən"
   },
   "git-error-branch": {
     "__desc__": "One of the error messages for git",
@@ -688,7 +694,7 @@ exports.strings = {
     "ta_IN": "இந்த கிளை ஏற்கனவே புதுப்பித்த நிலையில் உள்ளது...",
     "tr_TR": "Dal zaten güncel",
     "hu_HU": "Az ág már naprakész",
-    "az": "Branch onsuz da günceldir"
+    "az": "Branch onsuz da ən son vəziyyətdədir"
   },
   "git-error-exist": {
     "__desc__": "One of the error messages for git",

--- a/src/levels/remote/clone.js
+++ b/src/levels/remote/clone.js
@@ -24,7 +24,8 @@ exports.level = {
     "pl": "Wstęp do klonowania (clone)",
     "it_IT": "Introduzione al clone",
     "tr_TR": "Clone Tanıtımı",
-    "hu_HU": "Clone bevezetés"
+    "hu_HU": "Clone bevezetés",
+    "az": "Clone-a giriş"
   },
   "hint": {
     "en_US": "Just git clone!",
@@ -49,7 +50,8 @@ exports.level = {
     "pl": "Po prostu git clone!",
     "it_IT": "Semplicemente git clone!",
     "tr_TR": "Sadece git clone yapın!",
-    "hu_HU": "Csak git clone!"
+    "hu_HU": "Csak git clone!",
+    "az": "Sadəcə git clone et!"
   },
   "startDialog": {
     "en_US": {
@@ -1356,6 +1358,63 @@ exports.level = {
           "options": {
             "markdowns": [
               "A szint befejezéséhez egyszerűen clone-ozd a meglévő repódat a `git clone` paranccsal. A valódi tanulás a következő leckékben lesz."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Remote-ları",
+              "",
+              "Remote repozitoriyalar əslində o qədər də mürəkkəb deyil. Bulud hesablamalarının hökm sürdüyü bugünkü dünyada git remote-larının arxasında çoxlu sehr olduğunu düşünmək asandır, amma əslində onlar sadəcə repozitoriyanın başqa bir kompüterdəki nüsxələridir. Adətən bu kompüterlə İnternet vasitəsilə əlaqə saxlaya bilirsən ki, bu da commit-ləri qarşılıqlı şəkildə ötürməyə imkan verir.",
+              "",
+              "Bununla belə, remote repozitoriyaların bir sıra əla xüsusiyyəti var:",
+              "",
+              "- Hər şeydən əvvəl, remote-lar əla ehtiyat nüsxə rolunu oynayır! Lokal git repozitoriyaları faylları əvvəlki vəziyyətə qaytara bilir (bildiyin kimi), amma bütün bu məlumat lokal olaraq saxlanılır. Git repozitoriyanın nüsxələrini başqa kompüterlərdə saxlamaqla, bütün lokal məlumatlarını itirsən belə, qaldığın yerdən davam edə bilərsən.",
+              "",
+              "- Daha da vacibi, remote-lar kod yazmağı sosial edir! İndi ki layihənin bir nüsxəsi başqa yerdə saxlanılır, dostların layihənə çox rahat töhfə verə (və ya sənin son dəyişikliklərini çəkə) bilər.",
+              "",
+              "Remote repozitoriyalar ətrafındakı fəaliyyəti vizuallaşdıran veb saytlardan (məsələn, [GitHub](https://github.com/)) istifadə etmək çox populyarlaşıb, amma remote repozitoriyalar _həmişə_ bu alətlərin təməl dayağı olaraq qalır. Ona görə də onları anlamaq vacibdir!"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Remote yaratmaq üçün əmrimiz",
+              "",
+              "İndiyə qədər Learn Git Branching əsasən _lokal_ repozitoriya işinin əsaslarını (branch yaratmaq, merge, rebase və s.) öyrətməyə yönəlmişdi. Ancaq indi remote repozitoriya işini öyrənmək istədiyimiz üçün, həmin dərslər üçün mühiti quracaq bir əmrə ehtiyacımız var. Həmin əmr `git clone` olacaq.",
+              "",
+              "Texniki olaraq, real dünyada `git clone` remote repozitoriyaların (məsələn, github-dan) _lokal_ nüsxələrini yaratmaq üçün işlədəcəyin əmrdir. Ancaq biz Learn Git Branching-də bu əmri bir az fərqli işlədirik -- `git clone` əslində sənin lokal repozitoriyandan bir remote repozitoriya düzəldir. Düzdür, bu, texniki olaraq real əmrin əks mənasını daşıyır, amma clone etmək ilə remote repozitoriya işi arasında əlaqə qurmağa kömək edir, ona görə də hələlik belə davam edək.",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl yavaş başlayaq və sadəcə bir remote repozitoriyanın necə göründüyünə baxaq (bizim vizuallaşdırmada).",
+              ""
+            ],
+            "afterMarkdowns": [
+              "Budur! İndi layihəmizin bir remote repozitoriyası var. Görünüşü olduqca oxşardır, sadəcə fərqi aydın göstərmək üçün bəzi vizual dəyişikliklər var -- sonrakı bölümlərdə bu repozitoriyalar arasında işi necə paylaşdığımızı görəcəksən."
+            ],
+            "command": "git clone",
+            "beforeCommand": ""
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü bitirmək üçün sadəcə mövcud repozitoriyanı `git clone` et. Əsl öyrənmə növbəti dərslərdə olacaq."
             ]
           }
         }

--- a/src/levels/remote/fakeTeamwork.js
+++ b/src/levels/remote/fakeTeamwork.js
@@ -25,7 +25,8 @@ exports.level = {
     "pl": "Symulacja pracy zespołowej",
     "it_IT": "Simulare il lavoro di squadra",
     "tr_TR": "Takım Çalışması Simülasyonu",
-    "hu_HU": "Csapatmunka szimulálása"
+    "hu_HU": "Csapatmunka szimulálása",
+    "az": "Komanda İşini Təqlid Etmək"
   },
   "hint": {
     "en_US": "Remember you can specify the number of commits to fake",
@@ -50,7 +51,8 @@ exports.level = {
     "pl": "Pamiętaj, że możesz określić liczbę symulowanych commitów",
     "it_IT": "Tieni a mente che puoi specificare il numero di commit da simulare",
     "tr_TR": "Kaç commit oluşturulacağını belirtebileceğinizi unutmayın",
-    "hu_HU": "Emlékezz, megadhatod a szimulált commitok számát"
+    "hu_HU": "Emlékezz, megadhatod a szimulált commitok számát",
+    "az": "Unutma, təqlid ediləcək commit-lərin sayını göstərə bilərsən"
   },
   "startDialog": {
     "en_US": {
@@ -1292,6 +1294,60 @@ exports.level = {
               "A közelgő szintek elég nehezek lesznek, szóval többet kérünk tőled ennél a szintnél.",
               "",
               "Hozz létre egy remote-ot (`git clone`-nal), szimulálj néhány változtatást azon a remote-on, adj hozzá egy helyi commitot, majd töltsd le a remote változtatásait és merge-eld azokat. Ez olyan, mint néhány lecke egyben!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Əməkdaşlığı simulyasiya etmək",
+              "",
+              "Məsələ burasındadır ki -- qarşıdakı bəzi dərslər üçün remote-da edilən dəyişiklikləri necə çəkib endirməyi sənə öyrətməliyik.",
+              "",
+              "Bu o deməkdir ki, biz mahiyyətcə remote-un sənin iş yoldaşlarından / dostlarından / əməkdaşlarından biri tərəfindən — bəzən müəyyən bir branch-da və ya müəyyən sayda commit-lə — yeniləndiyini \"uydurmalıyıq\".",
+              "",
+              "Bunun üçün adına tam uyğun gələn `git fakeTeamwork` əmrini təqdim etdik! O, adından da göründüyü kimi olduqca aydındır, gəl bir nümayişə baxaq..."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "`fakeTeamwork`-in standart davranışı sadəcə main-də bir commit yerləşdirməkdir."
+            ],
+            "afterMarkdowns": [
+              "Budur -- remote yeni bir commit-lə yeniləndi, biz isə hələ `git fetch` işlətmədiyimiz üçün həmin commit-i endirməmişik."
+            ],
+            "command": "git fakeTeamwork",
+            "beforeCommand": "git clone"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Əmrin sonuna əlavə edərək commit-lərin sayını və ya branch-ı da göstərə bilərsən."
+            ],
+            "afterMarkdowns": [
+              "Bir əmrlə komanda yoldaşının remote-umuzdakı `foo` branch-ına üç commit push etməsini simulyasiya etdik."
+            ],
+            "command": "git fakeTeamwork foo 3",
+            "beforeCommand": "git clone"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Qarşıdakı bölümlər kifayət qədər çətin olacaq, ona görə də bu bölümdə səndən daha çox şey istəyirik.",
+              "",
+              "Davam et: bir remote yarat (`git clone` ilə), həmin remote-da bəzi dəyişiklikləri təqlid et, bir lokal commit əlavə et, sonra remote dəyişikliklərini çəkib endir və onları merge et. Bu, bir neçə dərs bir arada kimidir!"
             ]
           }
         }

--- a/src/levels/remote/fetch.js
+++ b/src/levels/remote/fetch.js
@@ -26,7 +26,8 @@ exports.level = {
     "it_IT": "Git Fetch",
     "tr_TR": "Git Fetch",
     "ta_IN": "Git Fetch",
-    "hu_HU": "Git fetch"
+    "hu_HU": "Git fetch",
+    "az": "Git Fetch"
   },
   "hint": {
     "en_US": "just run git fetch!",
@@ -52,7 +53,8 @@ exports.level = {
     "it_IT": "Semplicemente git fetch!",
     "tr_TR": "Sadece git fetch komutunu çalıştırın!",
     "ta_IN": "பொதுவாக git fetch நடத்துங்கள்!",
-    "hu_HU": "Csak futtasd a git fetch-et!"
+    "hu_HU": "Csak futtasd a git fetch-et!",
+    "az": "Sadəcə git fetch et!"
   },
   "startDialog": {
     "en_US": {
@@ -1799,6 +1801,79 @@ exports.level = {
           "options": {
             "markdowns": [
               "A szint befejezéséhez egyszerűen futtasd a `git fetch` parancsot, és töltsd le az összes commitot!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Fetch",
+              "",
+              "Git remote-ları ilə işləmək əslində sadəcə məlumatları digər repozitoriyalara _ötürmək_ və _onlardan almaq_ deməkdir. Commit-ləri qarşılıqlı göndərə bildiyimiz müddətcə, git-in izlədiyi istənilən növ yeniləməni paylaşa bilərik (deməli, işi, yeni faylları, yeni ideyaları, sevgi məktublarını və s. də paylaşa bilərik).",
+              "",
+              "Bu dərsdə remote repozitoriyadan məlumatı necə fetch etməyi öyrənəcəyik -- bu iş üçün əmr də elə münasib şəkildə `git fetch` adlanır.",
+              "",
+              "Görəcəksən ki, remote repozitoriyanın təsvirini yenilədikcə, bizim _remote_ branch-larımız da həmin yeni təsviri əks etdirmək üçün yenilənir. Bu, remote branch-lar haqqındakı əvvəlki dərslə bağlıdır."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "`git fetch`-in təfərrüatlarına keçməzdən əvvəl, gəl onu iş başında görək! Burada lokal repozitoriyamızda olmayan iki commit saxlayan bir remote repozitoriya var."
+            ],
+            "afterMarkdowns": [
+              "Budur! `C2` və `C3` commit-ləri lokal repozitoriyamıza endirildi və remote branch-ımız `o/main` buna uyğun yeniləndi."
+            ],
+            "command": "git fetch",
+            "beforeCommand": "git clone; git fakeTeamwork 2"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### fetch nə edir",
+              "",
+              "`git fetch` iki əsas addım, yalnız iki əsas addım yerinə yetirir. O:",
+              "",
+              "* remote-da olan, amma lokal repozitoriyamızda olmayan commit-ləri endirir və...",
+              "* remote branch-larımızın hara işarə etdiyini yeniləyir (məsələn, `o/main`)",
+              "",
+              "`git fetch` mahiyyətcə remote repozitoriyanın _lokal_ təsvirini _əsl_ remote repozitoriyanın (hazırkı) görünüşü ilə sinxronlaşdırır.",
+              "",
+              "Əvvəlki dərsdən yadına gəlirsə, demişdik ki, remote branch-lar həmin remote-larla sonuncu dəfə danışdığın _vaxtdan bəri_ remote repozitoriyaların vəziyyətini əks etdirir. `git fetch` məhz bu remote-larla danışmaq üsuludur! Ümid edirəm, remote branch-larla `git fetch` arasındakı əlaqə indi aydındır.",
+              "",
+              "`git fetch` adətən remote repozitoriya ilə İnternet vasitəsilə danışır (`http://` və ya `git://` kimi bir protokol üzərindən).",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### fetch nə etmir",
+              "",
+              "Ancaq `git fetch` sənin lokal vəziyyətində heç nəyi dəyişmir. O, `main` branch-ını yeniləmir və fayl sisteminin hazırkı görünüşündə heç nə dəyişmir.",
+              "",
+              "Bunu anlamaq vacibdir, çünki bir çox proqramçı düşünür ki, `git fetch` işlətmək onların lokal işini remote-un vəziyyətinə uyğunlaşdıracaq. O, bunu etmək üçün lazım olan bütün məlumatı endirə bilər, amma əslində sənin lokal fayllarının heç birini dəyişmir. Sonrakı dərslərdə məhz bunu edən əmrləri öyrənəcəyik :D",
+              "",
+              "Beləliklə, son nəticədə `git fetch` işlətməyi bir endirmə addımı kimi düşünə bilərsən."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bölümü bitirmək üçün sadəcə `git fetch` et və bütün commit-ləri endir!"
             ]
           }
         }

--- a/src/levels/remote/fetchArgs.js
+++ b/src/levels/remote/fetchArgs.js
@@ -25,7 +25,8 @@ exports.level = {
     "pl": "Argumenty fetch",
     "it_IT": "Parametri di git fetch",
     "tr_TR": "Fetch argümanları",
-    "hu_HU": "Fetch argumentumok"
+    "hu_HU": "Fetch argumentumok",
+    "az": "Fetch arqumentləri"
   },
   "hint": {
     "en_US": "Pay attention how the commit ids may have swapped! You can read slides again with \"help level\"",
@@ -50,7 +51,8 @@ exports.level = {
     "pl": "Zauważ, że identyfikatory commitów mogły zostać zamienione! Slajdy możesz przeczytać jeszcze raz po wpisaniu: \"help level\"",
     "it_IT": "Fai attenzione, alcuni ID dei commit potrebbero essere invertiti! Puoi leggere nuovamente le slide con \"help level\"",
     "tr_TR": "Commit ID'lerinin nasıl değiştiğine dikkat edin! \"help level\" komutunu kullanarak slaytları tekrar okuyabilirsiniz.",
-    "hu_HU": "Figyelj, hogyan cserélhetek helyet a commit azonosítók! A diákat újra elolvashatod a \"help level\" paranccsal"
+    "hu_HU": "Figyelj, hogyan cserélhetek helyet a commit azonosítók! A diákat újra elolvashatod a \"help level\" paranccsal",
+    "az": "Commit id-lərinin yerlərini necə dəyişə biləcəyinə diqqət et! Slaydları \\\"help level\\\" ilə yenidən oxuya bilərsən"
   },
   "startDialog": {
     "en_US": {
@@ -2890,6 +2892,128 @@ exports.level = {
               "Rendben, elég volt a beszédből! Ennek a szintnek a befejezéséhez csak a célvizualizációban meghatározott commitokat fetcheld le. Légy kreatív azokkal a parancsokkal!",
               "",
               "Mindkét fetch parancshoz meg kell adnod a forrást és a célt. Figyelj a célvizualizációra, mert az azonosítók fel lehetnek cserélve!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git fetch arqumentləri",
+              "",
+              "Deməli, indicə git push arqumentləri, bu gözəl `<yer>` parametri və hətta iki nöqtəli refspec-lər (`<mənbə>:<təyinat>`) haqqında hər şeyi öyrəndik. Bütün bu bilikləri `git fetch` üçün də işlədə bilərikmi?",
+              "",
+              "Əlbəttə! `git fetch`-in arqumentləri əslində `git push`-unkilərə *çox, çox* oxşardır. Eyni növ anlayışlardır, sadəcə əks istiqamətdə tətbiq olunur (çünki indi commit-ləri yükləmək əvəzinə endirirsən).",
+              "",
+              "Gəl anlayışları bir-bir nəzərdən keçirək..."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### `<yer>` parametri",
+              "",
+              "git fetch ilə aşağıdakı əmrdəki kimi bir yer göstərsən:",
+              "",
+              "`git fetch origin foo`",
+              "",
+              "Git remote-dakı `foo` branch-ına gedəcək, lokal olaraq mövcud olmayan bütün commit-ləri götürəcək və sonra onları lokal `o/foo` branch-ına yerləşdirəcək.",
+              "",
+              "Gəl bunu iş başında görək (sadəcə təkrar olaraq)."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Bir yer göstərməklə..."
+            ],
+            "afterMarkdowns": [
+              "Yalnız `foo`-dan commit-ləri endirir və onları `o/foo`-ya yerləşdiririk."
+            ],
+            "command": "git fetch origin foo",
+            "beforeCommand": "git clone; git fakeTeamwork foo 2"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Düşünə bilərsən -- git niyə həmin commit-ləri sadəcə mənim lokal `foo` branch-ıma yox, `o/foo` remote branch-ına yerləşdirdi? Mən elə bilirdim ki, `<yer>` parametri həm lokal, həm də remote-da mövcud olan bir yerdir?",
+              "",
+              "Bax, git bu halda xüsusi bir istisna edir, çünki `foo` branch-ında korlamaq istəmədiyin iş ola bilər!! Bu, `git fetch` haqqındakı əvvəlki dərslə bağlıdır -- o, sənin lokal remote-olmayan branch-larını yeniləmir, yalnız commit-ləri endirir (ki sonra onları nəzərdən keçirə / merge edə biləsən)."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "\"Yaxşı, onda `<mənbə>:<təyinat>` ilə həm mənbəni, həm də təyinatı açıq şəkildə təyin etsəm nə baş verir?\"",
+              "",
+              "Commit-ləri *birbaşa* lokal branch-a fetch etmək üçün kifayət qədər həvəslisənsə, bəli, bunu iki nöqtəli refspec ilə göstərə bilərsən. Checkout edilmiş branch-a commit fetch edə bilməzsən, amma başqa hallarda git buna icazə verəcək.",
+              "",
+              "Amma diqqət etməli olduğun yeganə məqam budur -- `<mənbə>` indi *remote*-dakı bir yerdir, `<təyinat>` isə həmin commit-ləri qoymaq üçün *lokal* bir yerdir. Bu, git push-un tam əksidir və bu məntiqlidir, çünki məlumatı əks istiqamətdə ötürürük!",
+              "",
+              "Bununla belə, proqramçılar praktikada bunu nadir hallarda edir. Mən bunu əsasən `fetch` ilə `push`-un nə qədər oxşar, sadəcə əks istiqamətdə olduğunu göstərmək üçün təqdim edirəm."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl bu dəliliyi iş başında görək:"
+            ],
+            "afterMarkdowns": [
+              "Vay! Bax, git `C2`-ni origin-dəki bir yer kimi müəyyən etdi və sonra həmin commit-ləri `bar`-a (ki bu, lokal branch idi) endirdi."
+            ],
+            "command": "git fetch origin C2:bar",
+            "beforeCommand": "git clone; git fakeTeamwork; git branch bar"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Bəs əmri işlətməzdən əvvəl təyinat mövcud deyilsə? Gəl son slayda baxaq, amma `bar` əvvəlcədən mövcud olmadan."
+            ],
+            "afterMarkdowns": [
+              "Bax, bu, TAM git push kimidir. Git fetch etməzdən əvvəl təyinatı lokal olaraq yaratdı, necə ki git push etməzdən əvvəl təyinatı remote-da yaradır (əgər mövcud deyilsə)."
+            ],
+            "command": "git fetch origin C2:bar",
+            "beforeCommand": "git clone; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Arqument yoxdur?",
+              "",
+              "`git fetch` heç bir arqument almasa, sadəcə remote-dan bütün commit-ləri bütün remote branch-larına endirir..."
+            ],
+            "afterMarkdowns": [
+              "Kifayət qədər sadədir, amma bir dəfə nəzərdən keçirməyə dəyər."
+            ],
+            "command": "git fetch",
+            "beforeCommand": "git clone; git fakeTeamwork foo 2; git fakeTeamwork main 2"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Yaxşı, danışıq bəsdir! Bu bölümü bitirmək üçün hədəf vizuallaşdırmasında göstərilən commit-ləri fetch et. Həmin əmrlərlə bir az ustalıq göstər!",
+              "",
+              "Hər iki fetch əmri üçün mənbə və təyinatı göstərməli olacaqsan. Hədəf vizuallaşdırmasına diqqət et, çünki ID-lər yerlərini dəyişə bilər!"
             ]
           }
         }

--- a/src/levels/remote/fetchRebase.js
+++ b/src/levels/remote/fetchRebase.js
@@ -24,7 +24,8 @@ exports.level = {
     "pl": "Rozbieżna  historia",
     "it_IT": "Storico divergente",
     "tr_TR": "Sapmış Tarihçe",
-    "hu_HU": "Szétágazó előzmények"
+    "hu_HU": "Szétágazó előzmények",
+    "az": "Ayrılmış Tarixçə"
   },
   "hint": {
     "en_US": "Check out the ordering from the goal visualization",
@@ -49,7 +50,8 @@ exports.level = {
     "pl": "Przyjrzyj się kolejności na wizualizacji celu",
     "it_IT": "Controlla l'ordinamento dalla schermata dell'obiettivo",
     "tr_TR": "Hedef görselleştirmesindeki sıralamaya dikkat edin",
-    "hu_HU": "Nézd meg a sorrendet a cél vizualizációban"
+    "hu_HU": "Nézd meg a sorrendet a cél vizualizációban",
+    "az": "Hədəf vizuallaşdırmasındakı ardıcıllığa bax"
   },
   "startDialog": {
     "en_US": {
@@ -3342,6 +3344,148 @@ exports.level = {
               "* Szimulálj csapatmunkát (1 commit)",
               "* Commitolj valami saját munkát (1 commit)",
               "* Tedd közzé a munkádat *rebase*-sel"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Ayrılmış İş",
+              "",
+              "İndiyə qədər başqalarından commit-ləri necə `pull` edib endirməyi və öz dəyişikliklərimizi necə `push` edib yükləməyi gördük. Kifayət qədər sadə görünür, bəs insanlar necə bu qədər çaşa bilər?",
+              "",
+              "Çətinlik repozitoriyanın tarixçəsi *ayrılanda* yaranır. Bunun təfərrüatlarını müzakirə etməzdən əvvəl, gəl bir nümunəyə baxaq..."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Təsəvvür et ki, bazar ertəsi bir repozitoriyanı clone edirsən və yan bir funksiya üzərində əl-qol açmağa başlayırsan. Cümə gününə qədər funksiyanı dərc etməyə hazırsan -- amma vay! İş yoldaşların həftə ərzində bir topa kod yazıb ki, bu da sənin funksiyanı köhnəlmiş (və yararsız) edib. Onlar həm də bu commit-ləri paylaşılan remote repozitoriyaya dərc ediblər, ona görə də indi *sənin* işin layihənin artıq aktual olmayan *köhnə* versiyasına əsaslanır.",
+              "",
+              "Bu halda `git push` əmri qeyri-müəyyəndir. `git push` işlətsən, git remote repozitoriyanı bazar ertəsi olduğu vəziyyətə geri qaytarmalıdır? Yeni kodu silmədən sənin kodunu əlavə etməyə çalışmalıdır? Yoxsa sənin dəyişikliklərini tamamilə köhnəldiyi üçün büsbütün nəzərə almamalıdır?",
+              "",
+              "Bu vəziyyətdə (tarixçənin ayrıldığı yerdə) çoxlu qeyri-müəyyənlik olduğu üçün, git sənə dəyişikliklərini `push` etməyə icazə vermir. O, əslində işini paylaşa bilməzdən əvvəl səni remote-un ən son vəziyyətini daxil etməyə məcbur edir."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Nə qədər danışıq! Gəl bu vəziyyəti iş başında görək."
+            ],
+            "afterMarkdowns": [
+              "Gördün? Heç nə baş vermədi, çünki əmr uğursuz olur. `git push` uğursuz olur, çünki sənin ən son commit-in `C3` remote-un `C1`-dəki vəziyyətinə əsaslanır. Amma remote o vaxtdan `C2`-yə yenilənib, ona görə də git sənin push-unu rədd edir."
+            ],
+            "command": "git push",
+            "beforeCommand": "git clone; git commit; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu vəziyyəti necə həll edirsən? Asandır, etməli olduğun tək şey işini remote branch-ının ən son versiyasına əsaslandırmaqdır.",
+              "",
+              "Bunun bir neçə yolu var, amma ən sadəsi işini rebase vasitəsilə köçürməkdir. Gəl davam edək və bunun necə göründüyünə baxaq."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Bu dəfə push etməzdən əvvəl rebase etsək..."
+            ],
+            "afterMarkdowns": [
+              "Bum! Remote-un lokal təsvirini `git fetch` ilə yenilədik, remote-dakı yeni dəyişiklikləri əks etdirmək üçün işimizi rebase etdik və sonra onları `git push` ilə push etdik."
+            ],
+            "command": "git fetch; git rebase o/main; git push",
+            "beforeCommand": "git clone; git commit; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Remote repozitoriya yeniləndikdə işimi yeniləməyin başqa yolları var? Əlbəttə! Gəl eyni şeyə, ancaq bunun əvəzinə `merge` ilə baxaq.",
+              "",
+              "`git merge` işini köçürməsə də (bunun əvəzinə sadəcə bir merge commit-i yaradır), o, git-ə remote-dan bütün dəyişiklikləri daxil etdiyini bildirməyin bir yoludur. Bunun səbəbi odur ki, remote branch indi sənin öz branch-ının *əcdadı*dır, yəni sənin commit-in remote branch-ındakı bütün commit-ləri əks etdirir.",
+              "",
+              "Gəl bunun nümayişinə baxaq..."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "İndi rebase etmək əvəzinə merge etsək..."
+            ],
+            "afterMarkdowns": [
+              "Bum! Remote-un lokal təsvirini `git fetch` ilə yenilədik, yeni işi öz işimizə *merge etdik* (remote-dakı yeni dəyişiklikləri əks etdirmək üçün) və sonra onları `git push` ilə push etdik."
+            ],
+            "command": "git fetch; git merge o/main; git push",
+            "beforeCommand": "git clone; git commit; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Möhtəşəm! Bunu bu qədər çox əmr yazmadan edə biləcəyim hər hansı yol var?",
+              "",
+              "Əlbəttə -- artıq bilirsən ki, `git pull` sadəcə fetch və merge üçün qısa yoldur. Yaxşı xəbər budur ki, `git pull --rebase` isə fetch və rebase üçün qısa yoldur!",
+              "",
+              "Gəl bu qısa yol əmrlərini iş başında görək."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Əvvəlcə `--rebase` ilə..."
+            ],
+            "afterMarkdowns": [
+              "Əvvəlki ilə eyni! Sadəcə xeyli qısa."
+            ],
+            "command": "git pull --rebase; git push",
+            "beforeCommand": "git clone; git commit; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "İndi isə adi `pull` ilə."
+            ],
+            "afterMarkdowns": [
+              "Yenə də, əvvəlki ilə tam eyni!"
+            ],
+            "command": "git pull; git push",
+            "beforeCommand": "git clone; git commit; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "fetch, rebase/merge və push etmə iş axını olduqca geniş yayılıb. Gələcək dərslərdə bu iş axınlarının daha mürəkkəb versiyalarını araşdıracağıq, amma hələlik gəl bunu sınayaq.",
+              "",
+              "Bu bölümü həll etmək üçün aşağıdakı addımları at:",
+              "",
+              "* Repozitoriyanı clone et",
+              "* Bir az komanda işini təqlid et (1 commit)",
+              "* Özün bir az iş commit et (1 commit)",
+              "* İşini *rebase* vasitəsilə dərc et"
             ]
           }
         }

--- a/src/levels/remote/lockedMain.js
+++ b/src/levels/remote/lockedMain.js
@@ -24,7 +24,8 @@ exports.level = {
     "vi": "Tạo những nhánh tính năng từ nhánh cục bộ trước khi trả chúng về lại giống như o/main",
     "it_IT": "Crea il ramo per la feature a partire dal main locale prima di resettarlo al pari del main remoto",
     "tr_TR": "Özellik dalını, origin/main ile aynı olacak şekilde sıfırlamadan önce yerel main'den oluşturun.",
-    "hu_HU": "Hozd létre a feature ágat a helyi main-ből, mielőtt visszaállítod azt az origin/main-nel azonos állapotba"
+    "hu_HU": "Hozd létre a feature ágat a helyi main-ből, mielőtt visszaállítod azt az origin/main-nel azonos állapotba",
+    "az": "Kilidli Main"
   },
   "name": {
     "en_US": "Locked Main",
@@ -48,7 +49,8 @@ exports.level = {
     "vi": "Nhánh chính bị khóa (Locked Main)",
     "it_IT": "Main bloccato",
     "tr_TR": "Kilitli Main",
-    "hu_HU": "Zárolt main"
+    "hu_HU": "Zárolt main",
+    "az": "Lokal main-i origin-in main-i ilə eyni olması üçün geri sıfırlamazdan əvvəl feature branch-ını ondan yarat"
   },
   "startDialog": {
     "en_US": {
@@ -937,6 +939,42 @@ exports.level = {
               "## A megoldás",
               "",
               "Hozz létre egy másik feature nevű ágat, és pushold azt a távoliba. Állítsd vissza a main-edet is, hogy szinkronban legyen a távolival, különben problémák adódhatnak a következő pull alkalmával, ha valaki más commitja ütközik a tiéddel."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Remote Rədd Etdi!",
+              "",
+              "Böyük bir komandada işləyirsənsə, çox güman ki main kilidlidir və dəyişiklikləri merge etmək üçün hansısa Pull Request prosesini tələb edir. Lokal olaraq birbaşa main-ə commit edib push etməyə çalışsan, buna bənzər bir mesajla qarşılaşacaqsan:"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Niyə rədd edildi?",
+              "",
+              "Remote birbaşa main-ə commit-lərin push edilməsini rədd etdi, çünki main-dəki siyasət bunun əvəzinə pull request-lərin işlədilməsini tələb edir.",
+              "",
+              "Sən branch yaradıb həmin branch-ı push edərək pull request açmaqla prosesə əməl etmək istəyirdin, amma unutdun və birbaşa main-ə commit etdin. İndi çıxılmaz vəziyyətdəsən və dəyişikliklərini push edə bilmirsən."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Həll",
+              "",
+              "feature adlı başqa bir branch yarat və onu remote-a push et. Həmçinin main-ini remote ilə sinxron olması üçün geri sıfırla, əks halda növbəti dəfə pull etdikdə başqasının commit-i səninkiylə konflikt yarada bilər."
             ]
           }
         }

--- a/src/levels/remote/mergeManyFeatures.js
+++ b/src/levels/remote/mergeManyFeatures.js
@@ -24,7 +24,8 @@ exports.level = {
     "pl": "Scalanie z remote",
     "it_IT": "Fondere in remoto",
     "tr_TR": "Uzak Sunucularla Birleştirme",
-    "hu_HU": "Merge a távolival"
+    "hu_HU": "Merge a távolival",
+    "az": "Remote-larla merge etmək"
   },
   "hint": {
     "en_US": "Pay attention to the goal tree!",
@@ -49,7 +50,8 @@ exports.level = {
     "pl": "Zwróć uwagę, jak wygląda docelowe drzewo!",
     "it_IT": "Fai attenzione all'albero nell'obiettivo",
     "tr_TR": "Hedef ağacına dikkat et!",
-    "hu_HU": "Figyelj a célgráfra!"
+    "hu_HU": "Figyelj a célgráfra!",
+    "az": "Hədəf ağacına diqqət et!"
   },
   "compareOnlyMain": true,
   "startDialog": {
@@ -1082,6 +1084,50 @@ exports.level = {
           "options": {
             "markdowns": [
               "Ehhez a szinthez próbáljuk meg megoldani az előző szintet, de *merge*-dzsel. Kicsit bonyolult lehet, de jól szemlélteti a lényeget."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Niyə merge yox?",
+              "",
+              "Remote-a yeni yeniləmələri push etmək üçün etməli olduğun tək şey remote-dan ən son dəyişiklikləri *daxil etmək*dir. Bu o deməkdir ki, remote branch-ı (məsələn, `o/main`) ya rebase, ya da merge edə bilərsən.",
+              "",
+              "Bəs hər iki üsulu edə bilirsənsə, dərslər indiyə qədər niyə əsasən rebase-ə yönəlib? Remote-larla işləyəndə `merge` niyə sevilmir?"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Proqramçı icmasında merge ilə rebase arasındakı güzəştlər barədə çoxlu mübahisə var. Rebase-in ümumi üstünlükləri / çatışmazlıqları budur:",
+              "",
+              "Üstünlüklər:",
+              "",
+              "* Rebase commit ağacını çox təmiz göstərir, çünki hər şey düz bir xətdə olur",
+              "",
+              "Çatışmazlıqlar:",
+              "",
+              "* Rebase commit ağacının (görünən) tarixçəsini dəyişir.",
+              "",
+              "Məsələn, `C1` commit-i `C3`-ün *o tərəfinə* rebase edilə bilər. Onda elə görünür ki, `C1'` üçün iş `C3`-dən sonra gəlib, halbuki əslində ondan əvvəl tamamlanıb.",
+              "",
+              "Bəzi proqramçılar tarixçəni qorumağı sevir və buna görə də merge-ə üstünlük verir. Digərləri (mənim kimi) təmiz commit ağacına sahib olmağı sevir və rebase-ə üstünlük verir. Hər şey zövqdən asılıdır :D"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Gəl əvvəlki bölümü bu dəfə *merge* ilə həll etməyə çalışaq. Bir az qarışıq ola bilər, amma məsələni yaxşı əyani göstərir."
             ]
           }
         }

--- a/src/levels/remote/pull.js
+++ b/src/levels/remote/pull.js
@@ -24,7 +24,8 @@ exports.level = {
     "pl": "Git pull",
     "it_IT": "Git Pull",
     "tr_TR": "Git Pull",
-    "hu_HU": "Git pull"
+    "hu_HU": "Git pull",
+    "az": "Git Pull"
   },
   "hint": {
     "en_US": "Just run git pull!",
@@ -49,7 +50,8 @@ exports.level = {
     "pl": "Po prostu uruchom git pull!",
     "it_IT": "Semplicemente git pull!",
     "tr_TR": "Sadece git pull komutunu çalıştırın!",
-    "hu_HU": "Csak futtasd a git pull-t!"
+    "hu_HU": "Csak futtasd a git pull-t!",
+    "az": "Sadəcə git pull et!"
   },
   "startDialog": {
     "en_US": {
@@ -1405,6 +1407,65 @@ exports.level = {
               "A `git pull` részleteit később fogjuk megvizsgálni (beleértve az opciókat és argumentumokat), de egyelőre próbáljuk ki a szinten.",
               "",
               "Emlékezz -- valójában megoldhatod ezt a szintet csak `fetch` és `merge`-gel is, de ez egy extra parancsba kerül :P"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Pull",
+              "",
+              "İndi ki `git fetch` ilə remote repozitoriyadan məlumatı necə fetch etməyi gördük, gəl həmin dəyişiklikləri əks etdirmək üçün işimizi yeniləyək!",
+              "",
+              "Bunu etməyin əslində bir çox yolu var -- yeni commit-lər lokal olaraq mövcud olan kimi, onları sanki başqa branch-lardakı adi commit-lərmiş kimi daxil edə bilərsən. Bu o deməkdir ki, aşağıdakı kimi əmrləri işlədə bilərsən:",
+              "",
+              "* `git cherry-pick o/main`",
+              "* `git rebase o/main`",
+              "* `git merge o/main`",
+              "* və s., və s.",
+              "",
+              "Əslində, remote dəyişikliklərini *fetch edib* sonra onları *merge etmək* iş axını o qədər geniş yayılıb ki, git hər ikisini eyni anda edən bir əmr təqdim edir! Həmin əmr `git pull`-dur."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl əvvəlcə ardıcıl işlədilən bir `fetch` və bir `merge`-ə baxaq."
+            ],
+            "afterMarkdowns": [
+              "Bum -- `fetch` ilə `C3`-ü endirdik və sonra həmin işi `git merge o/main` ilə merge etdik. İndi `main` branch-ımız remote-dan (bu halda `origin` adlanan) gələn yeni işi əks etdirir."
+            ],
+            "command": "git fetch; git merge o/main",
+            "beforeCommand": "git clone; git commit; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Bunun əvəzinə `git pull` işlətsəydik nə olardı?"
+            ],
+            "afterMarkdowns": [
+              "Eyni şey! Bu, aydın şəkildə göstərməlidir ki, `git pull` mahiyyətcə `git fetch`, ardınca da indicə fetch edilmiş branch-ı merge etməyin qısa yoludur."
+            ],
+            "command": "git pull",
+            "beforeCommand": "git clone; git commit; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "`git pull`-un təfərrüatlarını (o cümlədən seçimləri və arqumentləri) sonra araşdıracağıq, amma hələlik gəl onu bölümdə sınayaq.",
+              "",
+              "Unutma -- bu bölümü əslində təkcə `fetch` və `merge` ilə həll edə bilərsən, amma bu, sənə bir əlavə əmrə başa gələcək :P"
             ]
           }
         }

--- a/src/levels/remote/pullArgs.js
+++ b/src/levels/remote/pullArgs.js
@@ -25,7 +25,8 @@ exports.level = {
     "pl": "Argumenty pull",
     "it_IT": "Parametri di git pull",
     "tr_TR": "Git pull komutunun parametreleri",
-    "hu_HU": "Pull argumentumok"
+    "hu_HU": "Pull argumentumok",
+    "az": "Pull arqumentləri"
   },
   "hint": {
     "en_US": "Remember that you can create new local branches with fetch/pull arguments",
@@ -50,7 +51,8 @@ exports.level = {
     "pl": "Pamiętaj, że za pomocą argumentów fetch/pull możesz tworzyć nowe lokalne gałęzie",
     "it_IT": "Ricorda che puoi creare nuovi rami locali sfruttando fetch/pull + parametri",
     "tr_TR": "Unutma, fetch/pull parametreleri ile yeni yerel dallar oluşturabilirsin",
-    "hu_HU": "Ne feledd, a fetch/pull argumentumaival új helyi ágakat hozhatsz létre"
+    "hu_HU": "Ne feledd, a fetch/pull argumentumaival új helyi ágakat hozhatsz létre",
+    "az": "Unutma, fetch/pull arqumentləri ilə yeni lokal branch-lar yarada bilərsən"
   },
   "startDialog": {
     "en_US": {
@@ -1685,6 +1687,80 @@ exports.level = {
           "options": {
             "markdowns": [
               "Rendben, a befejezéshez érd el a célvizualizáció állapotát. Néhány commitot le kell töltened, új ágakat kell létrehoznod, és azokat az ágakat be kell merge-elned más ágakba, de nem kell sok parancs hozzá :P"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git pull arqumentləri",
+              "",
+              "İndi ki `git fetch` və `git push` arqumentləri haqqında bilinməli demək olar ki *hər şeyi* bilirsən, git pull üçün öyrəniləsi az qala heç nə qalmayıb :)",
+              "",
+              "Bunun səbəbi odur ki, git pull son nəticədə *əslində* sadəcə fetch etmək, ardınca da indicə fetch edileni merge etmək üçün qısa yoldur. Onu, *eyni* arqumentlərlə git fetch işlətmək və sonra həmin commit-lərin *düşdüyü yerdə* merge etmək kimi düşünə bilərsən.",
+              "",
+              "Bu, dəlicəsinə mürəkkəb arqumentlər işlədəndə də keçərlidir. Gəl bir neçə nümunəyə baxaq:"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Budur git-də bəzi ekvivalent əmrlər:",
+              "",
+              "`git pull origin foo` bununla eynidir:",
+              "",
+              "`git fetch origin foo; git merge o/foo`",
+              "",
+              "Və...",
+              "",
+              "`git pull origin bar:bugFix` bununla eynidir:",
+              "",
+              "`git fetch origin bar:bugFix; git merge bugFix`",
+              "",
+              "Gördün? git pull əslində sadəcə fetch + merge üçün qısa yoldur və git pull-un yeganə əhəmiyyət verdiyi şey commit-lərin harada düşməsidir (fetch zamanı müəyyən etdiyi `təyinat` arqumenti).",
+              "",
+              "Gəl bir nümayişə baxaq:"
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "fetch ediləcək yeri göstərsək, hər şey fetch-də olduğu kimi baş verir, amma indicə fetch edilən şeyi merge edirik."
+            ],
+            "afterMarkdowns": [
+              "Gördün! `main` göstərməklə commit-ləri həmişəki kimi `o/main`-ə endirdik. Sonra `o/main`-i hazırda checkout etdiyimiz yerə merge etdik ki, bu da lokal `main` branch-ı *deyil*. Məhz buna görə çoxlu branch-ı yeniləmək üçün git pull-u fərqli yerlərdən (eyni arqumentlərlə) bir neçə dəfə işlətmək əslində məntiqli ola bilər."
+            ],
+            "command": "git pull origin main",
+            "beforeCommand": "git clone; git fakeTeamwork; git checkout -b foo"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Mənbə və təyinatla da işləyir? Əlbəttə! Gəl buna baxaq:"
+            ],
+            "afterMarkdowns": [
+              "Vay, bu, bir əmrdə ÇOX iş deməkdir. Lokal olaraq `foo` adlı yeni bir branch yaratdıq, remote-un main-indən commit-ləri həmin `foo` branch-ına endirdik, sonra həmin branch-ı hazırda checkout etdiyimiz `bar` branch-ına merge etdik. 9000-i keçir!!!"
+            ],
+            "command": "git pull origin main:foo",
+            "beforeCommand": "git clone; git fakeTeamwork; git checkout -b bar"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Yaxşı, bitirmək üçün hədəf vizuallaşdırmasının vəziyyətinə çat. Bir neçə commit endirməli, bir neçə yeni branch yaratmalı və həmin branch-ları başqa branch-lara merge etməli olacaqsan, amma bu, çox əmr tələb etməməlidir :P"
             ]
           }
         }

--- a/src/levels/remote/push.js
+++ b/src/levels/remote/push.js
@@ -27,7 +27,8 @@ exports.level = {
     "pl": "Git push",
     "it_IT": "Git Push",
     "tr_TR": "Git Push",
-    "hu_HU": "Git push"
+    "hu_HU": "Git push",
+    "az": "Git Push"
   },
   "hint": {
     "en_US": "Remember you have to clone before you can push!",
@@ -51,7 +52,8 @@ exports.level = {
     "pl": "Najpierw sklonuj, potem pushuj!",
     "it_IT": "Ricorda di clonare il repository prima di usare push!",
     "tr_TR": "Unutmayın push işlemini yapmadan önce clone işlemini yapmanız gerekiyor!",
-    "hu_HU": "Ne felejtsd el, clone-ozni kell, mielőtt push-olhatsz!"
+    "hu_HU": "Ne felejtsd el, clone-ozni kell, mielőtt push-olhatsz!",
+    "az": "Unutma, push edə bilmək üçün əvvəlcə clone etməlisən!"
   },
   "startDialog": {
     "en_US": {
@@ -1032,6 +1034,49 @@ exports.level = {
           "options": {
             "markdowns": [
               "A szint befejezéséhez egyszerűen ossz meg két új commitot a remote-tal. De tartsd magad, mert ezek a leckék hamarosan sokkal nehezebbek lesznek!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Push",
+              "",
+              "Yaxşı, deməli, remote-dan dəyişiklikləri fetch etdim və onları lokal olaraq öz işimə daxil etdim. Bu, əla-filan... amma _öz_ möhtəşəm işimi başqaları ilə necə paylaşım?",
+              "",
+              "Bir sözlə, paylaşılan işi yükləmək paylaşılan işi endirməyin əksidir. Bəs `git pull`-un əksi nədir? `git push`!",
+              "",
+              "`git push` _sənin_ dəyişikliklərini göstərilən bir remote-a yükləməyə və həmin remote-u yeni commit-lərinlə yeniləməyə cavabdehdir. `git push` tamamlandıqdan sonra, bütün dostların sənin işini remote-dan endirə bilər.",
+              "",
+              "`git push`-u işini \"dərc etmək\" (publish) üçün bir əmr kimi düşünə bilərsən. Onun tezliklə keçəcəyimiz bir sıra incəlikləri var, amma gəl kiçik addımlarla başlayaq...",
+              "",
+              "*qeyd -- arqumentsiz `git push`-un davranışı git-in `push.default` adlanan parametrlərindən birindən asılı olaraq dəyişir. Bu parametrin standart dəyəri işlətdiyin git versiyasından asılıdır, amma biz dərslərimizdə `upstream` dəyərini işlədəcəyik. Bu, o qədər də böyük məsələ deyil, amma öz layihələrində push etməzdən əvvəl parametrlərini yoxlamağa dəyər.*"
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Burada remote-da olmayan bəzi dəyişikliklərimiz var. Gəl onları yükləyək!"
+            ],
+            "afterMarkdowns": [
+              "Budur -- remote `C2` commit-ini aldı, remote-dakı `main` branch-ı `C2`-yə işarə etmək üçün yeniləndi və remote-un bizdəki *öz* təsviri (`o/main`) da yeniləndi. Hər şey sinxrondadır!"
+            ],
+            "command": "git push",
+            "beforeCommand": "git clone; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü bitirmək üçün sadəcə iki yeni commit-i remote ilə paylaş. Amma özünü hazırla, çünki bu dərslər bir az sonra xeyli çətinləşəcək!"
             ]
           }
         }

--- a/src/levels/remote/pushArgs.js
+++ b/src/levels/remote/pushArgs.js
@@ -28,7 +28,8 @@ exports.level = {
     "pl": "Argumenty git push",
     "it_IT": "Parametri di git push",
     "tr_TR": "Git push argümanları",
-    "hu_HU": "Git push argumentumok"
+    "hu_HU": "Git push argumentumok",
+    "az": "Git push arqumentləri"
   },
   "hint": {
     "en_US": "You can always look at the last slide of the dialog with \"objective\"",
@@ -53,7 +54,8 @@ exports.level = {
     "pl": "Możesz wpisać \"objective\", żeby zobaczyć ostatni slajd z każdego poziomu",
     "it_IT": "Puoi sempre guardare l'ultima slide del dialogo con \"objective\"",
     "tr_TR": "Her zaman \"objective\" komutunu kullanarak diyalog penceresinin son sayfasına bakabilirsiniz",
-    "hu_HU": "Mindig megnézheted a párbeszéd utolsó diáját az \"objective\" paranccsal"
+    "hu_HU": "Mindig megnézheted a párbeszéd utolsó diáját az \"objective\" paranccsal",
+    "az": "Dialoqun son slaydına həmişə \\\"objective\\\" ilə baxa bilərsən"
   },
   "startDialog": {
     "en_US": {
@@ -1749,6 +1751,78 @@ exports.level = {
               "Rendben, ehhez a szinthez frissítsük mind a `foo`, mind a `main` ágat a távoliban. A csavar az, hogy ennél a szintnél a `git checkout` le van tiltva!",
               "",
               "*Megjegyzés: A távoli ágak `o/` előtaggal vannak jelölve, mert a teljes `origin/` jelölés nem fér el az UI-ban. Ne aggódj emiatt... egyszerűen használd az `origin`-t a távoli neveként, mint általában.*"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Push arqumentləri",
+              "",
+              "Əla! İndi ki remote izləmə branch-larını bilirsən, git push, fetch və pull-un necə işlədiyinin arxasındakı bəzi sirləri açmağa başlaya bilərik. Əmrləri bir-bir nəzərdən keçirəcəyik, amma aralarındakı anlayışlar çox oxşardır.",
+              "",
+              "Əvvəlcə `git push`-a baxacağıq. Remote izləmə dərsində öyrəndin ki, git hazırda checkout edilmiş branch-ın xüsusiyyətlərinə (onun \"izlədiyi\" remote-a) baxaraq push ediləcək remote-u *və* branch-ı müəyyən edirdi. Bu, heç bir arqument göstərilmədikdə olan davranışdır, amma git push istəyə bağlı olaraq bu formada arqumentlər qəbul edə bilər:",
+              "",
+              "`git push <remote> <yer>`"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "`<yer>` parametri nədir deyirsən? Təfərrüatlara tezliklə dərindən baxacağıq, amma əvvəlcə bir nümunə. Bu əmri vermək:",
+              "",
+              "`git push origin main`",
+              "",
+              "adi dildə belə ifadə olunur:",
+              "",
+              "*Mənim repozitoriyamdakı \"main\" adlı branch-a get, bütün commit-ləri götür, sonra \"origin\" adlı remote-dakı \"main\" branch-ına get. Həmin branch-da çatışmayan commit-ləri yerləşdir və bitirəndə mənə de.*",
+              "",
+              "`main`-i \"yer\" arqumenti kimi göstərməklə, git-ə commit-lərin *haradan gələcəyini* və *hara gedəcəyini* dedik. Bu, mahiyyətcə iki repozitoriya arasında sinxronlaşdırılacaq \"yer\" və ya \"məkan\"dır.",
+              "",
+              "Yadda saxla ki, git-ə bilməli olduğu hər şeyi dediyimiz üçün (hər iki arqumenti göstərməklə), o, harada checkout etdiyimizi tamamilə nəzərə almır!"
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl arqumentlərin göstərilməsinə dair bir nümunəyə baxaq. Bu nümunədə harada checkout etdiyimizə diqqət et."
+            ],
+            "afterMarkdowns": [
+              "Budur! Həmin arqumentləri göstərdiyimiz üçün remote-dakı `main` yeniləndi."
+            ],
+            "command": "git push origin main",
+            "beforeCommand": "git clone; git commit; git checkout C0"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Bəs arqumentləri göstərməsəydik? Nə baş verərdi?"
+            ],
+            "afterMarkdowns": [
+              "Əmr uğursuz olur (gördüyün kimi), çünki `HEAD` remote izləmə branch-ında checkout edilməyib."
+            ],
+            "command": "git push",
+            "beforeCommand": "git clone; git commit; git checkout C0"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Yaxşı, bu bölümdə gəl remote-dakı həm `foo`-nu, həm də `main`-i yeniləyək. İş orasındadır ki, bu bölüm üçün `git checkout` deaktiv edilib!",
+              "",
+              "*Qeyd: Remote branch-lar `o/` prefiksləri ilə işarələnib, çünki tam `origin/` etiketi bizim interfeysə sığmır. Bu barədə narahat olma... sadəcə həmişəki kimi remote-un adı olaraq `origin` işlət.*"
             ]
           }
         }

--- a/src/levels/remote/pushArgs2.js
+++ b/src/levels/remote/pushArgs2.js
@@ -24,7 +24,8 @@ exports.level = {
     "pl": "Argumenty git push -- Głębiej!",
     "it_IT": "Parametri di git push - Espansione!",
     "tr_TR": "Git push argümanları -- Genişletilmiş!",
-    "hu_HU": "Git push argumentumok -- Bővítve!"
+    "hu_HU": "Git push argumentumok -- Bővítve!",
+    "az": "Git push arqumentləri -- Genişləndirilmiş!"
   },
   "hint": {
     "en_US": "Remember you can admit defeat and type in \"show solution\" :P",
@@ -49,7 +50,8 @@ exports.level = {
     "pl": "Pamiętaj, że możesz się poddać i zobaczyć gotowe rozwiązanie, wpisując \"show solution\" :P",
     "it_IT": "Puoi sempre ammettere la tua sconfitta e digitare \"show solution\" :P",
     "tr_TR": "Unutma, teslim olabileceğini ve \"show solution\" yazabileceğini :P",
-    "hu_HU": "Ne feledd, mindig elismerheted a vereséged, és beírhatod: \"show solution\" :P"
+    "hu_HU": "Ne feledd, mindig elismerheted a vereséged, és beírhatod: \"show solution\" :P",
+    "az": "Unutma, məğlubiyyəti qəbul edib \\\"show solution\\\" yaza bilərsən :P"
   },
   "startDialog": {
     "en_US": {
@@ -1668,6 +1670,76 @@ exports.level = {
               "Ehhez a szinthez próbálj meg eljutni a vizualizációban mutatott végállapothoz, és ne felejtsd el a formátumot:",
               "",
               "`<source>:<destination>`"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## `<yer>` arqumentinin təfərrüatları",
+              "",
+              "Əvvəlki dərsdən yadına sal: git push üçün `main`-i yer arqumenti kimi göstərəndə, biz həm commit-lərin gələcəyi *mənbəni*, həm də commit-lərin gedəcəyi *təyinatı* göstərdik.",
+              "",
+              "Onda düşünə bilərsən -- bəs mənbə ilə təyinatın fərqli olmasını istəsək? Lokal `foo` branch-ındakı commit-ləri remote-dakı `bar` branch-ına push etmək istəsən?",
+              "",
+              "Təəssüf ki, bu, git-də mümkün deyil... zarafat edirəm! Əlbəttə ki mümkündür :)... git-in olduqca çox çevikliyi var (az qala həddindən artıq).",
+              "",
+              "Gəl növbəti slaydda necə olduğuna baxaq..."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "`<yer>`-in həm mənbəsini, həm də təyinatını göstərmək üçün sadəcə ikisini iki nöqtə ilə birləşdir:",
+              "",
+              "`git push origin <mənbə>:<təyinat>`",
+              "",
+              "Buna adətən iki nöqtəli refspec deyilir. Refspec sadəcə git-in müəyyən edə biləcəyi bir məkanın (məsələn, `foo` branch-ının və ya hətta sadəcə `HEAD~1`-in) qəşəng adıdır.",
+              "",
+              "Mənbə ilə təyinatı ayrı-ayrı göstərməyə başlayanda, remote əmrləri ilə olduqca ustalıqla və dəqiq işləyə bilərsən. Gəl bir nümayişə baxaq!"
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Unutma, `mənbə` git-in anlayacağı istənilən məkandır:"
+            ],
+            "afterMarkdowns": [
+              "Vay! Bu, olduqca başgicəlləndirici bir əmrdir, amma məntiqlidir -- git `foo^`-u bir məkana çevirdi, remote-da hələ olmayan commit-ləri yüklədi və sonra təyinatı yenilədi."
+            ],
+            "command": "git push origin foo^:main",
+            "beforeCommand": "git clone; git commit; git commit; git checkout -b foo; git commit"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Bəs push etmək istədiyin təyinat mövcud deyilsə? Problem yoxdur! Sadəcə bir branch adı ver və git remote-da həmin branch-ı sənin üçün yaradacaq."
+            ],
+            "afterMarkdowns": [
+              "Əla, bu, olduqca rahatdır :D"
+            ],
+            "command": "git push origin main:newBranch",
+            "beforeCommand": "git clone; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümdə vizuallaşdırmada göstərilən son hədəf vəziyyətinə çatmağa çalış və bu formatı unutma:",
+              "",
+              "`<mənbə>:<təyinat>`"
             ]
           }
         }

--- a/src/levels/remote/pushManyFeatures.js
+++ b/src/levels/remote/pushManyFeatures.js
@@ -25,7 +25,8 @@ exports.level = {
     "pl": "Pamiętaj, że zawsze możesz skorzystać z poleceń undo i reset",
     "it_IT": "Ricorda che puoi sempre usare i comandi undo e reset",
     "tr_TR": "Unutmayın, her zaman undo veya reset komutlarını kullanabilirsiniz.",
-    "hu_HU": "Ne feledd, mindig használhatod az undo vagy a reset parancsokat"
+    "hu_HU": "Ne feledd, mindig használhatod az undo vagy a reset parancsokat",
+    "az": "Main-i Push et!"
   },
   "name": {
     "en_US": "Push Main!",
@@ -50,7 +51,8 @@ exports.level = {
     "pl": "Wypychanie dla wytrwałych!",
     "it_IT": "Push main!",
     "tr_TR": "Main'i Push Et!",
-    "hu_HU": "Sok feature pusholása"
+    "hu_HU": "Sok feature pusholása",
+    "az": "Unutma, həmişə undo və ya reset əmrlərini işlədə bilərsən"
   },
   "compareOnlyMainHashAgnostic": true,
   "startDialog": {
@@ -1269,6 +1271,59 @@ exports.level = {
               "* A távoli azóta frissült, ezért azt a munkát is be kell építenünk",
               "",
               ":O intenzív! sok sikert, ennek a szintnek a teljesítése nagy lépés."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## feature branch-larını merge etmək",
+              "",
+              "İndi ki fetch, pull və push etməkdə özünü rahat hiss edirsən, gəl bu bacarıqları yeni bir iş axını ilə sınaqdan keçirək.",
+              "",
+              "Böyük layihələrdə proqramçıların bütün işlərini feature branch-larında (`main`-dən ayrılan) görməsi və həmin işi yalnız hazır olduqda inteqrasiya etməsi adi haldır. Bu, əvvəlki dərsə (yan branch-ların remote-a push edildiyi) bənzəyir, amma burada daha bir addım əlavə edirik.",
+              "",
+              "Bəzi proqramçılar yalnız `main` branch-ında olarkən push və pull edir -- beləliklə `main` həmişə remote-dakı (`o/main`) ilə yenilənmiş qalır.",
+              "",
+              "Beləliklə, bu iş axını üçün iki şeyi birləşdiririk:",
+              "",
+              "* feature branch işini `main`-ə inteqrasiya etmək və",
+              "* remote-dan push və pull etmək"
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl `main`-i necə yeniləyib işi push etməyin tez bir təkrarına baxaq."
+            ],
+            "afterMarkdowns": [
+              "Burada iki əmr işlətdik ki, onlar:",
+              "",
+              "* işimizi remote-dan gələn yeni commit-lərin üzərinə rebase etdi və",
+              "* işimizi remote-a dərc etdi"
+            ],
+            "command": "git pull --rebase; git push",
+            "beforeCommand": "git clone; git fakeTeamwork; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölüm kifayət qədər ağırdır -- həll etmək üçün ümumi plan budur:",
+              "",
+              "* Üç feature branch var -- `side1`, `side2` və `side3`",
+              "* Bu funksiyaların hər birini ardıcıllıqla remote-a push etmək istəyirik",
+              "* Remote o vaxtdan yenilənib, ona görə də həmin işi də daxil etməli olacağıq",
+              "",
+              ":O gərgindir! uğurlar, bu bölümü tamamlamaq böyük bir addımdır."
             ]
           }
         }

--- a/src/levels/remote/remoteBranches.js
+++ b/src/levels/remote/remoteBranches.js
@@ -25,7 +25,8 @@ exports.level = {
     "pl": "Zdalne gałęzie",
     "it_IT": "Rami Remoti",
     "tr_TR": "Uzak Dallar",
-    "hu_HU": "Távoli ágak"
+    "hu_HU": "Távoli ágak",
+    "az": "Remote Branch-lar"
   },
   "hint": {
     "en_US": "Pay attention to the ordering -- commit on main first!",
@@ -50,7 +51,8 @@ exports.level = {
     "pl": "Zwróć uwagę na kolejność -- najpierw zatwierdzaj na main",
     "it_IT": "Presta attenzione all'ordine -- fai prima un commit sul main!",
     "tr_TR": "Sıraya dikkat et -- önce main üzerinde commit yap!",
-    "hu_HU": "Figyelj a sorrendere -- először a main-en commitolj!"
+    "hu_HU": "Figyelj a sorrendere -- először a main-en commitolj!",
+    "az": "Ardıcıllığa diqqət et -- əvvəlcə main-də commit et!"
   },
   "startDialog": {
     "en_US": {
@@ -1467,6 +1469,69 @@ exports.level = {
           "options": {
             "markdowns": [
               "A szint befejezéséhez commitolj egyszer a `main`-ről, majd egyszer az `o/main` checkout-olása után. Ez segít megérteni, hogyan viselkednek másképp a távoli ágak, és hogy csak a remote állapotának tükrözésére frissülnek."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Remote Branch-ları",
+              "",
+              "İndi ki `git clone`-u iş başında gördün, gəl əslində nəyin dəyişdiyinə dərindən baxaq.",
+              "",
+              "Bəlkə də ilk diqqət etdiyin şey lokal repozitoriyamızda `o/main` adlı yeni bir branch-ın peyda olmasıdır. Bu tip branch _remote_ branch adlanır; remote branch-ların özünəməxsus xüsusiyyətləri var, çünki onlar unikal bir məqsədə xidmət edir.",
+              "",
+              "Remote branch-lar remote repozitoriyaların _vəziyyətini_ əks etdirir (həmin remote repozitoriyalarla sonuncu dəfə danışdığın vaxtdan bəri). Onlar sənin lokal işinlə ictimai olan iş arasındakı fərqi anlamağa kömək edir -- işini başqaları ilə paylaşmazdan əvvəl atılası vacib bir addım.",
+              "",
+              "Remote branch-ların belə bir özünəməxsus xüsusiyyəti var: onları checkout etdikdə, detached `HEAD` rejiminə keçirilirsən. Git bunu qəsdən edir, çünki bu branch-lar üzərində birbaşa işləyə bilməzsən; başqa yerdə işləməli və sonra işini remote ilə paylaşmalısan (bundan sonra remote branch-ların yenilənəcək).",
+              "",
+              "Aydın olsun deyə: Remote branch-lar sənin _lokal_ repozitoriyandadır, remote repozitoriyada deyil."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### `o/` nədir?",
+              "",
+              "Bəlkə də bu remote branch-lardakı öndəki `o/`-un nəyə lazım olduğunu düşünürsən. Yaxşı, remote branch-ların həm də (məcburi) adlandırma qaydası var -- onlar bu formatda göstərilir:",
+              "",
+              "* `<remote adı>/<branch adı>`",
+              "",
+              "Deməli, `o/main` adlı branch-a baxsan, branch adı `main`, remote-un adı isə `o`-dur.",
+              "",
+              "Əslində əksər proqramçılar əsas remote-larını `o` yox, `origin` adlandırır. Bu o qədər geniş yayılıb ki, repozitoriyanı `git clone` etdikdə git sənin remote-unu avtomatik `origin` adlandırır.",
+              "",
+              "Təəssüf ki, `origin`-in tam adı bizim interfeysə sığmır, ona görə də qısa olaraq `o` işlədirik :( Sadəcə yadda saxla: əsl git işlədəndə remote-un çox güman ki `origin` adlanacaq!",
+              "",
+              "Bu, mənimsəniləsi çox şeydir, ona görə də gəl bütün bunları iş başında görək."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl bir remote branch-ı checkout edək və nə baş verdiyinə baxaq."
+            ],
+            "afterMarkdowns": [
+              "Gördüyün kimi, git bizi detached `HEAD` rejiminə keçirdi və yeni commit əlavə etdikdə `o/main`-i yeniləmədi. Bunun səbəbi odur ki, `o/main` yalnız remote yeniləndikdə yenilənəcək."
+            ],
+            "command": "git checkout o/main; git commit",
+            "beforeCommand": "git clone"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü bitirmək üçün bir dəfə `main`-dən commit et, bir dəfə də `o/main`-i checkout etdikdən sonra commit et. Bu, remote branch-ların necə fərqli davrandığını və yalnız remote-un vəziyyətini əks etdirmək üçün yeniləndiyini yaxşı başa düşməyə kömək edəcək."
             ]
           }
         }

--- a/src/levels/remote/sourceNothing.js
+++ b/src/levels/remote/sourceNothing.js
@@ -30,7 +30,8 @@ exports.level = {
     "pl": "Źródło nicości",
     "it_IT": "Fonte del nulla",
     "tr_TR": "Hiçliğin kaynağı",
-    "hu_HU": "Semmi forrása"
+    "hu_HU": "Semmi forrása",
+    "az": "Heçliyin mənbəsi"
   },
   "hint": {
     "en_US": "The branch command is disabled for this level so you'll have to use fetch!",
@@ -55,7 +56,8 @@ exports.level = {
     "pl": "Polecenie branch jest zablokowane na tym poziomie, musisz skorzystać z fetch!",
     "it_IT": "Il comando branch è disabilitato per questo livello quindi dovrai usare fetch!",
     "tr_TR": "Bu seviyede branch komutu devre dışı bırakıldı, bu yüzden fetch kullanman gerekecek!",
-    "hu_HU": "A branch parancs le van tiltva ennél a szintnél, tehát a fetch-et kell használnod!"
+    "hu_HU": "A branch parancs le van tiltva ennél a szintnél, tehát a fetch-et kell használnod!",
+    "az": "Bu bölüm üçün branch əmri deaktiv edilib, ona görə də fetch işlətməli olacaqsan!"
   },
   "startDialog": {
     "en_US": {
@@ -1277,6 +1279,59 @@ exports.level = {
           "options": {
             "markdowns": [
               "Ez egy gyors szint -- csak törölj egy távoli ágat, és hozz létre egy új ágat a `git fetch`-csel a befejezéshez!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### `<mənbə>`-nin qəribəlikləri",
+              "",
+              "Git `<mənbə>` parametrindən iki qəribə üsulla sui-istifadə edir. Bu iki sui-istifadə ondan qaynaqlanır ki, sən texniki olaraq həm git push, həm də git fetch üçün etibarlı `mənbə` kimi \"heçlik\" göstərə bilərsən. Heçliyi boş bir arqumentlə göstərirsən:",
+              "",
+              "* `git push origin :side`",
+              "* `git fetch origin :bugFix`",
+              "",
+              "Gəl bunların nə etdiyinə baxaq..."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Remote branch-a \"heçlik\" push etmək nə edir? Onu silir!"
+            ],
+            "afterMarkdowns": [
+              "Budur, ona \"heçlik\" anlayışını push etməklə remote-dakı `foo` branch-ını uğurla sildik. Bu, bir növ məntiqlidir..."
+            ],
+            "command": "git push origin :foo",
+            "beforeCommand": "git clone; git fakeTeamwork foo"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Nəhayət, lokal olaraq bir yerə \"heçlik\" fetch etmək əslində yeni bir branch yaradır."
+            ],
+            "afterMarkdowns": [
+              "Çox qəribə / əcaib, amma nə olacaq ki. Bax, git belə şeydir!"
+            ],
+            "command": "git fetch origin :bar",
+            "beforeCommand": "git clone"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu, qısa bir bölümdür -- bitirmək üçün sadəcə bir remote branch-ı sil və `git fetch` ilə yeni bir branch yarat!"
             ]
           }
         }

--- a/src/levels/remote/tracking.js
+++ b/src/levels/remote/tracking.js
@@ -24,7 +24,8 @@ exports.level = {
     "pl": "Śledzenie zdalnych repo",
     "it_IT": "Tracciamento remoto",
     "tr_TR": "Uzaktan İzleme",
-    "hu_HU": "Távoli követés"
+    "hu_HU": "Távoli követés",
+    "az": "Remote İzləmə"
   },
   "hint": {
     "en_US": "Remember there are two ways to set remote tracking!",
@@ -49,7 +50,8 @@ exports.level = {
     "pl": "Pamiętaj, zdalne repo można śledzić na dwa sposoby!",
     "it_IT": "Ricorda che ci sono due modi per impostare il tracciamento remoto!",
     "tr_TR": "Unutma, uzak izlemeyi ayarlamanın iki yolu vardır!",
-    "hu_HU": "Ne feledd, a távoli követés beállításának két módja van!"
+    "hu_HU": "Ne feledd, a távoli követés beállításának két módja van!",
+    "az": "Unutma, remote izləməni qurmağın iki yolu var!"
   },
   "startDialog": {
     "en_US": {
@@ -2764,6 +2766,124 @@ exports.level = {
           "options": {
             "markdowns": [
               "Rendben! Ehhez a szinthez pusholjuk a munkát a távoli `main` ágra, miközben *nem* a helyi `main`-en vagyunk checkoutolva. Ehelyett hozz létre egy `side` nevű ágat, amelyet a céldiagram mutat."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### Remote-izləmə branch-ları",
+              "",
+              "Son bir neçə dərsdə \"sehrli\" görünə biləcək məqamlardan biri odur ki, git `main` branch-ının `o/main` ilə əlaqəli olduğunu bilirdi. Düzdür, bu branch-ların adları oxşardır və remote-dakı `main` branch-ını lokal `main` branch-ına bağlamaq məntiqli görünə bilər, amma bu əlaqə iki ssenaridə aydın şəkildə özünü göstərir:",
+              "",
+              "* pull əməliyyatı zamanı commit-lər `o/main`-ə endirilir və sonra `main` branch-ına *merge edilir*. Merge-in nəzərdə tutulan hədəfi məhz bu əlaqədən müəyyən edilir.",
+              "* push əməliyyatı zamanı `main` branch-ındakı iş remote-un `main` branch-ına push edildi (o da lokal olaraq `o/main` kimi təmsil olunurdu). Push-un *təyinat yeri* `main` ilə `o/main` arasındakı əlaqədən müəyyən edilir.",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Remote izləmə",
+              "",
+              "Qısası, `main` və `o/main` arasındakı bu əlaqə sadəcə branch-ların \"remote izləmə\" xüsusiyyəti ilə izah olunur. `main` branch-ı `o/main`-i izləməyə qurulub -- bu o deməkdir ki, `main` branch-ı üçün nəzərdə tutulan bir merge hədəfi və nəzərdə tutulan bir push təyinat yeri var.",
+              "",
+              "Bəlkə də bu xüsusiyyətin `main` branch-ında necə təyin olunduğunu düşünürsən, axı onu göstərmək üçün heç bir əmr işlətmədin. Yaxşı, repozitoriyanı git ilə clone etdikdə, bu xüsusiyyət əslində sənin üçün avtomatik təyin olunur. ",
+              "",
+              "clone zamanı git remote-dakı hər branch üçün bir remote branch yaradır (yəni `o/main` kimi branch-lar). Sonra remote-da hazırda aktiv olan branch-ı izləyən bir lokal branch yaradır ki, bu da əksər hallarda `main` olur.",
+              "",
+              "git clone tamamlandıqdan sonra yalnız bir lokal branch-ın olur (ki başın qarışmasın), amma remote-dakı bütün fərqli branch-ları görə bilirsən (əgər çox maraqlanırsansa). İkisi də bir yerdə!",
+              "",
+              "Bu həm də clone edərkən niyə aşağıdakı əmr çıxışını görə biləcəyini izah edir:",
+              "",
+              "    lokal branch \"main\" remote branch \"o/main\"-i izləməyə quruldu"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### Bunu özüm təyin edə bilərəmmi?",
+              "",
+              "Bəli, edə bilərsən! İstənilən branch-ı `o/main`-i izləməyə qura bilərsən və bunu etsən, həmin branch-ın da `main` ilə eyni nəzərdə tutulan push təyinat yeri və merge hədəfi olacaq. Bu o deməkdir ki, `totallyNotMain` adlı bir branch-da `git push` işlədib işini remote-dakı `main` branch-ına push edə bilərsən!",
+              "",
+              "Bu xüsusiyyəti təyin etməyin iki yolu var. Birincisi, remote branch-ı göstərilən ref kimi işlədərək yeni bir branch-ı checkout etməkdir. Bunu işlətmək:",
+              "",
+              "`git checkout -b totallyNotMain o/main`",
+              "",
+              "`totallyNotMain` adlı yeni bir branch yaradır və onu `o/main`-i izləməyə qurur."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Danışıq bəsdir, gəl bir nümayişə baxaq! `foo` adlı yeni bir branch-ı checkout edəcəyik və onu remote-dakı `main`-i izləməyə quracağıq."
+            ],
+            "afterMarkdowns": [
+              "Gördüyün kimi, `foo` branch-ını yeniləmək üçün `o/main`-in nəzərdə tutulan merge hədəfindən istifadə etdik. Diqqət et ki, main yenilənmir!!"
+            ],
+            "command": "git checkout -b foo o/main; git pull",
+            "beforeCommand": "git clone; git fakeTeamwork"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Bu, git push üçün də keçərlidir."
+            ],
+            "afterMarkdowns": [
+              "Bum. Branch-ımızın adı tamam başqa bir şey olsa da, işimizi remote-dakı `main`-ə push etdik."
+            ],
+            "command": "git checkout -b foo o/main; git commit; git push",
+            "beforeCommand": "git clone"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### Yol №2",
+              "",
+              "Bir branch-da remote izləməni təyin etməyin başqa bir yolu sadəcə `git branch -u` seçimini işlətməkdir. Bunu işlətmək:",
+              "",
+              "`git branch -u o/main foo`",
+              "",
+              "`foo` branch-ını `o/main`-i izləməyə quracaq. Əgər `foo` hazırda checkout edilibsə, onu heç yazmaya da bilərsən:",
+              "",
+              "`git branch -u o/main`",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl remote izləməni göstərməyin bu digər yoluna tezcə baxaq..."
+            ],
+            "afterMarkdowns": [
+              "Əvvəlki ilə eyni, sadəcə daha konkret bir əmr. Əla!"
+            ],
+            "command": "git branch -u o/main foo; git commit; git push",
+            "beforeCommand": "git clone; git checkout -b foo"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Yaxşı! Bu bölümdə gəl lokal olaraq `main`-də *olmadan* işi remote-dakı `main` branch-ına push edək. Bunun əvəzinə, hədəf diaqramında göstərilən `side` adlı bir branch yaratmalısan."
             ]
           }
         }


### PR DESCRIPTION
Continues #1382 (Azerbaijani intro sequence, merged) with the full **Remote** workflow.

## What's covered

All 16 remote level files across the **Remote** and **Remote Advanced** sequences — `clone`, `remoteBranches`, `fetch`, `pull`, `fakeTeamwork`, `push`, `fetchRebase`, `lockedMain`, `pushArgs`, `pushArgs2`, `fetchArgs`, `pullArgs`, `mergeManyFeatures`, `tracking`, `pushManyFeatures`, `sourceNothing` — each with `az` `name` / `hint` / `startDialog`.

Plus `intl/strings.js`: `az` for the 6 remote-specific command/error strings (origin fetch/push results, remote-branch and origin errors). This also corrects one intro-era string — `"günceldir"` → `"ən son vəziyyətdədir"` (*güncel* is Turkish, not standard Azerbaijani).

## Translation approach

Same convention as #1382: git commands stay in English, git terms are inflected with Azerbaijani suffixes (`commit-lər`, `branch-lar`, `remote-a`, `repozitoriya`). `remote` is kept in English to mirror the untranslated UI tab; `local` = `lokal`. Every file was reviewed for natural Azerbaijani phrasing and consistency with the merged intro.

## Verification

- `gulp fastBuild` + jshint clean
- all 313 specs pass
- Remote + Remote Advanced sequences render end-to-end at `?locale=az` with no untranslated markers and no layout breakage from the longer AZ strings
