### PR TITLE
Add Azerbaijani (az) locale — remaining level sequences + strings sweep

### DIFF
--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -163,7 +163,8 @@ exports.strings = {
     "it_IT": "Attenzione! Mercurial ha un garbage collector molto aggressivo e perciò deve potare il tuo albero",
     "ta_IN": "எச்சரிக்கை! மெர்குரியல் வலிய களிவு சேகரிப்பு செய்கிறது, இதனால் உங்கள் மரத்தை கத்தரிக்க வேண்டிவரும்",
     "tr_TR": "Uyarı! Mercurial, agresif garbage collection yapar bu nedenle ağacınızı prune etmeniz gerekebilir.",
-    "hu_HU": "Figyelmeztetés! A Mercurial agresszív szemétgyűjtést végez, ezért meg kell nyírnia a fádat"
+    "hu_HU": "Figyelmeztetés! A Mercurial agresszív szemétgyűjtést végez, ezért meg kell nyírnia a fádat",
+    "az": "Xəbərdarlıq! Mercurial aqressiv garbage collection aparır və buna görə ağacını budamalıdır"
   },
   "hg-a-option": {
     "__desc__": "warning for when using -A option",
@@ -189,7 +190,8 @@ exports.strings = {
     "it_IT": "L'opzione -A non è necessiaria, fai semplicemente commit!",
     "ta_IN": "இந்த பயன்பாட்டிற்கு -A மாற்று தேவையில்லை, `கமிட்` செய்யுங்கள்",
     "tr_TR": "Bu uygulama için -A seçeneği gereksizdir, sadece commit atın!",
-    "hu_HU": "Az -A opció nem szükséges ehhez az alkalmazáshoz, csak commit-olj!"
+    "hu_HU": "Az -A opció nem szükséges ehhez az alkalmazáshoz, csak commit-olj!",
+    "az": "Bu tətbiq üçün -A seçiminə ehtiyac yoxdur, sadəcə commit et!"
   },
   "hg-error-no-status": {
     "__desc__": "One of the errors for hg",
@@ -215,7 +217,8 @@ exports.strings = {
     "it_IT": "Non esiste il comando status in quest'app, visto che non esiste lo staging dei file. Prova invece `hg summary`",
     "ta_IN": "கோப்புகள் எதுவும் அடுத்த படிநிலையில் இல்லை என்பதால், இந்த பயன்பாட்டிற்கான மதிப்பீடும் கட்டளை எதுவும் இல்லை. அதற்கு பதிலாக `hg summary` முயற்சிக்கவும்",
     "tr_TR": "Bu uygulama için bir status komutu yok çünkü dosyalar stage edilemiyor. Bunun yerine hg summit komutunu deneyin.",
-    "hu_HU": "Nincs status parancs ehhez az alkalmazáshoz, mivel nincs fájlok állomásoztatása. Próbáld helyette az hg summary parancsot"
+    "hu_HU": "Nincs status parancs ehhez az alkalmazáshoz, mivel nincs fájlok állomásoztatása. Próbáld helyette az hg summary parancsot",
+    "az": "Bu tətbiqdə status əmri yoxdur, çünki faylların staging-i yoxdur. Onun əvəzinə hg summary sına"
   },
   "hg-error-need-option": {
     "__desc__": "One of the errors for hg",
@@ -241,7 +244,8 @@ exports.strings = {
     "it_IT": "Ho bisogno di {option} per quel comando!",
     "ta_IN": "எனக்கு அந்த கட்டளைக்கு மாற்று {option} தேவை",
     "tr_TR": "Bu komut için {seçenek} seçeneğine ihtiyacım var!",
-    "hu_HU": "Szükségem van a {option} opcióra ahhoz a parancshoz!"
+    "hu_HU": "Szükségem van a {option} opcióra ahhoz a parancshoz!",
+    "az": "Bu əmr üçün mənə {option} seçimi lazımdır!"
   },
   "hg-error-log-no-follow": {
     "__desc__": "hg log without -f (--follow)",
@@ -267,7 +271,8 @@ exports.strings = {
     "it_IT": "hg log senza -f non è attualmente supportato, usa -f",
     "ta_IN": "-f இல்லாமல் `hg log` தற்போது ஆதரிக்கப்படவில்லை, -f ஐப் பயன்படுத்தவும்",
     "tr_TR": "-f olmadan hg logu şu anda desteklenmiyor, -f kullanın.",
-    "hu_HU": "A -f nélküli hg log jelenleg nem támogatott, használd a -f kapcsolót"
+    "hu_HU": "A -f nélküli hg log jelenleg nem támogatott, használd a -f kapcsolót",
+    "az": "-f olmadan hg log hazırda dəstəklənmir, -f istifadə et"
   },
   "git-status-detached": {
     "__desc__": "One of the lines for git status output",
@@ -293,7 +298,8 @@ exports.strings = {
     "it_IT": "Testa distaccata (Detached head)!",
     "ta_IN": "பிரிக்கப்பட்ட தலை!",
     "tr_TR": "Detached head!(Bağımsız başlık!)",
-    "hu_HU": "Leválasztott HEAD (Detached head)!"
+    "hu_HU": "Leválasztott HEAD (Detached head)!",
+    "az": "Ayrılmış HEAD (Detached head)!"
   },
   "git-status-onbranch": {
     "__desc__": "One of the lines for git status output",
@@ -561,7 +567,8 @@ exports.strings = {
     "it_IT": "Non puoi eliminare il ramo main, il ramo in cui sei, o cose che non sono rami",
     "ta_IN": "பிரதான கிளை, தற்ப்போது நடப்பில் உள்ள கிளை மற்றும் கிளை அல்லாத வற்றை அழிக்க இயலாது",
     "tr_TR": "Şu anda üzerinde çalıştığın branch olan main i veya branch olmayan Refs leri silemezsin",
-    "hu_HU": "Nem törölheted a main ágat, azt az ágat amelyen éppen vagy, vagy olyan dolgokat amelyek nem ágak"
+    "hu_HU": "Nem törölheted a main ágat, azt az ágat amelyen éppen vagy, vagy olyan dolgokat amelyek nem ágak",
+    "az": "main branch-ını, üzərində olduğun branch-ı və ya branch olmayan şeyləri silə bilmərsən"
   },
   "git-merge-msg": {
     "__desc__": "The commit message for a merge commit",
@@ -614,7 +621,8 @@ exports.strings = {
     "it_IT": "Non ci sono commit da ribasare! Sono tutti commit di merge o i cambiamenti sono già stati applicati",
     "ta_IN": "`rebase` செய்ய எந்த கமிட்டும் இல்லை, அனைத்தும் இணைப்பு கமிட்கள் அல்லது முன்பே இணைக்கப்பட்டவை",
     "tr_TR": "Rebase edilecek commit yok! Her şey birleştirme commit i ya da zaten uygulanmış değişiklikler",
-    "hu_HU": "Nincs commit a rebase-hez! Minden merge commit vagy a változtatások már alkalmazva lettek"
+    "hu_HU": "Nincs commit a rebase-hez! Minden merge commit vagy a változtatások már alkalmazva lettek",
+    "az": "Rebase ediləcək commit yoxdur! Hər şey merge commit-dir və ya dəyişikliklər artıq tətbiq olunub"
   },
   "git-result-nothing": {
     "__desc__": "The message that explains the result of a git command",
@@ -640,7 +648,8 @@ exports.strings = {
     "it_IT": "Niente da fare...",
     "ta_IN": "செய்வதற்க்கு ஒன்றும் இல்லை...",
     "tr_TR": "Yapılacak bir şey yok...",
-    "hu_HU": "Nincs tennivaló..."
+    "hu_HU": "Nincs tennivaló...",
+    "az": "Ediləcək heç nə yoxdur..."
   },
   "git-result-fastforward": {
     "__desc__": "The message that explains the result of a git command",
@@ -720,7 +729,8 @@ exports.strings = {
     "it_IT": "Il riferimento (ref) {ref} non esiste o è sconosciuto",
     "ta_IN": "{ref} இல்லை அல்லது தெரியவில்லை",
     "tr_TR": "{ref} referansı mevcut değil veya bilinmiyo",
-    "hu_HU": "A(z) {ref} referencia nem létezik vagy ismeretlen"
+    "hu_HU": "A(z) {ref} referencia nem létezik vagy ismeretlen",
+    "az": "{ref} ref-i mövcud deyil və ya naməlumdur"
   },
   "git-error-relative-ref": {
     "__desc__": "One of the error messages for git",
@@ -746,7 +756,8 @@ exports.strings = {
     "it_IT": "Il commit {commit} non ha un {match}",
     "ta_IN": "{commit}க்கு {match} எதுவும் இல்லை",
     "tr_TR": "{commit} commit inin {match} bulunmamaktadı",
-    "hu_HU": "A(z) {commit} commit-nak nincs {match} szülője"
+    "hu_HU": "A(z) {commit} commit-nak nincs {match} szülője",
+    "az": "{commit} commit-inin {match} yoxdur"
   },
   "git-warning-detached": {
     "__desc__": "One of the warning messages for git",
@@ -772,7 +783,8 @@ exports.strings = {
     "it_IT": "Attenzione!! Situazione di testa distaccata (Detached HEAD)",
     "ta_IN": "எச்சரிக்கை !! `HEAD` துன்டிக்கப்பட்ட நிலையில் உள்ளது",
     "tr_TR": "Uyarı!! Bağımsız HEAD durumu",
-    "hu_HU": "Figyelmeztetés!! Leválasztott HEAD állapot"
+    "hu_HU": "Figyelmeztetés!! Leválasztott HEAD állapot",
+    "az": "Xəbərdarlıq!! Ayrılmış HEAD vəziyyəti"
   },
   "git-warning-add": {
     "__desc__": "One of the warning messages for git",
@@ -798,7 +810,8 @@ exports.strings = {
     "it_IT": "Non c'è bisogno di aggiungere file in questa demo",
     "ta_IN": "இந்த நடைமுறையில் கோப்புகளை சேர்க்க தேவையில்லை",
     "tr_TR": "Bu demoda dosya eklemeye gerek yok",
-    "hu_HU": "Ebben a demóban nincs szükség fájlok hozzáadására"
+    "hu_HU": "Ebben a demóban nincs szükség fájlok hozzáadására",
+    "az": "Bu demoda fayl əlavə etməyə ehtiyac yoxdur"
   },
   "git-error-options": {
     "__desc__": "One of the error messages for git",
@@ -824,7 +837,8 @@ exports.strings = {
     "it_IT": "Le opzioni che hai specificato sono incompatibili o sbagliate",
     "ta_IN": "நீங்கள் குறிப்பிட்ட அந்த மற்றிகள் பொருந்தாது அல்லது தவறானவை",
     "tr_TR": "Belirttiğiniz seçenekler uyumsuz veya yanlış",
-    "hu_HU": "A megadott opciók nem kompatibilisek vagy helytelenek"
+    "hu_HU": "A megadott opciók nem kompatibilisek vagy helytelenek",
+    "az": "Qeyd etdiyin seçimlər uyğunsuzdur və ya yanlışdır"
   },
   "git-error-already-exists": {
     "__desc__": "One of the error messages for git",
@@ -850,7 +864,8 @@ exports.strings = {
     "it_IT": "Il commit {commit} è già presente, annullo!",
     "ta_IN": "{commit} உங்கள் மாற்றங்களின் தொகுப்பில் ஏற்கனவே உள்ளது, கட்டளை கைவிடப்பட்டது!",
     "tr_TR": "Commit {commit} zaten değişiklik setinizde mevcut, işlem iptal ediliyor!",
-    "hu_HU": "A(z) {commit} commit már létezik a változtatások között, megszakítás!"
+    "hu_HU": "A(z) {commit} commit már létezik a változtatások között, megszakítás!",
+    "az": "{commit} commit-i artıq dəyişikliklər dəstində mövcuddur, ləğv edilir!"
   },
   "git-error-reset-detached": {
     "__desc__": "One of the error messages for git",
@@ -876,7 +891,8 @@ exports.strings = {
     "it_IT": "Non posso fare reset in modalità testa distaccata (detached head)! Utilizza checkout se vuoi spostarti",
     "ta_IN": "பிரிக்கப்பட்ட தலையில் மீட்டமைக்க முடியாது! நீங்கள் நகர்த்த விரும்பினால் `checkout` பயன்படுத்தவும்",
     "tr_TR": "Detached head durumunda sıfırlama yapılamaz! Taşımak istiyorsanız checkout kullanın",
-    "hu_HU": "Leválasztott HEAD állapotban nem lehet reset-et csinálni! Használd a checkout-ot ha mozogni szeretnél"
+    "hu_HU": "Leválasztott HEAD állapotban nem lehet reset-et csinálni! Használd a checkout-ot ha mozogni szeretnél",
+    "az": "Ayrılmış HEAD-də reset edə bilmərsən! Yerini dəyişmək istəyirsənsə checkout istifadə et"
   },
   "git-warning-hard": {
     "__desc__": "One of the warning messages for git",
@@ -902,7 +918,8 @@ exports.strings = {
     "it_IT": "Il comportamento base per i resets su LearnGitBranching è --hard, per cui puoi tranquillamente omettere quella opzione se ti sei stancato di scriverla. Ricorda però che in Git, l'opzione di default è --mixed.",
     "ta_IN": "The default behavior for resets on LearnGitBranching is a --hard, so feel free to omit that option if you get tired of typing it out in our lessons. Just remember that the default behavior on actual Git is --mixed.",
     "tr_TR": "LearnGitBranching deki sıfırlama işlemlerinin varsayılan davranışı --hard tır, bu yüzden derslerimizde yazarken bundan sıkılırsanız bu seçeneği atlayabilirsiniz. Ancak gerçek Git teki varsayılan davranışın --mixed olduğunu unutmayın.",
-    "hu_HU": "A LearnGitBranching alapértelmezett viselkedése reset esetén a --hard, tehát bátran kihagyhatod azt az opciót ha meguntad begépelni a leckéinkben. Csak emlékezz arra, hogy az eredeti Git alapértelmezése --mixed."
+    "hu_HU": "A LearnGitBranching alapértelmezett viselkedése reset esetén a --hard, tehát bátran kihagyhatod azt az opciót ha meguntad begépelni a leckéinkben. Csak emlékezz arra, hogy az eredeti Git alapértelmezése --mixed.",
+    "az": "LearnGitBranching-də reset-in standart davranışı --hard-dır, ona görə dərslərimizdə bunu yazmaqdan yorulsan bu seçimi buraxa bilərsən. Sadəcə yadında saxla ki, əsl Git-də standart davranış --mixed-dir."
   },
   "git-error-staging": {
     "__desc__": "One of the error messages for git",
@@ -928,7 +945,8 @@ exports.strings = {
     "it_IT": "Non esiste il concetto di aggiungere / indicizzare i file, quindi quell'opzione o comando non è valido!",
     "ta_IN": "கோப்புகளைச் சேர்ப்பது / நிலைநிறுத்துவது என்ற கருத்து ஒன்றும் இல்லை, எனவே அந்த மற்றி அல்லது கட்டளை தவறானது",
     "tr_TR": "Dosya ekleme / sahneleme kavramı yok, bu nedenle bu seçenek veya komut geçersiz!",
-    "hu_HU": "Nincs fájlok hozzáadása/állomásoztatása fogalom, tehát ez az opció vagy parancs érvénytelen!"
+    "hu_HU": "Nincs fájlok hozzáadása/állomásoztatása fogalom, tehát ez az opció vagy parancs érvénytelen!",
+    "az": "Fayl əlavə etmək / staging anlayışı yoxdur, ona görə bu seçim və ya əmr etibarsızdır!"
   },
   "git-revert-msg": {
     "__desc__": "Message for reverting git command",
@@ -954,7 +972,8 @@ exports.strings = {
     "it_IT": "Ripristino {oldCommit}: {oldMsg}",
     "ta_IN": "{oldCommit}: {oldMsg} மீன்டும் மாற்றியமைக்கிறது",
     "tr_TR": "{oldCommit} geri alınıyor: {oldMsg}",
-    "hu_HU": "{oldCommit} visszaállítása: {oldMsg}"
+    "hu_HU": "{oldCommit} visszaállítása: {oldMsg}",
+    "az": "{oldCommit} geri qaytarılır: {oldMsg}"
   },
   "git-error-args-many": {
     "__desc__": "One of the error messages for git",
@@ -980,7 +999,8 @@ exports.strings = {
     "it_IT": "Mi aspetto al massimo {upper} parametro/i per {what}",
     "ta_IN": "நான் {what}க்கான உள்ளீடு(கள்) அதிகபட்சமாக {upper} எதிர்பார்க்கிறேன்",
     "tr_TR": "{what} için en fazla {upper} argüman bekliyorum",
-    "hu_HU": "Legfeljebb {upper} argumentumot várok a(z) {what} számára"
+    "hu_HU": "Legfeljebb {upper} argumentumot várok a(z) {what} számára",
+    "az": "{what} üçün ən çoxu {upper} arqument gözləyirəm"
   },
   "git-error-args-few": {
     "__desc__": "One of the error messages for git",
@@ -1006,7 +1026,8 @@ exports.strings = {
     "it_IT": "Mi aspetto come minimo {lower} parametro/i per {what}",
     "ta_IN": "நான் {what}க்கான உள்ளீடு(கள்) குறைந்தபட்சம் {lower} எதிர்பார்க்கிறேன்",
     "tr_TR": "{what} için en az {lower} argüman bekliyorum",
-    "hu_HU": "Legalább {lower} argumentumot várok a(z) {what} számára"
+    "hu_HU": "Legalább {lower} argumentumot várok a(z) {what} számára",
+    "az": "{what} üçün ən azı {lower} arqument gözləyirəm"
   },
   "git-error-no-general-args": {
     "__desc__": "One of the error messages for git",
@@ -1032,7 +1053,8 @@ exports.strings = {
     "it_IT": "Quel comando non accetta parametri generici",
     "ta_IN": "அந்த கட்டளை பொதுவான உள்ளீடு எதுவும் ஏற்கவில்லை",
     "tr_TR": "Bu komut genel argüman kabul etmez",
-    "hu_HU": "Ez a parancs nem fogad el általános argumentumokat"
+    "hu_HU": "Ez a parancs nem fogad el általános argumentumokat",
+    "az": "Bu əmr ümumi arqumentləri qəbul etmir"
   },
   "git-error-command-not-supported": {
     "__desc__": "Message that appears in git console when command was not recognized.",
@@ -1054,7 +1076,8 @@ exports.strings = {
     "sl_SI": "Ukaz \"{command}\" ni podprt, oprostite!",
     "ta_IN": "\"{command}\" என்ற கட்டளை ஆதரிக்கப்படவில்லை, வருந்துகிறோம்!",
     "tr_TR": "\"{command}\" komutu desteklenmiyor, üzgünüm!",
-    "hu_HU": "A(z) \"{command}\" parancs nem támogatott, sajnálom!"
+    "hu_HU": "A(z) \"{command}\" parancs nem támogatott, sajnálom!",
+    "az": "\"{command}\" əmri dəstəklənmir, üzr istəyirəm!"
   },
   "copy-tree-string": {
     "__desc__": "The prompt to copy the tree when sharing",
@@ -1080,7 +1103,8 @@ exports.strings = {
     "it_IT": "Copia il codice dell'albero qua sotto",
     "ta_IN": "`tree string`ஐ கீழே நகலெடுக்கவும்",
     "tr_TR": "Aşağıdaki ağaç dizesini kopyalayın",
-    "hu_HU": "Másold le az alábbi faszöveget"
+    "hu_HU": "Másold le az alábbi faszöveget",
+    "az": "Aşağıdakı ağac sətrini kopyala"
   },
   "learn-git-branching": {
     "__desc__": "The title of the app, with spaces",
@@ -1206,7 +1230,8 @@ exports.strings = {
     "it_IT": "Scusa ma i nomi dei rami devono essere brevi per essere visualizzati. Il nome del tuo ramo è stato accorciato a 9 caratteri, rinominandolo come \"{branch}\"",
     "ta_IN": "மன்னிக்கவும், காட்சிகளுக்கு கிளை பெயர்களை குறுகியதாக வைத்திருக்க வேண்டி உள்ளது. உங்கள் கிளையின் பெயர் 9 எழுத்துகளாக சுருக்கப்பட்டு, \"{branch}\" ஆக மற்றப்பட்டுள்ளது",
     "tr_TR": "Üzgünüm, görseller için dal isimlerini kısa tutmamız gerekiyor. Dal isminiz 9 karaktere kısaltıldı, bu da \"{branch}\" oldu.",
-    "hu_HU": "Sajnos rövidnek kell tartanunk az ágneveket a megjelenítéshez. Az ágneved 9 karakterre lett rövidítve, az eredmény: \"{branch}\""
+    "hu_HU": "Sajnos rövidnek kell tartanunk az ágneveket a megjelenítéshez. Az ágneved 9 karakterre lett rövidítve, az eredmény: \"{branch}\"",
+    "az": "Üzr istəyirik, vizual görüntü üçün branch adlarını qısa saxlamalıyıq. Branch adın 9 simvola qısaldıldı və nəticədə \"{branch}\" oldu"
   },
   "bad-branch-name": {
     "__desc__": "When the user enters a branch name thats not ok",
@@ -1232,7 +1257,8 @@ exports.strings = {
     "it_IT": "Il nome \"{branch}\" per i rami non è consentito!",
     "ta_IN": "\"{branch}\" ஐ கிளையின் பெயராக ஏற்க்க இயலாது!",
     "tr_TR": "Bu dal ismi \"{branch}\" izin verilmez!",
-    "hu_HU": "Ez az ágnév \"{branch}\" nem megengedett!"
+    "hu_HU": "Ez az ágnév \"{branch}\" nem megengedett!",
+    "az": "\"{branch}\" branch adına icazə verilmir!"
   },
   "bad-tag-name": {
     "__desc__": "When the user enters a tag name thats not ok",
@@ -1258,7 +1284,8 @@ exports.strings = {
     "it_IT": "Il nome \"{tag}\" per i tag non è consentito!",
     "ta_IN": "\"{tag}\" ஐ குறிச்சொல் பெயராக ஏற்க்க இயலாது!",
     "tr_TR": "Bu etiket ismi \"{tag}\" izin verilmez!",
-    "hu_HU": "Ez a tagnév \"{tag}\" nem megengedett!"
+    "hu_HU": "Ez a tagnév \"{tag}\" nem megengedett!",
+    "az": "\"{tag}\" tag adına icazə verilmir!"
   },
   "option-not-supported": {
     "__desc__": "When the user specifies an option that is not supported by our demo",
@@ -1284,7 +1311,8 @@ exports.strings = {
     "it_IT": "L'opzione \"{option}\" non è supportata!",
     "ta_IN": "\"{option}\" மாற்று செயல் ஆதரிக்கப்படவில்லை!",
     "tr_TR": "\"{option}\" seçeneği desteklenmiyor!",
-    "hu_HU": "A(z) \"{option}\" opció nem támogatott!"
+    "hu_HU": "A(z) \"{option}\" opció nem támogatott!",
+    "az": "\"{option}\" seçimi dəstəklənmir!"
   },
   "git-usage-command": {
     "__desc__": "The line that shows how to format a git command",
@@ -1310,7 +1338,8 @@ exports.strings = {
     "it_IT": "git <command> [<args>]",
     "ta_IN": "git <command> [<args>]",
     "tr_TR": "git <komut> [<argümanlar>]",
-    "hu_HU": "git <parancs> [<argumentumok>]"
+    "hu_HU": "git <parancs> [<argumentumok>]",
+    "az": "git <əmr> [<arqumentlər>]"
   },
   "git-supported-commands": {
     "__desc__": "In the git help command, the header above the supported commands",
@@ -1336,7 +1365,8 @@ exports.strings = {
     "it_IT": "Comandi supportati:",
     "ta_IN": "செயலாக்கம் உள்ள கட்டளைகள்;",
     "tr_TR": "Desteklenen komutlar:",
-    "hu_HU": "Támogatott parancsok:"
+    "hu_HU": "Támogatott parancsok:",
+    "az": "Dəstəklənən əmrlər:"
   },
   "git-usage": {
     "__desc__": "In the dummy git output, the header before showing all the commands",
@@ -1362,7 +1392,8 @@ exports.strings = {
     "it_IT": "Utilizzo:",
     "ta_IN": "பயன்பாடு",
     "tr_TR": "Kullanım:",
-    "hu_HU": "Használat:"
+    "hu_HU": "Használat:",
+    "az": "İstifadə:"
   },
   "git-version": {
     "__desc__": "The git version dummy output, kind of silly. PCOTTLE is my unix name but feel free to put yours instead",
@@ -1388,7 +1419,8 @@ exports.strings = {
     "it_IT": "Git Version SHARDANA_SOFT.1.0.0",
     "ta_IN": "Git Version PCOTTLE.1.0",
     "tr_TR": "Git versiyonu PCOTTLE.1.0",
-    "hu_HU": "Git Verzió PCOTTLE.1.0"
+    "hu_HU": "Git Verzió PCOTTLE.1.0",
+    "az": "Git Versiyası PCOTTLE.1.0"
   },
   "flip-tree-command": {
     "__desc__": "when the tree is being flipped",
@@ -1414,7 +1446,8 @@ exports.strings = {
     "it_IT": "Girando l'albero...",
     "ta_IN": "Flipping tree...",
     "tr_TR": "Ağaç ters çevriliyor...",
-    "hu_HU": "Fa megfordítása..."
+    "hu_HU": "Fa megfordítása...",
+    "az": "Ağac çevrilir..."
   },
   "refresh-tree-command": {
     "__desc__": "when the tree is visually refreshed",
@@ -1440,7 +1473,8 @@ exports.strings = {
     "it_IT": "Aggiornando l'albero...",
     "ta_IN": "Refreshing tree...",
     "tr_TR": "Ağaç yenileniyor...",
-    "hu_HU": "Fa frissítése..."
+    "hu_HU": "Fa frissítése...",
+    "az": "Ağac yenilənir..."
   },
   "locale-command": {
     "__desc__": "when the locale is set to something",
@@ -1466,7 +1500,8 @@ exports.strings = {
     "it_IT": "Locale impostato a {locale}",
     "ta_IN": "பிரதேசம் {locale}ஆக மற்ற பட்டுள்ளது",
     "tr_TR": "{locale} olarak dil ayarlandı",
-    "hu_HU": "Nyelv beállítva: {locale}"
+    "hu_HU": "Nyelv beállítva: {locale}",
+    "az": "Dil {locale} olaraq təyin olundu"
   },
   "locale-reset-command": {
     "__desc__": "when the locale is reset",
@@ -1492,7 +1527,8 @@ exports.strings = {
     "it_IT": "Locale resettato al valore di default, che è {locale}",
     "ta_IN": "பிரதேசம் இயல்புநிலை {locale}க்கி மீட்டமைக்கப்பட்டுள்ளது",
     "tr_TR": "Dil varsayılan olarak sıfırlandı, bu {locale}",
-    "hu_HU": "Nyelv visszaállítva az alapértelmezettre: {locale}"
+    "hu_HU": "Nyelv visszaállítva az alapértelmezettre: {locale}",
+    "az": "Dil standart olan {locale}-ə sıfırlandı"
   },
   "show-command": {
     "__desc__": "command output title from \"show\"",
@@ -1518,7 +1554,8 @@ exports.strings = {
     "it_IT": "Usa uno dei seguenti comandi per maggiori informazioni:",
     "ta_IN": "மேலும் தகவலுக்கு பின்வரும் கட்டளைகளில் ஒன்றைப் பயன்படுத்தவும்:",
     "tr_TR": "Daha fazla bilgi için lütfen aşağıdaki komutlardan birini kullanın:",
-    "hu_HU": "Kérlek használd az alábbi parancsok egyikét további információkért:"
+    "hu_HU": "Kérlek használd az alábbi parancsok egyikét további információkért:",
+    "az": "Daha çox məlumat üçün aşağıdakı əmrlərdən birini istifadə et:"
   },
   "show-all-commands": {
     "__desc__": "command output title from \"show commands\"",
@@ -1544,7 +1581,8 @@ exports.strings = {
     "it_IT": "Ecco la lista con tutti i comandi disponibili:",
     "ta_IN": "கிடைக்கக்கூடிய அனைத்து கட்டளைகளின் பட்டியல்:",
     "tr_TR": "İşte tüm mevcut komutların bir listesi:",
-    "hu_HU": "Íme az összes elérhető parancs listája:"
+    "hu_HU": "Íme az összes elérhető parancs listája:",
+    "az": "Mövcud bütün əmrlərin siyahısı budur:"
   },
   "cd-command": {
     "__desc__": "dummy command output for the command in the key",
@@ -1570,7 +1608,8 @@ exports.strings = {
     "it_IT": "Cartella modificata in  \"/directories/dont/matter/in/this/demo\"",
     "ta_IN": "அடைவு \"/directories/dont/matter/in/this/demo\"க்கு மாற்றப்பட்டது",
     "tr_TR": "Dizin \"/directories/dont/matter/in/this/demo\" olarak değiştirildi",
-    "hu_HU": "Könyvtár megváltoztatva: \"/konyvtarak/nem/fontosak/ebben/a/demoban\""
+    "hu_HU": "Könyvtár megváltoztatva: \"/konyvtarak/nem/fontosak/ebben/a/demoban\"",
+    "az": "Qovluq \"/qovluqlar/bu/demoda/vacib/deyil\" olaraq dəyişdirildi"
   },
   "ls-command": {
     "__desc__": "Dummy command output for the command in the key",
@@ -1596,7 +1635,8 @@ exports.strings = {
     "it_IT": "NoNdEvIpReOcCuPaRtIdEiFiLeInQuEsTaDeMo.txt",
     "ta_IN": "DontWorryAboutFilesInThisDemo.txt",
     "tr_TR": "DontWorryAboutFilesInThisDemo.txt",
-    "hu_HU": "NeFeleddAFajlokNemFontosabbanADemoban.txt"
+    "hu_HU": "NeFeleddAFajlokNemFontosabbanADemoban.txt",
+    "az": "BuDemodaFayllarHaqqındaNarahatOlma.txt"
   },
   "mobile-alert": {
     "__desc__": "When someone comes to the site on a mobile device, they can not input commands so this is a nasty alert to tell them",
@@ -1622,7 +1662,8 @@ exports.strings = {
     "it_IT": "LGB non funziona su mobile, vieni a trovarci da pc! Ne vale veramente la pena :D",
     "ta_IN": "LGBஆல் மொபைலில் உள்ளீட்டைப் பெற முடியாது, டெஸ்க்டாப்பில் பார்வையிடவும், அது பயணுள்ளது :D",
     "tr_TR": "LGB mobilde giriş alamaz, masaüstü üzerinden ziyaret et! Değmesine değer :D",
-    "hu_HU": "Az LGB nem tud bemenetet fogadni mobilon, látogass el asztali gépen! Megéri :D"
+    "hu_HU": "Az LGB nem tud bemenetet fogadni mobilon, látogass el asztali gépen! Megéri :D",
+    "az": "LGB mobil cihazlarda daxiletmə qəbul edə bilmir, masaüstündən daxil ol! Buna dəyər :D"
   },
   "share-tree": {
     "__desc__": "When you export a tree, we want you to share the tree with friends",
@@ -1648,7 +1689,8 @@ exports.strings = {
     "it_IT": "Condividi quest'albero con i tuoi amici! Può essere importato tramite \"import tree\"",
     "ta_IN": "இந்த `tree`ஐ நண்பர்களுடன் பகிர்ந்து கொள்ளுங்கள்! அவர்கள் அதை \"import tree\" மூலம் பெறலாம்",
     "tr_TR": "Bu ağacı arkadaşlarınla paylaş! \"import tree\" komutuyla yükleyebilirler",
-    "hu_HU": "Oszd meg ezt a fát barátaiddal! Betölthetik az \"import tree\" paranccsal"
+    "hu_HU": "Oszd meg ezt a fát barátaiddal! Betölthetik az \"import tree\" paranccsal",
+    "az": "Bu ağacı dostlarınla paylaş! Onlar onu \"import tree\" ilə yükləyə bilərlər"
   },
   "paste-json": {
     "__desc__": "When you are importing a level or tree",
@@ -1674,7 +1716,8 @@ exports.strings = {
     "it_IT": "Incolla un blob JSON qui sotto!",
     "ta_IN": "ஒரு JSON blob-ஐ கீழே ஒட்டவும்",
     "tr_TR": "Aşağıya bir JSON verisi yapıştırın!",
-    "hu_HU": "Illessz be egy JSON blobot alább!"
+    "hu_HU": "Illessz be egy JSON blobot alább!",
+    "az": "Aşağıya bir JSON blob-u yapışdır!"
   },
   "solved-map-reset": {
     "__desc__": "When you reset the solved map to clear your solved history, in case someone else wants to use your browser",
@@ -1700,7 +1743,8 @@ exports.strings = {
     "it_IT": "I progresse salvati sono stati resettati, stai iniziando da zero!",
     "ta_IN": "தீர்க்கப்பட்ட கோப்பு மீட்டமைக்கப்பட்டது, நீங்கள் ஆரம்பத்தில் இருந்து தொடங்குகிறீர்கள்!",
     "tr_TR": "Çözülen harita sıfırlandı, temiz bir sayfadan başlıyorsunuz!",
-    "hu_HU": "A megoldott térkép visszaállítva, tiszta lappal kezdesz!"
+    "hu_HU": "A megoldott térkép visszaállítva, tiszta lappal kezdesz!",
+    "az": "Həll xəritəsi sıfırlandı, təmiz vərəqdən başlayırsan!"
   },
   "level-cant-exit": {
     "__desc__": "When the user tries to exit a level when they are not in one",
@@ -1726,7 +1770,8 @@ exports.strings = {
     "it_IT": "Non ti trovi in un livello! Sei nella sandbox, inizia un livello con \"levels\"",
     "ta_IN": "ஒரு நிலையில் இல்லாமல், நீங்கள் sandbox-இல் உள்ளீர்கள்! \"நிலைகள்\" மூலம் ஒரு நிலையைத் தொடங்கவும்",
     "tr_TR": "Bir seviyede değilsiniz! Bir kum havuzundasınız, \"levels\" ile bir seviye başlatın.",
-    "hu_HU": "Nem vagy egy szintben! A homokozóban vagy, indíts el egy szintet a \"levels\" paranccsal"
+    "hu_HU": "Nem vagy egy szintben! A homokozóban vagy, indíts el egy szintet a \"levels\" paranccsal",
+    "az": "Sən bölümdə deyilsən! Sandbox-dasan, \"levels\" ilə bir bölüm başlat"
   },
   "level-no-id": {
     "__desc__": "When you say an id but that level doesn't exist",
@@ -1752,7 +1797,8 @@ exports.strings = {
     "it_IT": "Non è stato trovato un livello con id \"{id}\"! Apro la finestra con la selezione dei livelli",
     "ta_IN": "அந்த \"{id}\"-க்கான நிலை  காணப்படவில்லை! நிலை தேர்வு செய்யும் திரை திறக்கிறது",
     "tr_TR": "Bu id'ye \"{id}\" ait bir seviye bulunamadı! Seviye seçimi görünümünü açıyorum.",
-    "hu_HU": "Nem található szint a(z) \"{id}\" azonosítóhoz! Szintválasztó nézet megnyitása"
+    "hu_HU": "Nem található szint a(z) \"{id}\" azonosítóhoz! Szintválasztó nézet megnyitása",
+    "az": "\"{id}\" id-li bölüm tapılmadı! Bölüm seçimi görünüşü açılır"
   },
   "undo-stack-empty": {
     "__desc__": "The undo command can only undo back until the last time the level was reset or the beginning of the level",
@@ -1778,7 +1824,8 @@ exports.strings = {
     "it_IT": "Non sono presenti comandi da annullare!",
     "ta_IN": "மீள்பதிவு அடுக்கு காலியாக உள்ளது!",
     "tr_TR": "Geri alma yığını boş!",
-    "hu_HU": "A visszavonási verem üres!"
+    "hu_HU": "A visszavonási verem üres!",
+    "az": "Geri al yığını boşdur!"
   },
   "already-solved": {
     "__desc__": "When you play in a level that is already solved",
@@ -1857,7 +1904,8 @@ exports.strings = {
     "it_IT": "Questo comando git è disabilitato per questo livello!",
     "ta_IN": "இந்த நிலையில் அந்த கிட் கட்டளை முடக்கப்பட்டுள்ளது",
     "tr_TR": "Bu seviyede o git komutu devre dışı bırakılmıştır!",
-    "hu_HU": "Ez a git parancs le van tiltva ennél a szintnél!"
+    "hu_HU": "Ez a git parancs le van tiltva ennél a szintnél!",
+    "az": "Bu git əmri bu bölüm üçün deaktiv edilib!"
   },
   "share-json": {
     "__desc__": "when you have made the level, prompt to share this",
@@ -1883,7 +1931,8 @@ exports.strings = {
     "it_IT": "Ecco il JSON per questo livello! Condividilo con qualcuno o inviamelo tramite GitHub",
     "ta_IN": "இதோ இந்த நிலைக்கான JSON, இதை பகிர்ந்து கொள்ளுங்கள் அல்லது GitHub-இல் எனக்கு அனுப்புங்கள்",
     "tr_TR": "İşte bu seviye için JSON! Bunu birisiyle paylaşabilir veya GitHub üzerinden bana gönderebilirsiniz.",
-    "hu_HU": "Íme a JSON ehhez a szinthez! Oszd meg valakivel vagy küldd el nekem a GitHub-on"
+    "hu_HU": "Íme a JSON ehhez a szinthez! Oszd meg valakivel vagy küldd el nekem a GitHub-on",
+    "az": "Bu bölüm üçün JSON budur! Onu kiminləsə paylaş və ya GitHub-da mənə göndər"
   },
   "want-start-dialog": {
     "__desc__": "prompt to add a start dialog",
@@ -1963,7 +2012,8 @@ exports.strings = {
     "it_IT": "Inserisci un suggerimento per questo livello, oppure lascialo vuoto se non ne vuoi aggiungere",
     "ta_IN": "இந்த நிலைக்கான குறிப்பை உள்ளிடவும், குறிப்பு தேவை இல்லை என்றால் இதனை காலியாக விடுவும்",
     "tr_TR": "Bu seviye için ipucu girin, ya da bir ipucu eklemek istemiyorsanız burayı boş bırakın",
-    "hu_HU": "Add meg a tippet ehhez a szinthez, vagy hagyd üresen ha nem szeretnél egyet hozzáadni"
+    "hu_HU": "Add meg a tippet ehhez a szinthez, vagy hagyd üresen ha nem szeretnél egyet hozzáadni",
+    "az": "Bu bölüm üçün ipucunu daxil et, ya da əlavə etmək istəmirsənsə boş burax"
   },
   "prompt-name": {
     "__desc__": "prompt for level name",
@@ -1989,11 +2039,13 @@ exports.strings = {
     "it_IT": "Inserisci il nome per questo livello",
     "ta_IN": "நிலைக்கான பெயரை உள்ளிடவும்",
     "tr_TR": "Seviye için adı girin",
-    "hu_HU": "Add meg a szint nevét"
+    "hu_HU": "Add meg a szint nevét",
+    "az": "Bölümün adını daxil et"
   },
   "no-solution-defined": {
     "__desc__": "Shown when the user runs `show solution` but the current level has no solution defined to place in the command box",
-    "en_US": "This level doesn't have a solution to show!"
+    "en_US": "This level doesn't have a solution to show!",
+    "az": "Bu bölümün göstəriləcək həlli yoxdur!"
   },
   "solution-empty": {
     "__desc__": "If you define a solution without any commands, aka a level that is solved without doing anything",
@@ -2019,7 +2071,8 @@ exports.strings = {
     "it_IT": "C'è qualcosa che non va. La soluzione è vuota!! ",
     "ta_IN": "உங்கள் தீர்வு காலியாக உள்ளது!! ஏதோ தவறாக இருக்கிறது",
     "tr_TR": "Çözümünüz boş!! Bir şeyler eksik",
-    "hu_HU": "A megoldásod üres!! Valami hiányzik"
+    "hu_HU": "A megoldásod üres!! Valami hiányzik",
+    "az": "Sənin həllin boşdur!! Nəsə səhvdir"
   },
   "define-start-warning": {
     "__desc__": "When you define the start point again, it overwrites the solution and goal so we add a warning",
@@ -2045,7 +2098,8 @@ exports.strings = {
     "it_IT": "Definendo punto di partenza... soluzione e obiettivo saranno sovrascritti se erano già stati definiti.",
     "ta_IN": "தொடக்கத்தை வரையறுத்தல்... தீர்வு மற்றும் குறிக்கோள் முன்னரே வரையறுக்கப்பட்டிருந்தால் மேலெழுதப்படும்",
     "tr_TR": "Başlangıç noktası belirleniyor... daha önce tanımlanan çözüm ve hedef üzerine yazılacaktır",
-    "hu_HU": "Kezdőpont meghatározása... a megoldás és a cél felül lesz írva ha korábban már meg volt határozva"
+    "hu_HU": "Kezdőpont meghatározása... a megoldás és a cél felül lesz írva ha korábban már meg volt határozva",
+    "az": "Başlanğıc nöqtəsi təyin edilir... əvvəllər təyin edilibsə, həll və hədəf üzərinə yazılacaq"
   },
   "help-vague-level": {
     "__desc__": "When you are in a level and you say help, its vague and you need to specify",
@@ -2071,7 +2125,8 @@ exports.strings = {
     "it_IT": "Sei dentro a un livello, hai a disposizione vari tipi di aiuto. Digita \"help level\" per saperne di più su questa lezione, \"help general\" per come usare Learn GitBranching, o \"objective\" per capire come risolvere il livello.",
     "ta_IN": "நீங்கள் ஒரு நிலையில் உள்ளீர்கள், எனவே பல வகையான உதவி பெற இயலும். இந்த பாடத்தைப் பற்றி மேலும் அறிய \"நிலைக்கான உதவி\" என்பதைத் தேர்ந்தெடுக்கவும், Learn GitBranching பற்றி மேலும் அறிய \"பொது உதவி\" பயன்படுத்துக, அல்லது இந்த நிலையை எவ்வாறு தீர்ப்பது என்பது பற்றி அறிய \"நோக்கம்\" தேர்ந்தெடுக்கவும்.",
     "tr_TR": "Bir seviyedesiniz, bu nedenle birden fazla yardım seçeneği mevcuttur. Bu derse dair daha fazla bilgi almak için \"help level\", Learn GitBranching kullanımını öğrenmek için \"help general\" veya seviyeyi nasıl çözeceğiniz hakkında bilgi almak için \"objective\" seçeneğini belirleyebilirsiniz.",
-    "hu_HU": "Szintben vagy, ezért több segítségi forma is elérhető. Kérlek válaszd a \"help level\" lehetőséget ha többet szeretnél megtudni erről a leckéről, a \"help general\" lehetőséget a Learn GitBranching használatához, vagy az \"objective\" lehetőséget a szint megoldásának elsajátításához."
+    "hu_HU": "Szintben vagy, ezért több segítségi forma is elérhető. Kérlek válaszd a \"help level\" lehetőséget ha többet szeretnél megtudni erről a leckéről, a \"help general\" lehetőséget a Learn GitBranching használatához, vagy az \"objective\" lehetőséget a szint megoldásának elsajátításához.",
+    "az": "Sən bir bölümdəsən, ona görə bir neçə növ kömək mövcuddur. Bu dərs haqqında ətraflı bilmək üçün \"help level\", Learn GitBranching-dən istifadə üçün \"help general\", ya da bölümü necə həll edəcəyini öyrənmək üçün \"objective\" seç."
   },
   "help-vague-builder": {
     "__desc__": "When you are in a level builder, the help command is vague so you need to specify what you mean",
@@ -2097,7 +2152,8 @@ exports.strings = {
     "it_IT": "Sei in un generatore di livelli, hai a disposizione vari tipi di aiuto. Digita \"help general\" o \"help builder\"",
     "ta_IN": "நீங்கள் ஒரு நிலை கட்டமைப்பானில் உள்ளீர்கள், எனவே பல வகையான உதவி பெற இயலும். தயவுசெய்து \"பொது உதவி\" அல்லது \"கட்டமைப்பான் உதவி\" என்பதைத் தேர்ந்தெடுக்கவும்",
     "tr_TR": "Bir seviye oluşturucudasınız, bu nedenle birden fazla yardım seçeneği mevcuttur. Lütfen \"help general\" veya \"help builder\" seçeneklerinden birini seçin.",
-    "hu_HU": "Szintépítőben vagy, ezért több segítségi forma is elérhető. Kérlek válassz a \"help general\" vagy \"help builder\" lehetőségek közül"
+    "hu_HU": "Szintépítőben vagy, ezért több segítségi forma is elérhető. Kérlek válassz a \"help general\" vagy \"help builder\" lehetőségek közül",
+    "az": "Sən bölüm konstruktorundasan, ona görə bir neçə növ kömək mövcuddur. Zəhmət olmasa \"help general\" və ya \"help builder\" seç"
   },
   "show-goal-button": {
     "__desc__": "button label to show goal",
@@ -2343,7 +2399,8 @@ exports.strings = {
     "pl": "Twórca poziomu",
     "it_IT": "Generatore di livelli",
     "ta_IN": "நிலை கட்டமைப்பான்",
-    "hu_HU": "Szintépítő"
+    "hu_HU": "Szintépítő",
+    "az": "Bölüm Konstruktoru"
   },
   "no-start-dialog": {
     "__desc__": "when the user tries to open a start dialog for a level that does not have one",
@@ -2426,7 +2483,8 @@ exports.strings = {
     "it_IT": "La traduzione per {key} non esiste ancora :( Fai un salto su GitHub e dacci una mano!",
     "ta_IN": "{key}-இன் மொழிபெயர்ப்பு கிடைக்கவில்லை :( github-இன் வழியாக் நீங்களும் மொழி பெயர்க்க உதவலாம்!",
     "tr_TR": "{key} için henüz bir çeviri yok :( Lütfen GitHub'a gidin ve bir çeviri önerin!",
-    "hu_HU": "A(z) {key} fordítása még nem létezik :( Kérlek ugorj fel a GitHub-ra és ajánlj fel egy fordítást!"
+    "hu_HU": "A(z) {key} fordítása még nem létezik :( Kérlek ugorj fel a GitHub-ra és ajánlj fel egy fordítást!",
+    "az": "{key} üçün tərcümə hələ mövcud deyil :( Zəhmət olmasa GitHub-a keç və tərcümə təklif et!"
   },
   "error-untranslated": {
     "__desc__": "The general error when we encounter a dialog that is not translated",
@@ -2453,7 +2511,8 @@ exports.strings = {
     "it_IT": "Questo messaggio o testo non è ancora stato tradotto nella tua lingua :(  Fai un salto su GitHub e dacci una mano!",
     "ta_IN": "இந்த உரையாடல் அல்லது உரை உங்கள் தமிழில் இன்னும் மொழிபெயர்க்கப்படவில்லை :( github-இன் வழியாக் நீங்களும் மொழி பெயர்க்க உதவலாம்!",
     "tr_TR": "Bu ileti veya metin henüz dilimize çevrilmemiş :( Çeviriye yardımcı olmak için GitHub'da bize katılın!",
-    "hu_HU": "Ez a párbeszéd vagy szöveg még nincs lefordítva a te nyelvedre :( Ugorj fel a GitHub-ra a fordításhoz való segítségért!"
+    "hu_HU": "Ez a párbeszéd vagy szöveg még nincs lefordítva a te nyelvedre :( Ugorj fel a GitHub-ra a fordításhoz való segítségért!",
+    "az": "Bu dialoq və ya mətn sənin dilinə hələ tərcümə olunmayıb :( Tərcüməyə kömək etmək üçün GitHub-a keç!"
   },
   "cancel-button": {
     "__desc__": "Cancel button label after completing a level",
@@ -2521,11 +2580,13 @@ exports.strings = {
   },
   "close-window": {
     "__desc__": "Tooltip for the red control that closes a window.",
-    "en_US": "Close window"
+    "en_US": "Close window",
+    "az": "Pəncərəni bağla"
   },
   "helper-bar-back": {
     "__desc__": "Back label in the bottom helper bar sub-menus.",
-    "en_US": "Back"
+    "en_US": "Back",
+    "az": "Geri"
   },
   "command-helper-bar-levels": {
     "__desc__": "Levels command label in the bottom command helper bar.",
@@ -2664,7 +2725,8 @@ exports.strings = {
     "pl": "To polecenie jest poprawne, ale nie jest obsługiwane w obecnym środowisku! Spróbuj wybrać poziom lub włączyć konstruktor poziomów, aby użyć tej komendy",
     "vi": "Lệnh đó hợp lệ, nhưng không được hỗ trợ ở môi trường hiện tại! Hãy thử vào một cấp độ hoặc trình tạo cấp độ để sử dụng lệnh",
     "tr_TR": "Bu komut geçerli bir komuttur, fakat bu ortamda desteklenmemektedir, bu komutu kullanmak için bir seviye (level) ya da seviye oluşturucu ekleyin (level builder).",
-    "hu_HU": "Ez a parancs érvényes, de nem támogatott a jelenlegi környezetben! Próbálj belépni egy szintbe vagy szintépítőbe hogy használd ezt a parancsot"
+    "hu_HU": "Ez a parancs érvényes, de nem támogatott a jelenlegi környezetben! Próbálj belépni egy szintbe vagy szintépítőbe hogy használd ezt a parancsot",
+    "az": "Bu əmr etibarlıdır, lakin cari mühitdə dəstəklənmir! Bu əmri istifadə etmək üçün bir bölümə və ya bölüm konstruktoruna daxil olmağı sına"
   },
   "interactive-rebase-title": {
     "__desc__": "Title for the popup",
@@ -2684,6 +2746,7 @@ exports.strings = {
     "pl": "Interaktywny Rebase",
     "vi": "Rebase tương tác",
     "tr_TR": "Etkileşimli Yeniden Temellendirme",
-    "hu_HU": "Interaktív rebase"
+    "hu_HU": "Interaktív rebase",
+    "az": "İnteraktiv Rebase"
   }
 }

--- a/src/levels/advanced/multipleParents.js
+++ b/src/levels/advanced/multipleParents.js
@@ -27,7 +27,8 @@ exports.level = {
     "it_IT": "Genitori multipli",
     "pl": "Wielu rodziców",
     "tr_TR": "Birden fazla ebeveyn",
-    "hu_HU": "Több szülő"
+    "hu_HU": "Több szülő",
+    "az": "Bir neçə valideyn"
   },
   "hint": {
     "en_US": "Use `git branch bugWork` with a target commit to create the missing reference.",
@@ -54,7 +55,8 @@ exports.level = {
     "it_IT": "Scrivi `git branch bugWork` con un commit per creare il riferimento mancante.",
     "pl": "Użyj `git branch bugWork` na docelowym commicie, aby utworzyć brakującą referencję.",
     "tr_TR": "Eksik referansı oluşturmak için hedef commit ile `git branch bugWork` komutunu kullanın.",
-    "hu_HU": "Használd a `git branch bugWork` parancsot egy célcommittal a hiányzó referencia létrehozásához."
+    "hu_HU": "Használd a `git branch bugWork` parancsot egy célcommittal a hiányzó referencia létrehozásához.",
+    "az": "Əskik referansı yaratmaq üçün hədəf commit ilə `git branch bugWork` istifadə et."
   },
   "startDialog": {
     "en_US": {
@@ -2225,6 +2227,93 @@ exports.level = {
               "A szint teljesítéséhez hozz létre egy új ágat a meghatározott célhelyen.",
               "",
               "Nyilvánvalóan egyszerű lenne a commitot közvetlenül megadni (például `C6`-tal), de arra kérlek, hogy helyette a tárgyalt módosítókat használd!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### Valideynləri müəyyən etmək",
+              "",
+              "`~` modifikatoru kimi, `^` modifikatoru da özündən sonra istəyə bağlı bir rəqəm qəbul edir.",
+              "",
+              "Neçə nəsil geriyə getmək lazım olduğunu göstərmək əvəzinə (`~`-in etdiyi budur), `^`-dan sonrakı rəqəm merge commit-dən hansı valideyn referansının izlənəcəyini müəyyən edir. Yadda saxla ki, merge commit-lərin bir neçə valideyni olur, ona görə hansı yolun seçiləcəyi qeyri-müəyyəndir.",
+              "",
+              "Git adətən merge commit-dən yuxarı doğru \"birinci\" valideyni izləyir, lakin `^` ilə rəqəm göstərmək bu defolt davranışı dəyişir.",
+              "",
+              "Kifayət qədər danışdıq, gəl bunu əməldə görək.",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Burada bir merge commit-imiz var. Əgər `main^`-i modifikatorsuz checkout etsək, merge commit-dən sonra birinci valideyni izləyəcəyik. ",
+              "",
+              "(*Bizim vizuallaşdırmalarımızda birinci valideyn merge commit-in düz üstündə yerləşir.*)"
+            ],
+            "afterMarkdowns": [
+              "Asandır -- hamımızın öyrəşdiyi budur."
+            ],
+            "command": "git checkout main^",
+            "beforeCommand": "git checkout HEAD^; git commit; git checkout main; git merge C2"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "İndi isə əvəzində ikinci valideyni göstərməyə cəhd edək..."
+            ],
+            "afterMarkdowns": [
+              "Gördün? Biz digər valideyni yuxarı izlədik."
+            ],
+            "command": "git checkout main^2",
+            "beforeCommand": "git checkout HEAD^; git commit; git checkout main; git merge C2"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "`^` və `~` modifikatorları commit ağacında hərəkət etməyi çox güclü edə bilər:"
+            ],
+            "afterMarkdowns": [
+              "İldırım sürətilə!"
+            ],
+            "command": "git checkout HEAD~; git checkout HEAD^2; git checkout HEAD~2",
+            "beforeCommand": "git commit; git checkout C0; git commit; git commit; git commit; git checkout main; git merge C5; git commit"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Daha da dəlisi, bu modifikatorlar bir-birinə zəncirlənə bilər! Buna bax:"
+            ],
+            "afterMarkdowns": [
+              "Əvvəlki ilə eyni hərəkət, amma hamısı bir əmrdə."
+            ],
+            "command": "git checkout HEAD~^2~2",
+            "beforeCommand": "git commit; git checkout C0; git commit; git commit; git commit; git checkout main; git merge C5; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### Bunu təcrübədə tətbiq et",
+              "",
+              "Bu bölümü bitirmək üçün göstərilən yerdə yeni bir branch yarat.",
+              "",
+              "Əlbəttə, commit-i birbaşa göstərmək asan olardı (`C6` kimi bir şeylə), amma sənə bunun əvəzinə danışdığımız modifikatorları istifadə etməyi məsləhət görürəm!"
             ]
           }
         }

--- a/src/levels/mixed/describe.js
+++ b/src/levels/mixed/describe.js
@@ -35,7 +35,8 @@ exports.level = {
     "pl": "Git describe",
     "tr_TR": "git describe",
     "ta_IN": "Git விவரம்",
-    "hu_HU": "Git describe"
+    "hu_HU": "Git describe",
+    "az": "Git Describe"
   },
   "hint": {
     "en_US": "Just commit once on bugFix when you're ready to move on",
@@ -62,7 +63,8 @@ exports.level = {
     "pl": "Scommituj raz na bugFix, żeby przejść dalej",
     "ta_IN": "நீங்கள் தொடர தயாராக இருக்கும்போது bugFix இல் ஒருமுறை commit செய்யவும்.",
     "tr_TR": "Hazır olduğunuzda bugFix üzerine sadece bir commit atmanız yeterlidir.",
-    "hu_HU": "Ha készen állsz, csak commitolj egyszer a bugFix ágon"
+    "hu_HU": "Ha készen állsz, csak commitolj egyszer a bugFix ágon",
+    "az": "Davam etməyə hazır olduğunda, sadəcə bugFix üzərində bir dəfə commit et"
   },
   "startDialog": {
     "en_US": {
@@ -1576,6 +1578,69 @@ exports.level = {
               "Ennyi az egész a git describe-ról! Próbáld ki a parancsot a szint néhány pontján, hogy megszokd a használatát.",
               "",
               "Ha készen állsz, csak commitolj egyszer a szint befejezéséhez. Ingyen adjuk :P"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### Git Describe",
+              "",
+              "Tag-lər kod bazasında çox yaxşı \"lövbər\" rolunu oynadığı üçün, git-in ən yaxın \"lövbərə\" (yəni tag-a) nisbətən harada olduğunu *təsvir edən* bir komandası var. Və bu komanda `git describe` adlanır!",
+              "",
+              "Git describe, tarixçədə çoxlu commit irəli və ya geri hərəkət etdikdən sonra özünü oriyentasiya etməyə kömək edir; bu, bir git bisect (debaq axtarışı) başa çatdıqdan sonra və ya təzəcə məzuniyyətdən qayıdan həmkarının kompüterinin arxasında oturanda baş verə bilər."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Git describe aşağıdakı formadadır:",
+              "",
+              "`git describe <ref>`",
+              "",
+              "Burada `<ref>` git-in commit-ə çevirə biləcəyi istənilən şeydir. Əgər ref göstərməsən, git sadəcə hazırda checkout etdiyin yeri (`HEAD`) istifadə edir.",
+              "",
+              "Komandanın nəticəsi belə görünür:",
+              "",
+              "`<tag>-<numCommits>-g<hash>`",
+              "",
+              "Burada `tag` tarixçədəki ən yaxın əcdad tag-dır, `numCommits` həmin tag-dan neçə commit uzaqda olduğunu göstərir, `<hash>` isə təsvir olunan commit-in hash-idir."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl tez bir nümunəyə baxaq. Aşağıdakı ağac üçün:"
+            ],
+            "afterMarkdowns": [
+              "`git describe main` komandası bunu çıxaracaq:",
+              "",
+              "`v1-2-gC2`",
+              "",
+              "`git describe side` isə bunu çıxaracaq:",
+              "",
+              "`v2-1-gC4`"
+            ],
+            "command": "git tag v2 C3",
+            "beforeCommand": "git commit; go -b side HEAD~1; gc; gc; git tag v1 C0"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Git describe haqqında bilməli olduğun demək olar ki, hər şey budur! Bu bölümdəki bir neçə yerini təsvir etməyə çalış ki, komandanı hiss edəsən.",
+              "",
+              "Hazır olanda isə, bölümü bitirmək üçün sadəcə bir dəfə commit et. Bunu sənə hədiyyə edirik :P"
             ]
           }
         }

--- a/src/levels/mixed/grabbingOneCommit.js
+++ b/src/levels/mixed/grabbingOneCommit.js
@@ -38,7 +38,8 @@ exports.level = {
     "pl": "Wzięcie tylko 1 commita",
     "ta_IN": "ஒரே ஒரு commit மட்டும் எடுப்பது",
     "tr_TR": "Sadece 1 commit'i yakalamak",
-    "hu_HU": "Csak 1 commit átvétele"
+    "hu_HU": "Csak 1 commit átvétele",
+    "az": "Cəmi 1 commit-i götürmək"
   },
   "hint": {
     "en_US": "Remember, interactive rebase or cherry-pick is your friend here",
@@ -65,7 +66,8 @@ exports.level = {
     "pl": "Pamiętaj, że znasz już interaktywny rebase oraz cherry-pick",
     "ta_IN": "மறவாதீர்கள், interactive rebase அல்லது cherry-pick இங்கே உங்கள் நண்பர்",
     "tr_TR": "Unutmayın interactive rebase ve cherry-pick buradaki en iyi dostlarınız.",
-    "hu_HU": "Ne feledd, az interaktív rebase vagy a cherry-pick a barátod ebben"
+    "hu_HU": "Ne feledd, az interaktív rebase vagy a cherry-pick a barátod ebben",
+    "az": "Yadında saxla, interactive rebase və ya cherry-pick burada sənin dostundur"
   },
   "startDialog": {
     "en_US": {
@@ -1041,6 +1043,45 @@ exports.level = {
           "options": {
             "markdowns": [
               "Ez egy haladóbb szint, ezért rád bízzuk, hogy melyik parancsot szeretnéd használni, de a szint teljesítéséhez gondoskodj arról, hogy a `main` megkapja azt a commitot, amelyre a `bugFix` mutat."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Lokal olaraq üst-üstə yığılmış commit-lər",
+              "",
+              "Tez-tez rast gəlinən development vəziyyəti: bir bug-ı izləməyə çalışıram, amma o kifayət qədər çətin tapılandır. Detektiv işimə kömək etmək üçün bir neçə debug əmri və bir neçə print ifadəsi əlavə edirəm.",
+              "",
+              "Bütün bu debugging / print ifadələri öz commit-lərindədir. Nəhayət bug-ı tapıram, düzəldirəm və sevinirəm!",
+              "",
+              "Yeganə problem odur ki, indi `bugFix`-i `main` branch-ına qaytarmalıyam. Əgər sadəcə `main`-i fast-forward etsəm, onda `main` bütün debug ifadələrimi alacaq ki, bu da arzuolunmazdır. Mütləq başqa bir yol olmalıdır..."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Git-ə deməliyik ki, commit-lərdən yalnız birini kopyalasın. Bu, işi daşımaqla bağlı əvvəlki bölümlərlə eynidir -- eyni əmrlərdən istifadə edə bilərik:",
+              "",
+              "* `git rebase -i`",
+              "* `git cherry-pick`",
+              "",
+              "Bu məqsədə çatmaq üçün."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu, sonrakı bölümlərdən biridir, ona görə də hansı əmrdən istifadə etmək istədiyini sənə buraxırıq, amma bölümü bitirmək üçün `main`-in `bugFix`-in işarə etdiyi commit-i aldığından əmin ol."
             ]
           }
         }

--- a/src/levels/mixed/jugglingCommits.js
+++ b/src/levels/mixed/jugglingCommits.js
@@ -42,7 +42,8 @@ exports.level = {
     "pl": "Żonglowanie commitami",
     "ta_IN": "Commitகளுடன் வித்தைகள்",
     "tr_TR": "Commit'leri Şekillendirme",
-    "hu_HU": "Commitok átrendezése"
+    "hu_HU": "Commitok átrendezése",
+    "az": "Commit-lərin Hoqqabazlığı"
   },
   "hint": {
     "en_US": "The first command is git rebase -i HEAD~2",
@@ -69,7 +70,8 @@ exports.level = {
     "pl": "Pierwsze polecenie to: git rebase -i HEAD~2",
     "ta_IN": "முதலில் கொடுக்கவேண்டிய கட்டளை git rebase -i HEAD~2",
     "tr_TR": "İlk komutunuz git rebase -i HEAD~2",
-    "hu_HU": "Az első parancs: git rebase -i HEAD~2"
+    "hu_HU": "Az első parancs: git rebase -i HEAD~2",
+    "az": "İlk əmr git rebase -i HEAD~2 olmalıdır"
   },
   "startDialog": {
     "en_US": {
@@ -925,6 +927,40 @@ exports.level = {
               "Végül figyelj a célállapotra itt -- mivel a commitokat kétszer mozgatjuk, mindkettőhöz hozzáadódik egy aposztróf. Az általunk módosított commithoz egy további aposztróf adódik, ami megadja a fa végleges formáját.",
               "",
               "Azzal együtt, most már tudom összehasonlítani a szinteket szerkezet és relatív aposztróf-különbségek alapján. Amíg a fád `main` ága azonos szerkezettel és relatív aposztróf-különbségekkel rendelkezik, teljes pontot adok."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Commit-lərin Hoqqabazlığı",
+              "",
+              "Budur, kifayət qədər tez-tez baş verən başqa bir vəziyyət. Bir-biri ilə əlaqəli olan bəzi dəyişikliklərin (`newImage`) və başqa bir dəyişiklik dəstinin (`caption`) var, ona görə də onlar repozitoriyanda üst-üstə yığılıb (yəni bir-birinin ardınca gəlir).",
+              "",
+              "Çətin məqam odur ki, bəzən daha əvvəlki bir commit-də kiçik bir dəyişiklik etməyə ehtiyacın olur. Bu halda, dizayn komandası bizdən `newImage`-in ölçülərini bir az dəyişməyimizi istəyir, hətta həmin commit tarixçəmizdə çox geridə olsa belə!!"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu çətinliyi aşağıdakıları edərək aradan qaldıracağıq:",
+              "",
+              "* `git rebase -i` ilə commit-ləri elə yenidən sıralayacağıq ki, dəyişmək istədiyimiz commit üstdə olsun",
+              "* Kiçik dəyişikliyi etmək üçün `git commit --amend` işlədəcəyik",
+              "* Sonra `git rebase -i` ilə commit-ləri əvvəlki sırasına qaytaracağıq",
+              "* Nəhayət, bölümü bitirmək üçün main-i ağacın bu yenilənmiş hissəsinə köçürəcəyik (özün seçdiyin üsulla)",
+              "",
+              "Bu ümumi məqsədə çatmağın bir çox yolu var (görürəm, cherry-pick-ə göz qoyursan), və sonra onlardan bir neçəsini də görəcəyik, amma hələlik bu texnikaya fokuslanaq.",
+              "Sonda, buradakı hədəf vəziyyətə diqqət et -- commit-ləri iki dəfə köçürdüyümüz üçün, hər ikisinə bir apostrof əlavə olunur. Amend etdiyimiz commit üçün isə daha bir apostrof əlavə olunur ki, bu da bizə ağacın son formasını verir ",
+              "",
+              "Bunu deməklə, indi bölümləri struktur və nisbi apostrof fərqlərinə əsasən müqayisə edə bilərəm. Ağacındakı `main` branch-ı eyni struktura və nisbi apostrof fərqlərinə malik olduğu müddətcə, sənə tam bal verəcəyəm."
             ]
           }
         }

--- a/src/levels/mixed/jugglingCommits2.js
+++ b/src/levels/mixed/jugglingCommits2.js
@@ -41,7 +41,8 @@ exports.level = {
     "pl": "Żonglowanie commitami #2",
     "ta_IN": "Commitகளுடன் வித்தைகள் #2",
     "tr_TR": "Commit'leri Şekillendirme #2",
-    "hu_HU": "Commitok átrendezése #2"
+    "hu_HU": "Commitok átrendezése #2",
+    "az": "Commit Hoqqabazlığı #2"
   },
   "hint": {
     "en_US": "Don't forget to forward main to the updated changes!",
@@ -68,7 +69,8 @@ exports.level = {
     "pl": "Nie zapomnij sforwardować maina do najnowszych zmian!",
     "ta_IN": "Main ஐ புதுப்பிக்கப்பட்ட மாற்றங்களுக்கு முன்னேற்றமிடுவதை மறக்க வேண்டாம்!",
     "tr_TR": "Main'i yaptığınız değişikliklere ilerletmeyi unutmayın!",
-    "hu_HU": "Ne feledd a main-t a frissített változásokra előregörgetni!"
+    "hu_HU": "Ne feledd a main-t a frissített változásokra előregörgetni!",
+    "az": "main-i yenilənmiş dəyişikliklərə irəli aparmağı unutma!"
   },
   "startDialog": {
     "en_US": {
@@ -1094,6 +1096,49 @@ exports.level = {
               "Tehát ezen a szinten érjük el ugyanazt a célt -- módosítsuk a `C2`-t --, de kerüljük el a `rebase -i` használatát. Rád bízom, hogy kitaláld! :D",
               "",
               "Ne feledd, a commitokon lévő aposztrófok (') pontos száma nem fontos, csak a relatív különbségek számítanak. Például, teljes pontot adok egy olyan fára, amely megfelel a célnak, de mindenhol egy extra aposztróffal rendelkezik."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Commit Hoqqabazlığı #2",
+              "",
+              "*Əgər Commit Hoqqabazlığı #1-i (əvvəlki bölümü) bitirməmisənsə, davam etməzdən əvvəl xahiş edirəm onu bitir*",
+              "",
+              "Əvvəlki bölümdə gördüyün kimi, commit-ləri yenidən sıralamaq üçün `rebase -i`-dan istifadə etdik. Dəyişdirmək istədiyimiz commit yuxarıya çıxan kimi, onu asanlıqla --amend edə və istədiyimiz sıraya geri qaytara bildik.",
+              "",
+              "Buradakı yeganə problem odur ki, çoxlu yenidən sıralama gedir, bu da rebase konfliktlərinə səbəb ola bilər. Gəl `git cherry-pick` ilə başqa bir metoda baxaq."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Yadında saxla ki, git cherry-pick ağacın istənilən yerindən bir commit-i götürüb HEAD-in üzərinə qoyacaq (bir şərtlə ki, həmin commit HEAD-in əcdadı olmasın).",
+              "",
+              "Budur kiçik bir xatırlatma demo:"
+            ],
+            "afterMarkdowns": [
+              "Əla! Davam edək."
+            ],
+            "command": "git cherry-pick C2",
+            "beforeCommand": "git checkout -b bugFix; git commit; git checkout main; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Beləliklə, bu bölümdə eyni məqsədə çatmağa çalışaq — `C2`-ni bir dəfə amend et — amma `rebase -i`-dan istifadə etməkdən çəkin. Bunu necə edəcəyini sənə buraxıram! :D",
+              "",
+              "Yadında saxla, commit üzərindəki apostrofların (') dəqiq sayı vacib deyil, yalnız nisbi fərqlər önəmlidir. Məsələn, hədəf ağacla üst-üstə düşən, amma hər yerdə bir artıq apostrofu olan ağacı da düzgün sayacağam."
             ]
           }
         }

--- a/src/levels/mixed/tags.js
+++ b/src/levels/mixed/tags.js
@@ -27,7 +27,8 @@ exports.level = {
     "pl": "Tagi Gita",
     "ta_IN": "Git டேக்கள்",
     "tr_TR": "Git Tagleri",
-    "hu_HU": "Git tagek"
+    "hu_HU": "Git tagek",
+    "az": "Git Tag-lər"
   },
   "hint": {
     "en_US": "you can either check out the commit directly or simply checkout the tag!",
@@ -54,7 +55,8 @@ exports.level = {
     "pl": "Możesz checkoutować commit bezpośrednio lub po prostu tag!",
     "ta_IN": "நீங்கள் நேரடியாக commit ஐ அல்லது tag ஐ checkout செய்யலாம்!",
     "tr_TR": "İsterseniz direkt commit'e veya direkt tag'e checkout yapabilirsiniz!",
-    "hu_HU": "Közvetlenül checkoutolhatod a commitot, vagy egyszerűen a taget!"
+    "hu_HU": "Közvetlenül checkoutolhatod a commitot, vagy egyszerűen a taget!",
+    "az": "İstəsən, birbaşa commit-i checkout edə bilərsən, ya da sadəcə tag-ı checkout et!"
   },
   "startDialog": {
     "en_US": {
@@ -1302,6 +1304,58 @@ exports.level = {
               "Ehhez a szinthez csak hozd létre a tageket a célvizualizációban, majd checkoutold a `v1`-et. Figyelj, hogyan kerülsz leválasztott (`detached`) `HEAD` állapotba -- ez azért van, mert nem commitolhatsz közvetlenül a `v1` tagre.",
               "",
               "A következő szinten egy érdekesebb felhasználási esetet vizsgálunk meg a tagek esetén."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Tag-lər",
+              "",
+              "Əvvəlki bölümlərdən öyrəndiyin kimi, branch-ları asanlıqla yerini dəyişmək olar və onların üzərində iş tamamlandıqca tez-tez fərqli commit-lərə işarə edirlər. Branch-lar asanlıqla dəyişir, çox vaxt müvəqqəti olur və həmişə dəyişkəndir.",
+              "",
+              "Belədirsə, bəlkə də düşünürsən ki, layihənin tarixindəki nöqtələri *daimi* olaraq qeyd etməyin bir yolu varmı. Böyük buraxılışlar (release) və böyük merge-lər kimi şeylər üçün, bu commit-ləri branch-dan daha daimi bir şeylə qeyd etməyin yolu varmı?",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Əlbəttə var! Git tag-lər məhz bu məqsəd üçündür -- onlar müəyyən commit-ləri (bir qədər) daimi olaraq \"mərhələ\" (milestone) kimi qeyd edir və sonra branch kimi onlara istinad edə bilərsən.",
+              "",
+              "Daha vacibi isə, yeni commit-lər yaradıldıqca onlar heç vaxt yerini dəyişmir. Bir tag-ı \"checkout\" edib sonra o tag üzərində işi tamamlaya bilmirsən -- tag-lar commit ağacında müəyyən yerləri göstərən lövbərlər kimi mövcuddur.",
+              "",
+              "Gəl görək tag-lar əməli olaraq necə görünür."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl `C1`-də bir tag yaratmağa cəhd edək -- bu bizim 1-ci versiya prototipimizdir."
+            ],
+            "afterMarkdowns": [
+              "Budur! Kifayət qədər asan. Tag-a `v1` adı verdik və birbaşa `C1` commit-inə istinad etdik. Əgər commit-i qeyd etməsən, git sadəcə `HEAD`-in olduğu yeri istifadə edəcək."
+            ],
+            "command": "git tag v1 C1",
+            "beforeCommand": "git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölüm üçün sadəcə hədəf vizuallaşdırmasındakı tag-ları yarat və sonra `v1`-i checkout et. Necə detached `HEAD` vəziyyətinə keçdiyinə diqqət et -- bunun səbəbi `v1` tag-ının üzərinə birbaşa commit edə bilməməyindir.",
+              "",
+              "Növbəti bölümdə tag-lar üçün daha maraqlı bir istifadə halını araşdıracağıq."
             ]
           }
         }

--- a/src/levels/rampup/cherryPick.js
+++ b/src/levels/rampup/cherryPick.js
@@ -30,7 +30,8 @@ exports.level = {
     "pl": "Wprowadzenie do cherry-pick",
     "ta_IN": "Cherry-pick அறிமுகம்",
     "tr_TR": "Cherry-pick işlemine giriş",
-    "hu_HU": "Cherry-pick bevezetés"
+    "hu_HU": "Cherry-pick bevezetés",
+    "az": "Cherry-pick-ə Giriş"
   },
   "hint": {
     "fr_FR": "git cherry-pick suivi par les noms de commits",
@@ -56,7 +57,8 @@ exports.level = {
     "pl": "git cherry-pick a po nim nazwy commitów!",
     "ta_IN": "git cherry-pick க்கு பிறகு commit பெயர்களை பின்தொடரவும்!",
     "tr_TR": "git cherry-pick  komutunun ardından, seçilen commit'lerin adlarını yazın!",
-    "hu_HU": "A git cherry-pick után add meg a commit neveket!"
+    "hu_HU": "A git cherry-pick után add meg a commit neveket!",
+    "az": "git cherry-pick-dən sonra commit adlarını yaz!"
   },
   "startDialog": {
     "en_US": {
@@ -1418,6 +1420,63 @@ exports.level = {
           "options": {
             "markdowns": [
               "A szint teljesítéséhez egyszerűen másold át a három branchből a munkát a main-be. Megláthatod, melyik commitokat szeretnénk, ha megnézed a cél vizualizációt.",
+              ""
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## İşi Daşımaq",
+              "",
+              "İndiyə qədər git-in əsaslarını öyrəndik -- commit etmək, branch yaratmaq və source tree daxilində hərəkət etmək. Bu anlayışlar git repozitoriyalarının gücünün 90%-indən istifadə etmək və proqramçıların əsas ehtiyaclarını ödəmək üçün kifayətdir.",
+              "",
+              "Ancaq qalan 10%, mürəkkəb iş axınları zamanı (və ya özünü çətin vəziyyətə saldığın zaman) olduqca faydalı ola bilər. Növbəti öyrənəcəyimiz anlayış \"işi daşımaq\"dır -- başqa sözlə, bu, proqramçıların \"bu işi burada, o işi isə orada istəyirəm\" deməsinin dəqiq, aydın və çevik bir yoludur.",
+              "",
+              "Bu, çox kimi görünə bilər, amma sadə bir anlayışdır."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git Cherry-pick",
+              "",
+              "Bu seriyadakı ilk əmr `git cherry-pick` adlanır. Aşağıdakı formada istifadə olunur:",
+              "",
+              "* `git cherry-pick <Commit1> <Commit2> <...>`",
+              "",
+              "Bu, hazırkı mövqeyinin (`HEAD`) altına bir sıra commit-i kopyalamaq istədiyini bildirmək üçün çox sadə bir yoldur. Şəxsən mən `cherry-pick`-i çox sevirəm, çünki içində çox az sehr var və başa düşülməsi asandır.",
+              "",
+              "Gəl bir demo görək!",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Budur, `side` branch-ında `main`-ə kopyalamaq istədiyimiz bəzi işlərin olduğu bir repozitoriya. Bu, artıq öyrəndiyimiz rebase vasitəsilə də edilə bilərdi, amma gəl cherry-pick-in necə işlədiyinə baxaq."
+            ],
+            "afterMarkdowns": [
+              "Hamısı bu qədər! Biz `C2` və `C4` commit-lərini istəyirdik və git onları düz altımıza qoydu. Bu qədər sadədir!"
+            ],
+            "command": "git cherry-pick C2 C4",
+            "beforeCommand": "git checkout -b side; git commit; git commit; git commit; git checkout main; git commit;"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü bitirmək üçün sadəcə göstərilən üç branch-dan bəzi işləri main-ə kopyala. Hansı commit-ləri istədiyimizi hədəf vizuallaşdırmasına baxaraq görə bilərsən.",
               ""
             ]
           }

--- a/src/levels/rampup/detachedHead.js
+++ b/src/levels/rampup/detachedHead.js
@@ -27,7 +27,8 @@ exports.level = {
     "pl": "Odczep sobie HEAD",
     "tr_TR": "HEAD'i Ayır",
     "ta_IN": "உங்கள் HEAD ஐப் பிரிகொள்ளுங்கள்",
-    "hu_HU": "Fejlécz le! (Detach HEAD)"
+    "hu_HU": "Fejlécz le! (Detach HEAD)",
+    "az": "HEAD'ini Ayır"
   },
   "hint": {
     "en_US": "Use the label (hash) on the commit for help!",
@@ -53,7 +54,8 @@ exports.level = {
     "pl": "Użyj nazwy commita (hasza)!",
     "ta_IN": "உங்களுக்கு உதவ commit இன் லேபிள் (hash) ஐப் பயன்படுத்துங்கள்!",
     "tr_TR": "Yardım için commit üzerindeki etiket (hash) değerini kullanın!",
-    "hu_HU": "Használd a commit azonosítóját (hash)!"
+    "hu_HU": "Használd a commit azonosítóját (hash)!",
+    "az": "Kömək üçün commit üzərindəki etiketdən (hash) istifadə et!"
   },
   "startDialog": {
     "en_US": {
@@ -1905,6 +1907,84 @@ exports.level = {
               "A szint teljesítéséhez válasszuk le a HEAD-et a `bugFix`-ről, és csatoljuk inkább a commithoz.",
               "",
               "Adja meg ezt a commitot a hash-e alapján. Az egyes commitok hash-e megjelenik a commitot jelképező körön."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git-də Hərəkət Etmək",
+              "",
+              "Git-in daha qabaqcıl xüsusiyyətlərinə keçməzdən əvvəl, layihəni təmsil edən commit ağacında hərəkət etməyin müxtəlif yollarını başa düşmək vacibdir.",
+              "",
+              "Hərəkət etməyə vərdiş etdikdən sonra, digər git əmrlərindəki gücün artacaq!",
+              "",
+              "",
+              "",
+              "",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## HEAD",
+              "",
+              "Əvvəlcə \"HEAD\" haqqında danışmalıyıq. HEAD hazırda checkout edilmiş commit-in simvolik adıdır -- əslində üzərində işlədiyin commit budur.",
+              "",
+              "HEAD həmişə iş ağacında əks olunan ən son commit-ə işarə edir. İş ağacında dəyişiklik edən git əmrlərinin əksəriyyəti HEAD-i dəyişməklə başlayır.",
+              "",
+              "Adətən HEAD bir branch adına (məsələn, bugFix) işarə edir. Commit etdikdə, bugFix-in vəziyyəti dəyişir və bu dəyişiklik HEAD vasitəsilə görünür."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Bunu əməldə görək. Burada commit-dən əvvəl və sonra HEAD-i aşkar edəcəyik."
+            ],
+            "afterMarkdowns": [
+              "Bax! HEAD bütün bu müddət `main` branch-ımızın altında gizlənirmiş."
+            ],
+            "command": "git checkout C1; git checkout main; git commit; git checkout C2",
+            "beforeCommand": ""
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "### HEAD-i Ayırmaq",
+              "",
+              "HEAD-i ayırmaq sadəcə onu branch əvəzinə commit-ə bağlamaq deməkdir. Bundan əvvəl belə görünür:",
+              "",
+              "HEAD -> main -> C1",
+              ""
+            ],
+            "afterMarkdowns": [
+              "İndi isə belədir",
+              "",
+              "HEAD -> C1"
+            ],
+            "command": "git checkout C1",
+            "beforeCommand": ""
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü bitirmək üçün gəl HEAD-i `bugFix`-dən ayıraq və onun əvəzinə commit-ə bağlayaq.",
+              "",
+              "Bu commit-i hash-i ilə göstər. Hər commit-in hash-i onu təmsil edən dairənin üzərində göstərilir."
             ]
           }
         }

--- a/src/levels/rampup/interactiveRebase.js
+++ b/src/levels/rampup/interactiveRebase.js
@@ -30,7 +30,8 @@ exports.level = {
     "pl": "Możesz użyć gałęzi lub referencji względnych (HEAD~), aby określić cel rebase'a",
     "ta_IN": "நீங்கள் rebase இலக்கை குறிப்பதற்கு கிளைகள் அல்லது பொருந்திய ரெஃபரன்ஸ்கள் (HEAD~) பயன்படுத்த முடியும்",
     "tr_TR": "Rebase hedefini belirtmek için ya dalları ya da göreli referansları (HEAD~) kullanabilirsiniz",
-    "hu_HU": "A rebase célját megadhatod branchekkel vagy relatív hivatkozásokkal (HEAD~)"
+    "hu_HU": "A rebase célját megadhatod branchekkel vagy relatív hivatkozásokkal (HEAD~)",
+    "az": "Rebase hədəfini göstərmək üçün branch-lardan və ya nisbi ref-lərdən (HEAD~) istifadə edə bilərsən"
   },
   "name": {
     "en_US": "Interactive Rebase Intro",
@@ -56,7 +57,8 @@ exports.level = {
     "pl": "Wprowadzenie do interaktywnego rebase'a",
     "ta_IN": "இன்டராக்டிவ் ரீபெஸ் அறிமுகம்",
     "tr_TR": "Etkileşimli Rebase'e Giriş",
-    "hu_HU": "Interaktív rebase bevezetés"
+    "hu_HU": "Interaktív rebase bevezetés",
+    "az": "İnteraktiv Rebase-yə giriş"
   },
   "startDialog": {
     "en_US": {
@@ -1626,6 +1628,72 @@ exports.level = {
           "options": {
             "markdowns": [
               "A szint befejezéséhez végezz el egy interaktív rebase-t, és érd el a cél vizualizációban látható sorrendet. Ne feledd, hogy mindig használhatod az `undo` vagy `reset` parancsot a hibák javítására :D"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git İnteraktiv Rebase",
+              "",
+              "Git cherry-pick, hansı commit-ləri istədiyini bildiyin zaman (_və_ onların uyğun hash-lərini də bildiyin zaman) əladır -- verdiyi sadəliyi keçmək çətindir.",
+              "",
+              "Bəs hansı commit-ləri istədiyini bilmədiyin vəziyyətdə nə etməli? Xoşbəxtlikdən git bunu da düşünüb! Bunun üçün interaktiv rebase-dən istifadə edə bilərik -- bu, rebase etmək istədiyin bir sıra commit-ə nəzər salmağın ən yaxşı yoludur.",
+              "",
+              "Gəl detallara keçək..."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "İnteraktiv rebase sadəcə Git-in `rebase` əmrini `-i` seçimi ilə istifadə etməsi deməkdir.",
+              "",
+              "Bu seçimi əlavə etsən, git rebase-in hədəfinin altına kopyalanacaq commit-ləri göstərən bir interfeys açacaq. Həmçinin onların commit hash-lərini və mesajlarını da göstərir ki, bu da nəyin nə olduğunu anlamaq üçün əladır.",
+              "",
+              "\"Əsl\" git-də, bu interfeys pəncərəsi `vim` kimi bir mətn redaktorunda fayl açmaq deməkdir. Bizim məqsədimiz üçün isə eyni şəkildə davranan kiçik bir dialoq pəncərəsi qurmuşam."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "İnteraktiv rebase dialoqu açıldıqda, tədris tətbiqimizdə iki şey etmək imkanın var:",
+              "",
+              "* Commit-lərin sırasını sadəcə interfeysdə (siçanla sürükləyib buraxaraq) dəyişməklə yenidən sıralaya bilərsən.",
+              "* Bütün commit-ləri saxlamağı və ya müəyyən olanları atmağı seçə bilərsən. Dialoq açıldıqda, hər commit yanındakı `pick` düyməsi aktiv olduğu üçün daxil edilməyə təyin olunub. Bir commit-i atmaq üçün onun `pick` düyməsini söndür.",
+              "",
+              "*Qeyd etmək lazımdır ki, əsl git-in interaktiv rebase-ində squash etmək (birləşdirmək), commit mesajlarını dəyişmək və hətta commit-lərin özünü redaktə etmək kimi daha çox şey edə bilərsən. Bizim məqsədimiz üçün isə yuxarıdakı iki əməliyyata fokuslanacağıq.*",
+              "",
+              "Əla! Gəl bir nümunəyə baxaq."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Düyməyə basdıqda, interaktiv rebase pəncərəsi görünəcək. Bəzi commit-lərin sırasını dəyiş (yaxud bəzilərini seçmə) və nəticəyə bax!"
+            ],
+            "afterMarkdowns": [
+              "Bum! Git commit-ləri tam olaraq interfeys vasitəsilə göstərdiyin kimi kopyaladı."
+            ],
+            "command": "git rebase -i HEAD~4 --aboveAll",
+            "beforeCommand": "git commit; git commit; git commit; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü bitirmək üçün interaktiv rebase et və hədəf vizuallaşdırmasında göstərilən sıraya nail ol. Unutma ki, səhvləri düzəltmək üçün həmişə `undo` və ya `reset` edə bilərsən :D"
             ]
           }
         }

--- a/src/levels/rampup/relativeRefs.js
+++ b/src/levels/rampup/relativeRefs.js
@@ -26,7 +26,8 @@ exports.level = {
     "pl": "Referencje względne (^)",
     "tr_TR": "İlgili Referanslar (^)",
     "ta_IN": "உதவிக்குறிப்பு குறிப்பிடல்கள் (^)",
-    "hu_HU": "Relatív hivatkozások (^)"
+    "hu_HU": "Relatív hivatkozások (^)",
+    "az": "Nisbi Ref-lər (^)"
   },
   "hint": {
     "en_US": "Remember the Caret (^) operator!",
@@ -52,7 +53,8 @@ exports.level = {
     "pl": "Pamiętaj o operatorze wstawienia (^)!",
     "ta_IN": "உதவிக்குறிப்பை (^), மறக்காதீர்கள்!",
     "tr_TR": "^ operatörünü hatırlayın!",
-    "hu_HU": "Ne feledd a kalap (^) operátort!"
+    "hu_HU": "Ne feledd a kalap (^) operátort!",
+    "az": "Caret (^) operatorunu yadında saxla!"
   },
   "startDialog": {
     "en_US": {
@@ -1775,6 +1777,81 @@ exports.level = {
               "A szint teljesítéséhez válts a `bugFix` szülő commitjára. Ez leválasztja a `HEAD`-et.",
               "",
               "Ha akarod, megadhatod a hash-t, de próbálj inkább relatív hivatkozásokat használni!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Nisbi Ref-lər",
+              "",
+              "Git-də commit hash-lərini göstərməklə hərəkət etmək bir az yorucu ola bilər. Real dünyada terminalının yanında belə gözəl bir commit ağacı vizuallaşdırması olmayacaq, ona görə hash-ləri görmək üçün `git log`-dan istifadə etməli olacaqsan.",
+              "",
+              "Üstəlik, real Git dünyasında hash-lər adətən xeyli daha uzun olur. Məsələn, əvvəlki bölümü təqdim edən commit-in hash-i `fed2da64c0efc5293610bdd892f82a58e8cbc5d8`-dir. Deyəndə dil süründürmür...",
+              "",
+              "Yaxşı tərəfi odur ki, Git hash-lər barədə ağıllıdır. O, yalnız commit-i unikal şəkildə identifikasiya edən qədər simvol yazmağını tələb edir. Beləliklə, yuxarıdakı uzun sətir əvəzinə sadəcə `fed2` yaza bilərəm."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Dediyim kimi, commit-ləri hash-lə göstərmək heç də ən rahat üsul deyil, elə buna görə də Git-də nisbi ref-lər var. Onlar möhtəşəmdir!",
+              "",
+              "Nisbi ref-lərlə yadda qalan bir yerdən (məsələn, `bugFix` branch-ı və ya `HEAD`) başlaya və oradan davam edə bilərsən.",
+              "",
+              "Nisbi commit-lər güclüdür, amma biz burada iki sadə üsulu təqdim edəcəyik:",
+              "",
+              "* `^` ilə hər dəfə bir commit yuxarı hərəkət etmək",
+              "* `~<say>` ilə bir neçə dəfə yuxarı hərəkət etmək"
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl əvvəlcə Caret (^) operatoruna baxaq. Onu bir ref adının sonuna hər əlavə etdiyində, Git-ə göstərilən commit-in valideynini tapmasını deyirsən.",
+              "",
+              "Beləliklə, `main^` demək \"`main`-in birinci valideyni\" deməkdir.",
+              "",
+              "`main^^` isə `main`-in babası (ikinci nəsil əcdadı)dır",
+              "",
+              "Gəl burada main-in üstündəki commit-i checkout edək."
+            ],
+            "afterMarkdowns": [
+              "Bumm! Oldu. Commit hash-ini yazmaqdan qat-qat asandır."
+            ],
+            "command": "git checkout main^",
+            "beforeCommand": "git commit"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "`HEAD`-i də nisbi ref kimi istifadə edə bilərsən. Gəl commit ağacında yuxarı hərəkət etmək üçün onu bir neçə dəfə işlədək."
+            ],
+            "afterMarkdowns": [
+              "Asandır! `HEAD^` ilə zamanda geriyə səyahət edə bilərik"
+            ],
+            "command": "git checkout C3; git checkout HEAD^; git checkout HEAD^; git checkout HEAD^",
+            "beforeCommand": "git commit; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü bitirmək üçün `bugFix`-in valideyn commit-ini checkout et. Bu, `HEAD`-i ayıracaq (detached HEAD).",
+              "",
+              "İstəsən hash-i göstərə bilərsən, amma bunun əvəzinə nisbi ref-lərdən istifadə etməyə çalış!"
             ]
           }
         }

--- a/src/levels/rampup/relativeRefs2.js
+++ b/src/levels/rampup/relativeRefs2.js
@@ -26,7 +26,8 @@ exports.level = {
     "pl": "Aby ukończyć ten poziom, musisz użyć co najmniej jednej bezpośredniej referencji (hasza).",
     "ta_IN": "இந்த நிலவை முடிக்க குறைந்தது ஒரு நேரடி குறிப்பு (ஹாஷ்) பயன்படுத்த வேண்டும்",
     "tr_TR": "Bu seviyeyi tamamlamak için en az bir doğrudan referans (hash) kullanmanız gerekecek",
-    "hu_HU": "A szint teljesítéséhez legalább egy közvetlen hivatkozást (hash) kell használnod"
+    "hu_HU": "A szint teljesítéséhez legalább egy közvetlen hivatkozást (hash) kell használnod",
+    "az": "Bu bölümü bitirmək üçün ən azı bir birbaşa istinaddan (hash) istifadə etməlisən"
   },
   "name": {
     "en_US": "Relative Refs #2 (~)",
@@ -52,7 +53,8 @@ exports.level = {
     "pl": "Referencje względne #2 (~)",
     "ta_IN": "இணைக்கப்பட்ட குறிப்பு #2 (~)",
     "tr_TR": "Göreli Referanslar #2 (~)",
-    "hu_HU": "Relatív hivatkozások #2 (~)"
+    "hu_HU": "Relatív hivatkozások #2 (~)",
+    "az": "Nisbi Ref-lər #2 (~)"
   },
   "startDialog": {
     "en_US": {
@@ -1634,6 +1636,77 @@ exports.level = {
               "Most, hogy láttad a relatív hivatkozásokat és a branch kényszerítést kombinálva, használjuk ezeket a következő szint megoldásához.",
               "",
               "A szint teljesítéséhez mozgasd a `HEAD`-et, a `main`-t és a `bugFix`-et a megjelölt célállomásokra."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### \"~\" operatoru",
+              "",
+              "Tutaq ki, commit ağacında çoxlu səviyyə yuxarı qalxmaq istəyirsən. `^` işarəsini bir neçə dəfə yazmaq yorucu ola bilər, ona görə Git-də tilde (~) operatoru da var.",
+              "",
+              "",
+              "Tilde operatorunun sonuna (istəsən) neçə valideynə qədər yuxarı qalxmaq istədiyini göstərən bir ədəd əlavə edə bilərsən. Gəl, bunu əməldə görək."
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl, `~` ilə neçə commit geriyə qayıtmaq istədiyimizi göstərək."
+            ],
+            "afterMarkdowns": [
+              "Vay! Necə də yığcam -- nisbi ref-lər əladır."
+            ],
+            "command": "git checkout HEAD~4",
+            "beforeCommand": "git commit; git commit; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### Branch məcburiyyəti",
+              "",
+              "İndi sən nisbi ref-lər üzrə ekspertsən, ona görə gəl onlardan həqiqətən nə isə üçün *istifadə edək*.",
+              "",
+              "Mənim nisbi ref-lərdən istifadə etdiyim ən çox yayılmış yollardan biri branch-ları yerdəyişdirməkdir. Sən `-f` seçimi ilə bir branch-ı birbaşa başqa commit-ə yenidən təyin edə bilərsən. Məsələn, belə bir şey:",
+              "",
+              "`git branch -f main HEAD~3`",
+              "",
+              "main branch-ını (məcburi şəkildə) HEAD-dən üç valideyn geriyə köçürür.",
+              "",
+              "*Qeyd: Həqiqi git mühitində `git branch -f` əmrinə sənin cari branch-ın üçün icazə verilmir.*"
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "Gəl, əvvəlki əmri əməldə görək."
+            ],
+            "afterMarkdowns": [
+              "Budur! Nisbi ref-lər bizə `C1`-ə istinad etmək üçün yığcam bir yol verdi, branch məcburiyyəti (`-f`) isə bizə bir branch-ı tez bir şəkildə həmin yerə köçürmək imkanı verdi."
+            ],
+            "command": "git branch -f main HEAD~3",
+            "beforeCommand": "git commit; git commit; git commit; git checkout -b bugFix"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "İndi ki, nisbi ref-ləri və branch məcburiyyətini birlikdə gördün, gəl onlardan növbəti bölümü həll etmək üçün istifadə edək.",
+              "",
+              "Bu bölümü bitirmək üçün `HEAD`, `main` və `bugFix`-i göstərilən hədəf mövqelərinə köçür."
             ]
           }
         }

--- a/src/levels/rampup/reversingChanges.js
+++ b/src/levels/rampup/reversingChanges.js
@@ -27,7 +27,8 @@ exports.level = {
     "it_IT": "Annullare i cambiamenti in Git",
     "pl": "Odwracanie zmian w Gicie",
     "tr_TR": "Değişiklikleri Git'te Geri Almak",
-    "hu_HU": "Változtatások visszavonása Gitben"
+    "hu_HU": "Változtatások visszavonása Gitben",
+    "az": "Git-də Dəyişikliklərin Geri Qaytarılması"
   },
   "hint": {
     "en_US": "Notice that revert and reset take different arguments.",
@@ -52,7 +53,8 @@ exports.level = {
     "it_IT": "Revert e reset hanno parametri diversi.",
     "pl": "Zauważ, że revert i reset przyjmują różne argumenty",
     "tr_TR": "revert ve reset'in farklı parametreler aldığını unutma.",
-    "hu_HU": "Figyeld meg, hogy a revert és a reset különböző argumentumokat fogad."
+    "hu_HU": "Figyeld meg, hogy a revert és a reset különböző argumentumokat fogad.",
+    "az": "Qeyd et ki, revert və reset fərqli parametrlər qəbul edir."
   },
   "startDialog": {
     "en_US": {
@@ -1491,6 +1493,69 @@ exports.level = {
               "A szint teljesítéséhez vonja vissza a legutóbbi commitot mind a `local`, mind a `pushed` brancheken. Összesen két commitot fogsz visszavonni (branchenként egyet).",
               "",
               "Tartsd észben, hogy a `pushed` egy távoli branch, a `local` pedig egy helyi branch -- ez segíteni fog a módszerek megválasztásában."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Git-də Dəyişikliklərin Geri Qaytarılması",
+              "",
+              "Git-də dəyişiklikləri geri qaytarmağın bir çox yolu var. Məhz commit etmək kimi, Git-də dəyişikliklərin geri qaytarılmasının da aşağı səviyyəli tərəfi (ayrı-ayrı faylların və ya hissələrin stage edilməsi) və yuxarı səviyyəli tərəfi (dəyişikliklərin faktiki olaraq necə geri qaytarıldığı) var. Tətbiqimiz sonuncuya fokuslanacaq.",
+              "",
+              "Git-də dəyişiklikləri ləğv etməyin iki əsas yolu var -- biri `git reset`, digəri isə `git revert`-dən istifadə etməkdir. Növbəti dialoqda hər ikisinə baxacağıq",
+              ""
+            ]
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "## Git Reset",
+              "",
+              "`git reset` branch istinadını zamanda geriyə, daha köhnə bir commit-ə köçürməklə dəyişiklikləri geri qaytarır. Bu mənada onu \"tarixi yenidən yazmaq\" kimi düşünə bilərsən; `git reset` branch-ı elə geri aparacaq ki, sanki həmin commit heç vaxt edilməyib.",
+              "",
+              "Gəl görək bu necə görünür:"
+            ],
+            "afterMarkdowns": [
+              "Əla! Git `main` branch istinadını geri, `C1`-ə köçürdü; indi lokal repozitoriyamız sanki `C2` heç vaxt baş verməyib kimi bir vəziyyətdədir."
+            ],
+            "command": "git reset HEAD~1",
+            "beforeCommand": "git commit"
+          }
+        },
+        {
+          "type": "GitDemonstrationView",
+          "options": {
+            "beforeMarkdowns": [
+              "## Git Revert",
+              "",
+              "Reset öz komputerindəki lokal branch-lar üçün əla işləsə də, onun \"tarixi yenidən yazmaq\" metodu başqalarının istifadə etdiyi remote branch-lar üçün işləmir.",
+              "",
+              "Dəyişiklikləri geri qaytarmaq və bu geri qaytarılmış dəyişiklikləri başqaları ilə *paylaşmaq* üçün `git revert`-dən istifadə etməliyik. Gəl bunu əməldə görək."
+            ],
+            "afterMarkdowns": [
+              "Qəribədir, geri qaytarmaq istədiyimiz commit-in altında yeni bir commit peyda oldu. Bunun səbəbi odur ki, bu yeni `C2'` commit-i *dəyişikliklər* təqdim edir -- sadəcə bu dəyişikliklər məhz `C2` commit-ini dəqiq geri qaytaran dəyişikliklərdir.",
+              "",
+              "Revert etməklə, dəyişikliklərini başqaları ilə paylaşmaq üçün push edə bilərsən."
+            ],
+            "command": "git revert HEAD^",
+            "beforeCommand": "git commit; git commit"
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Bu bölümü tamamlamaq üçün, həm `local`, həm də `pushed` üzərindəki ən son commit-i geri qaytar. Ümumilikdə iki commit-i revert edəcəksən (hər branch üçün bir dənə).",
+              "",
+              "Yadında saxla ki, `pushed` remote branch, `local` isə lokal branch-dır -- bu, hansı metodları seçəcəyini müəyyən etməyə kömək edəcək."
             ]
           }
         }

--- a/src/levels/rebase/manyRebases.js
+++ b/src/levels/rebase/manyRebases.js
@@ -31,7 +31,8 @@ exports.level = {
     "it_IT": "Rebasing livello 9000",
     "pl": "Rebase ponad 9000 razy",
     "tr_TR": "9000 kereden fazla rebase işlemi yapmak",
-    "hu_HU": "Sok rebase"
+    "hu_HU": "Sok rebase",
+    "az": "9000-dən çox dəfə rebase etmək"
   },
   "hint": {
     "en_US": "Remember, the most efficient way might be to only update main at the end...",
@@ -57,7 +58,8 @@ exports.level = {
     "it_IT": "Ricorda, il modo migliore potrebbe essere di aggiornare il main alla fine...",
     "pl": "Pamiętaj, że najskuteczniejszym sposobem może być aktualizacja `main` dopiero na samym końcu...",
     "tr_TR": "Şunu hatırlamanı isterim ki: belki de en verimli yol işin sonunda maini güncellemektir.",
-    "hu_HU": "Ne feledd, a leghatékonyabb módszer talán az, ha a main-t csak a végén frissíted..."
+    "hu_HU": "Ne feledd, a leghatékonyabb módszer talán az, ha a main-t csak a végén frissíted...",
+    "az": "Yadında saxla, ən səmərəli yol bəlkə də main-i yalnız sonda yeniləməkdir..."
   },
   "startDialog": {
     "en_US": {
@@ -487,6 +489,24 @@ exports.level = {
               "A felsőbb vezetés azonban egy kicsit nehezebbé teszi ezt -- azt szeretnék, hogy az összes commit sorban legyen egymás után. Ez azt jelenti, hogy a végső fánkon a `C7'`-nek legyen legalul, a `C6'` fölötte, és így tovább, sorban.",
               "",
               "Ha elrontod útközben, nyugodtan használd a `reset`-et az újrakezdéshez. Feltétlenül nézd meg a megoldásunkat, és nézd meg, hogy kevesebb paranccsal is megoldható-e!"
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "### Bir neçə Branch-ı Rebase Etmək",
+              "",
+              "Burda çoxlu branch var! Gəl bu branch-lardakı bütün işi main-ə rebase edək.",
+              "",
+              "Ancaq yuxarı rəhbərlik işi bir az çətinləşdirir -- onlar bütün commit-lərin ardıcıl sırada olmasını istəyir. Bu o deməkdir ki, son ağacımızda `C7'` ən aşağıda, onun üstündə `C6'` və s. sırayla olmalıdır.",
+              "",
+              "Yol boyu səhv etsən, yenidən başlamaq üçün `reset`-dən istifadə et. Həllimizi mütləq yoxla və gör daha az əmrlə edə bilərsənmi!"
             ]
           }
         }

--- a/src/levels/rebase/selectiveRebase.js
+++ b/src/levels/rebase/selectiveRebase.js
@@ -30,7 +30,8 @@ exports.level = {
     "it_IT": "Rami spaghettificati",
     "pl": "Spaghetti gałęzi",
     "tr_TR": "Branch Spagettisi",
-    "hu_HU": "Ág-spagetti"
+    "hu_HU": "Ág-spagetti",
+    "az": "Branch Spagetti"
   },
   "hint": {
     "en_US": "Make sure to do everything in the proper order! Branch one first, then two, then three",
@@ -56,7 +57,8 @@ exports.level = {
     "it_IT": "Assicurati di fare tutto nel giusto ordine! Prima il primo ramo, poi il secondo, poi il terzo",
     "pl": "Upewnij się, że robisz wszystko w odpowiedniej kolejności! Gałąź pierwsza, potem druga, potem trzecia.",
     "tr_TR": "Her şeyi doğru sırada yaptığından emin ol! Önce ilk branch (one), ardından ikinci branch (two), ardından üçüncü branch (three)",
-    "hu_HU": "Ügyelj arra, hogy mindent a megfelelő sorrendben végezz el! Először a `one` ág, majd a `two`, aztán a `three`"
+    "hu_HU": "Ügyelj arra, hogy mindent a megfelelő sorrendben végezz el! Először a `one` ág, majd a `two`, aztán a `three`",
+    "az": "Hər şeyi düzgün ardıcıllıqla etdiyinə əmin ol! Əvvəl `one` branch, sonra `two`, sonra `three`"
   },
   "startDialog": {
     "en_US": {
@@ -534,6 +536,26 @@ exports.level = {
               "Az `one` ágnak át kell rendeznie ezeket a commitokat, és ki kell hagynia a `C5`-öt. A `two` ágnak csak át kell rendeznie a commitokat, a `three` ágnak pedig csak egy commitot kell átvennie!",
               "",
               "Rád bízzuk, hogy rájöjj, hogyan oldod meg -- ezután mindenképpen nézd meg a megoldásunkat a `show solution` paranccsal."
+            ]
+          }
+        }
+      ]
+    },
+    "az": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Branch Spagetti",
+              "",
+              "Vaaay! Bu bölümdə çatmalı olduğumuz kifayət qədər böyük bir hədəf var.",
+              "",
+              "Burda `main` var ki, `one`, `two` və `three` branch-larından bir neçə commit qabaqdadır. Nə səbəbdənsə, bu üç branch-ı main-dəki son bir neçə commit-in dəyişdirilmiş versiyaları ilə yeniləməliyik.",
+              "",
+              "`one` branch-ı həmin commit-lərin yenidən sıralanmasını və `C5`-in çıxarılmasını/atılmasını tələb edir. `two` branch-ı sadəcə commit-lərin sadə sıralanmasını tələb edir, `three` isə yalnız bir commit-in ötürülməsini tələb edir!",
+              "",
+              "Bunu necə həll edəcəyini özün tapacaqsan -- sonra mütləq `show solution` ilə həllimizi yoxla."
             ]
           }
         }


### PR DESCRIPTION
Completes the `az` (Azerbaijani) locale started in #1382 (intro, merged) and #1383 (remote, merged). This translates every remaining level and finishes the shared UI / error strings, so `az` is now full coverage.

## What's covered

**14 level files**, each with `az` `name` / `hint` / `startDialog` mirroring the `en_US` structure:
- `levels/rampup/*` (6): `cherryPick`, `detachedHead`, `interactiveRebase`, `relativeRefs`, `relativeRefs2`, `reversingChanges`
- `levels/mixed/*` (5): `describe`, `grabbingOneCommit`, `jugglingCommits`, `jugglingCommits2`, `tags`
- `levels/rebase/*` (2): `manyRebases`, `selectiveRebase`
- `levels/advanced/multipleParents.js` (1)

**`intl/strings.js`**: `az` for the remaining ~63 keys — git/hg command help, errors, warnings, sandbox commands (`show`, `cd`, `ls`, `locale`, …), level-builder, and UI chrome. Four keys are intentionally left to fall back to `en_US` where `az` would equal English (`git-dummy-msg`, `learn-git-branching`, `main`/`remote` level tabs).

## Translation approach

Same convention as #1382 / #1383: git commands stay in English, git terms are inflected with Azerbaijani suffixes (`commit-lər`, `branch-lar`, `rebase et`, `HEAD`, `valideyn` for *parent*). `tr_TR` was used as prior art for phrasing on the harder concepts (interactive rebase, cherry-pick, relative refs, multiple parents). `{placeholders}` and backtick code spans are preserved exactly.

## Verification

- `gulp fastBuild` + jshint clean
- all 313 specs pass
- rampup / mixed / rebase / advanced sequences render end-to-end at `?locale=az` — `name`, `hint`, and `startDialog` bodies all in Azerbaijani, UI chrome ("Bölüm seç", "Hədəfi Göstər", "Təlimatlar") localized, no untranslated markers and no layout breakage from the longer AZ strings