### PR TITLE
Add zh_CN and zh_TW translations for staging and restore levels

### DIFF
--- a/src/levels/workingDir/restore.js
+++ b/src/levels/workingDir/restore.js
@@ -4,10 +4,14 @@ exports.level = {
   "solutionCommand": "git restore --staged secret.env;git restore experiment.js;git commit",
   "startTree": '{"branches":{"main":{"target":"C1","id":"main"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"},"workingChanges":{"app.js":"staged","secret.env":"staged","experiment.js":"modified"}}',
   "name": {
-    "en_US": "Undoing with git restore"
+    "en_US": "Undoing with git restore",
+    "zh_CN": "使用 git restore 撤销修改",
+    "zh_TW": "使用 git restore 復原變更"
   },
   "hint": {
-    "en_US": "Unstage with `git restore --staged secret.env`, throw away the experiment with `git restore experiment.js`, then `git commit`."
+    "en_US": "Unstage with `git restore --staged secret.env`, throw away the experiment with `git restore experiment.js`, then `git commit`.",
+    "zh_CN": "使用 `git restore --staged secret.env` 取消暂存，使用 `git restore experiment.js` 丢弃实验性修改，然后执行 `git commit`。",
+    "zh_TW": "使用 `git restore --staged secret.env` 取消預存，使用 `git restore experiment.js` 捨棄實驗性變更，然後執行 `git commit`。"
   },
   "startDialog": {
     "en_US": {
@@ -65,6 +69,126 @@ exports.level = {
               "* Commit what's left: `git commit`",
               "",
               "That lands one clean commit, with only the work you meant to keep."
+            ]
+          }
+        }
+      ]
+    },
+    "zh_CN": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## 使用 `git restore` 撤销修改",
+              "",
+              "每个人偶尔都会把工作区弄乱一点：可能暂存了不该暂存的文件，也可能开始了一项后来想要丢弃的实验。`git restore` 是专门为工作区和暂存区设计的现代撤销工具。",
+              "",
+              "它有两种用法：",
+              "",
+              "* `git restore --staged <file>`：**取消暂存**文件（将文件移出暂存区，但保留你的修改）",
+              "* `git restore <file>`：彻底**丢弃**文件修改（请小心，这会删除这些修改！）",
+              "",
+              "*(它们取代了旧式的 `git reset HEAD <file>` 和 `git checkout -- <file>` 用法。作用相同，但名称清晰得多。)*"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "现在，你的工作区有点乱：",
+              "",
+              "```",
+              "Changes to be committed:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   secret.env",
+              "```",
+              "",
+              "```",
+              "Changes not staged for commit:",
+              "  modified:   experiment.js",
+              "```",
+              "",
+              "你只想提交 `app.js`，但 `secret.env` 不小心提前进入了暂存区（它应该留到下一个提交记录），所以先把它留到以后。另外，`experiment.js` 中的修改没有效果，因此把它们全部丢弃。"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "整理好工作区，然后提交：",
+              "",
+              "* 取消暂存敏感文件：`git restore --staged secret.env`",
+              "* 丢弃实验性修改：`git restore experiment.js`",
+              "* 提交剩余内容：`git commit`",
+              "",
+              "这样会得到一个干净的提交记录，其中只包含你确实想保留的工作。"
+            ]
+          }
+        }
+      ]
+    },
+    "zh_TW": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## 使用 `git restore` 復原變更",
+              "",
+              "每個人偶爾都會把工作目錄弄亂一點：可能預存了不該預存的檔案，也可能開始了一項後來想要捨棄的實驗。`git restore` 是專門為工作目錄和預存區設計的現代復原工具。",
+              "",
+              "它有兩種用法：",
+              "",
+              "* `git restore --staged <file>`：**取消預存**檔案（將檔案移出預存區，但保留你的變更）",
+              "* `git restore <file>`：徹底**捨棄**檔案變更（請小心，這會刪除這些變更！）",
+              "",
+              "*(它們取代了舊式的 `git reset HEAD <file>` 和 `git checkout -- <file>` 用法。作用相同，但名稱清楚得多。)*"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "現在，你的工作目錄有點亂：",
+              "",
+              "```",
+              "Changes to be committed:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   secret.env",
+              "```",
+              "",
+              "```",
+              "Changes not staged for commit:",
+              "  modified:   experiment.js",
+              "```",
+              "",
+              "你只想提交 `app.js`，但 `secret.env` 不小心提前進入了預存區（它應該留到下一個 commit），所以先把它留到之後。另外，`experiment.js` 中的變更沒有成功，因此把它們全部捨棄。"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "整理好工作目錄，然後提交：",
+              "",
+              "* 取消預存敏感檔案：`git restore --staged secret.env`",
+              "* 捨棄實驗性變更：`git restore experiment.js`",
+              "* 提交剩餘內容：`git commit`",
+              "",
+              "這樣會得到一個乾淨的 commit，其中只包含你確實想保留的工作。"
             ]
           }
         }

--- a/src/levels/workingDir/restore.js
+++ b/src/levels/workingDir/restore.js
@@ -11,7 +11,7 @@ exports.level = {
   "hint": {
     "en_US": "Unstage with `git restore --staged secret.env`, throw away the experiment with `git restore experiment.js`, then `git commit`.",
     "zh_CN": "使用 `git restore --staged secret.env` 取消暂存，使用 `git restore experiment.js` 丢弃实验性修改，然后执行 `git commit`。",
-    "zh_TW": "使用 `git restore --staged secret.env` 取消預存，使用 `git restore experiment.js` 捨棄實驗性變更，然後執行 `git commit`。"
+    "zh_TW": "使用 `git restore --staged secret.env` 取消暫存，使用 `git restore experiment.js` 捨棄實驗性變更，然後執行 `git commit`。"
   },
   "startDialog": {
     "en_US": {
@@ -142,11 +142,11 @@ exports.level = {
             "markdowns": [
               "## 使用 `git restore` 復原變更",
               "",
-              "每個人偶爾都會把工作目錄弄亂一點：可能預存了不該預存的檔案，也可能開始了一項後來想要捨棄的實驗。`git restore` 是專門為工作目錄和預存區設計的現代復原工具。",
+              "每個人偶爾都會把工作目錄弄亂一點：可能暫存了不該暫存的檔案，也可能開始了一項後來想要捨棄的實驗。`git restore` 是專門為工作目錄和暫存區設計的現代復原工具。",
               "",
               "它有兩種用法：",
               "",
-              "* `git restore --staged <file>`：**取消預存**檔案（將檔案移出預存區，但保留你的變更）",
+              "* `git restore --staged <file>`：**取消暫存**檔案（將檔案移出暫存區，但保留你的變更）",
               "* `git restore <file>`：徹底**捨棄**檔案變更（請小心，這會刪除這些變更！）",
               "",
               "*(它們取代了舊式的 `git reset HEAD <file>` 和 `git checkout -- <file>` 用法。作用相同，但名稱清楚得多。)*"
@@ -174,7 +174,7 @@ exports.level = {
               "  modified:   experiment.js",
               "```",
               "",
-              "你只想提交 `app.js`，但 `secret.env` 不小心提前進入了預存區（它應該留到下一個 commit），所以先把它留到之後。另外，`experiment.js` 中的變更沒有成功，因此把它們全部捨棄。"
+              "你只想提交 `app.js`，但 `secret.env` 不小心提前進入了暫存區（它應該留到下一個 commit），所以先把它留到之後。另外，`experiment.js` 中的變更沒有成功，因此把它們全部捨棄。"
             ]
           }
         },
@@ -184,7 +184,7 @@ exports.level = {
             "markdowns": [
               "整理好工作目錄，然後提交：",
               "",
-              "* 取消預存敏感檔案：`git restore --staged secret.env`",
+              "* 取消暫存敏感檔案：`git restore --staged secret.env`",
               "* 捨棄實驗性變更：`git restore experiment.js`",
               "* 提交剩餘內容：`git commit`",
               "",

--- a/src/levels/workingDir/staging.js
+++ b/src/levels/workingDir/staging.js
@@ -6,12 +6,12 @@ exports.level = {
   "name": {
     "en_US": "The Staging Area",
     "zh_CN": "暂存区 Staging Area",
-    "zh_TW": "預存區 Staging Area"
+    "zh_TW": "暫存區 Staging Area"
   },
   "hint": {
     "en_US": "Stage a file with `git add <file>`, then snapshot it with `git commit`. Do that twice, once per file.",
     "zh_CN": "使用 `git add <file>` 暂存一个文件，再用 `git commit` 将其保存为快照。每个文件各执行一次，共执行两次。",
-    "zh_TW": "使用 `git add <file>` 預存一個檔案，再用 `git commit` 將它儲存為快照。每個檔案各執行一次，共執行兩次。"
+    "zh_TW": "使用 `git add <file>` 暫存一個檔案，再用 `git commit` 將它儲存為快照。每個檔案各執行一次，共執行兩次。"
   },
   "startDialog": {
     "en_US": {
@@ -134,13 +134,13 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "## 預存區 Staging Area",
+              "## 暫存區 Staging Area",
               "",
               "到目前為止，我們一直沒有深入說明實際建立一個 commit 時究竟發生了什麼。你可能知道，commit 代表一組檔案的變更，但要決定哪些檔案的變更應該放進哪一個 commit，還需要經過一個選擇的過程。",
               "",
               "Git 不會自動把所有已修改的檔案都放進每個 commit——那樣不好！它可能會包含你不想永久保留的變更，甚至可能把 API 金鑰之類的敏感內容隨 commit 歷史洩漏到 GitHub。",
               "",
-              "因此，檔案變更在成為 commit 的一部分之前，必須經過明確選擇。為此，Git 劃分了三個區域：**工作目錄**（本機檔案系統中的專案目錄，也就是實際編輯檔案的位置）、**預存區**（記錄下一個 commit 將包含哪些變更的區域），以及**版本庫**（保存 commit 歷史與專案後設資料的地方）。",
+              "因此，檔案變更在成為 commit 的一部分之前，必須經過明確選擇。為此，Git 劃分了三個區域：**工作目錄**（本機檔案系統中的專案目錄，也就是實際編輯檔案的位置）、**暫存區**（記錄下一個 commit 將包含哪些變更的區域），以及**版本庫**（保存 commit 歷史與專案後設資料的地方）。",
               "",
               "使用 `git add`，你可以精確選擇每個 commit 要包含的內容。這樣既能讓 commit 保持整潔，也不必一次提交所有變更。",
               "",
@@ -152,7 +152,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "隨時執行 `git status` 都可以查看目前狀態。現在，它會顯示兩個已經修改、但尚未預存的檔案：",
+              "隨時執行 `git status` 都可以查看目前狀態。現在，它會顯示兩個已經修改、但尚未暫存的檔案：",
               "",
               "```",
               "Changes not staged for commit:",
@@ -164,7 +164,7 @@ exports.level = {
               "  modified:   styles.css",
               "```",
               "",
-              "使用 `git add app.js` 可以預存單一檔案，使用 `git add .` 則可以一次預存所有檔案。檔案進入預存區後，`git commit` 會將它封存為一份快照。",
+              "使用 `git add app.js` 可以暫存單一檔案，使用 `git add .` 則可以一次暫存所有檔案。檔案進入暫存區後，`git commit` 會將它封存為一份快照。",
               "",
               "如果有些檔案永遠不想提交，例如敏感檔案、日誌或建置產物，可以把它們列入 `.gitignore` 檔案，Git 就會安靜地忽略它們。"
             ]
@@ -174,7 +174,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "輪到你了！請**一次只預存並提交一個檔案**，讓每次提交都保持專注：",
+              "輪到你了！請**一次只暫存並提交一個檔案**，讓每次提交都保持專注：",
               "",
               "* 執行 `git add app.js`，然後執行 `git commit`",
               "* 執行 `git add styles.css`，然後執行 `git commit`",

--- a/src/levels/workingDir/staging.js
+++ b/src/levels/workingDir/staging.js
@@ -4,10 +4,14 @@ exports.level = {
   "solutionCommand": "git add app.js;git commit;git add styles.css;git commit",
   "startTree": '{"branches":{"main":{"target":"C1","id":"main"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"},"workingChanges":{"app.js":"modified","styles.css":"modified"}}',
   "name": {
-    "en_US": "The Staging Area"
+    "en_US": "The Staging Area",
+    "zh_CN": "暂存区 Staging Area",
+    "zh_TW": "預存區 Staging Area"
   },
   "hint": {
-    "en_US": "Stage a file with `git add <file>`, then snapshot it with `git commit`. Do that twice, once per file."
+    "en_US": "Stage a file with `git add <file>`, then snapshot it with `git commit`. Do that twice, once per file.",
+    "zh_CN": "使用 `git add <file>` 暂存一个文件，再用 `git commit` 将其保存为快照。每个文件各执行一次，共执行两次。",
+    "zh_TW": "使用 `git add <file>` 預存一個檔案，再用 `git commit` 將它儲存為快照。每個檔案各執行一次，共執行兩次。"
   },
   "startDialog": {
     "en_US": {
@@ -62,6 +66,120 @@ exports.level = {
               "* `git add styles.css`, then `git commit`",
               "",
               "The filenames beside each goal commit show exactly where each change belongs. Two clean commits and the level is yours."
+            ]
+          }
+        }
+      ]
+    },
+    "zh_CN": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## 暂存区 Staging Area",
+              "",
+              "到目前为止，我们一直没有深入讲解实际创建一个提交记录时究竟发生了什么。你可能知道，提交记录代表一组文件的修改，但要决定哪些文件的修改应该放进哪个提交记录，还需要经过一个选择过程。",
+              "",
+              "Git 不会自动把所有已修改的文件都放进每个提交记录——那样不好！它可能会包含你不想永久保留的修改，甚至可能把 API 密钥之类的敏感内容随提交历史泄露到 GitHub。",
+              "",
+              "因此，文件修改在成为提交记录的一部分之前，必须经过明确选择。为此，Git 划分了三个区域：**工作区**（本地文件系统中的项目目录，也就是实际编辑文件的位置）、**暂存区**（记录下一个提交记录将包含哪些修改的区域），以及 **Git 仓库**（保存提交历史和项目元数据的地方）。",
+              "",
+              "使用 `git add`，你可以精确选择每个提交记录要包含的内容。这样既能让提交记录保持整洁，也不必一次提交所有修改。",
+              "",
+              "（在接下来的关卡中，我们会显示每个提交记录包含了哪些文件。）"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "随时运行 `git status` 都可以查看当前状态。现在，它会显示两个已经修改、但尚未暂存的文件：",
+              "",
+              "```",
+              "Changes not staged for commit:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   styles.css",
+              "```",
+              "",
+              "使用 `git add app.js` 可以暂存单个文件，使用 `git add .` 则可以一次暂存所有文件。文件进入暂存区后，`git commit` 会将它封存为一份快照。",
+              "",
+              "如果有些文件永远不想提交，例如敏感文件、日志或构建产物，可以把它们列入 `.gitignore` 文件，Git 就会安静地忽略它们。"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "轮到你了！请**一次只暂存并提交一个文件**，让每次提交都保持专注：",
+              "",
+              "* 执行 `git add app.js`，然后执行 `git commit`",
+              "* 执行 `git add styles.css`，然后执行 `git commit`",
+              "",
+              "目标提交记录旁的文件名清楚地标出了每项修改应该放在哪里。完成两个干净的提交记录，就能通过本关。"
+            ]
+          }
+        }
+      ]
+    },
+    "zh_TW": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## 預存區 Staging Area",
+              "",
+              "到目前為止，我們一直沒有深入說明實際建立一個 commit 時究竟發生了什麼。你可能知道，commit 代表一組檔案的變更，但要決定哪些檔案的變更應該放進哪一個 commit，還需要經過一個選擇的過程。",
+              "",
+              "Git 不會自動把所有已修改的檔案都放進每個 commit——那樣不好！它可能會包含你不想永久保留的變更，甚至可能把 API 金鑰之類的敏感內容隨 commit 歷史洩漏到 GitHub。",
+              "",
+              "因此，檔案變更在成為 commit 的一部分之前，必須經過明確選擇。為此，Git 劃分了三個區域：**工作目錄**（本機檔案系統中的專案目錄，也就是實際編輯檔案的位置）、**預存區**（記錄下一個 commit 將包含哪些變更的區域），以及**版本庫**（保存 commit 歷史與專案後設資料的地方）。",
+              "",
+              "使用 `git add`，你可以精確選擇每個 commit 要包含的內容。這樣既能讓 commit 保持整潔，也不必一次提交所有變更。",
+              "",
+              "（在接下來的關卡中，我們會顯示每個 commit 包含了哪些檔案。）"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "隨時執行 `git status` 都可以查看目前狀態。現在，它會顯示兩個已經修改、但尚未預存的檔案：",
+              "",
+              "```",
+              "Changes not staged for commit:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   styles.css",
+              "```",
+              "",
+              "使用 `git add app.js` 可以預存單一檔案，使用 `git add .` 則可以一次預存所有檔案。檔案進入預存區後，`git commit` 會將它封存為一份快照。",
+              "",
+              "如果有些檔案永遠不想提交，例如敏感檔案、日誌或建置產物，可以把它們列入 `.gitignore` 檔案，Git 就會安靜地忽略它們。"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "輪到你了！請**一次只預存並提交一個檔案**，讓每次提交都保持專注：",
+              "",
+              "* 執行 `git add app.js`，然後執行 `git commit`",
+              "* 執行 `git add styles.css`，然後執行 `git commit`",
+              "",
+              "目標 commit 旁的檔案名稱清楚地標出了每項變更應該放在哪裡。完成兩個乾淨的 commit，就能通過本關。"
             ]
           }
         }


### PR DESCRIPTION
## Summary

Adds Simplified Chinese (`zh_CN`) and Traditional Chinese (`zh_TW`)
translations for the staging area and `git restore` levels.

## What's covered

- Localized the level names and hints.
- Translated all three introductory dialog pages for each level.
- Kept Git commands and technical terms such as `git add`, `git commit`,
  `git restore`, and `Staging Area` recognizable.
- Matched the terminology and tone of the existing Chinese translations.

## Verification

- `gulp fastBuild`
- `gulp lint`
- `gulp test` — 353/353 specs passed
- All 34 level translations are present for both `zh_CN` and `zh_TW`

## Screenshots
<img width="911" height="524" alt="image" src="https://github.com/user-attachments/assets/e79b61f9-8b82-43ab-a70d-8bc48bff55e6" />
<img width="906" height="446" alt="image" src="https://github.com/user-attachments/assets/0d2b83c4-dd13-4e53-a2bc-515b1cae2e52" />
<img width="903" height="320" alt="image" src="https://github.com/user-attachments/assets/16a7ca1b-7577-4947-8a71-ff081d179d6d" />
<img width="901" height="449" alt="image" src="https://github.com/user-attachments/assets/f169b7a1-8a46-4ca0-91a5-774b62d69bd1" />
<img width="907" height="409" alt="image" src="https://github.com/user-attachments/assets/ef1fa2ae-3524-42b3-b84d-c1e7d9fe23f8" />
<img width="903" height="377" alt="image" src="https://github.com/user-attachments/assets/1d674744-e2ea-41d2-939b-0f1d90bc8433" />
<img width="258" height="72" alt="image" src="https://github.com/user-attachments/assets/5d6c6e49-1990-4764-96c6-bd97c69e319f" />
<img width="226" height="68" alt="image" src="https://github.com/user-attachments/assets/3702702a-944b-4d21-9f01-04b15f70e2f1" />
