### PR TITLE
Complete and correct the tr_TR translation

### DIFF
--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -79,7 +79,7 @@ exports.strings = {
     "pl": "Niesamowite! Rozwiązałeś zadanie w ten sam sposób lub lepiej.",
     "it_IT": "Grandioso! Hai eguagliato o migliorato la nostra soluzione.",
     "ta_IN": "அருமை! எங்கள் கொடுக்க பட்ட தீர்வை நிறைவு செய்து விட்டீர்கள்.",
-    "tr_TR": "Mükemmel! ideal çözümle aynı veya daha iyi bir çözüm yaptınız.",
+    "tr_TR": "Mükemmel! Bizim çözümümüzle aynı sonuca ulaştınız.",
     "hu_HU": "Fantasztikus! A megoldásod megegyezik a miénkkel.",
     "az": "Əla! Bizim həlli təkrarladın."
   },
@@ -107,7 +107,7 @@ exports.strings = {
     "pl": "Niesamowite! Rozwiązałeś zadanie w ten sam sposób lub lepiej.",
     "it_IT": "Grandioso! Hai eguagliato o migliorato la nostra soluzione.",
     "ta_IN": "அருமை! எங்கள் கொடுக்க பட்ட தீர்வை நிறைவு செய்து விட்டீர்கள்.",
-    "tr_TR": "Mükemmel! ideal çözümle aynı veya daha iyi bir çözüm yaptınız.",
+    "tr_TR": "Mükemmel! Bizim çözümümüzü geçtiniz.",
     "hu_HU": "Fantasztikus! Túlszárnyaltad a megoldásunkat.",
     "az": "Əla! Bizim həlli qabaqladın."
   },
@@ -216,7 +216,7 @@ exports.strings = {
     "pl": "W tej aplikacji nie ma polecenia `status`, ponieważ nie ma przemieszczania plików. Zamiast tego wypróbuj `hg summary`",
     "it_IT": "Non esiste il comando status in quest'app, visto che non esiste lo staging dei file. Prova invece `hg summary`",
     "ta_IN": "கோப்புகள் எதுவும் அடுத்த படிநிலையில் இல்லை என்பதால், இந்த பயன்பாட்டிற்கான மதிப்பீடும் கட்டளை எதுவும் இல்லை. அதற்கு பதிலாக `hg summary` முயற்சிக்கவும்",
-    "tr_TR": "Bu uygulama için bir status komutu yok çünkü dosyalar stage edilemiyor. Bunun yerine hg summit komutunu deneyin.",
+    "tr_TR": "Bu uygulama için bir status komutu yok çünkü dosyalar stage edilemiyor. Bunun yerine hg summary komutunu deneyin.",
     "hu_HU": "Nincs status parancs ehhez az alkalmazáshoz, mivel nincs fájlok állomásoztatása. Próbáld helyette az hg summary parancsot",
     "az": "Bu tətbiqdə status əmri yoxdur, çünki faylların staging-i yoxdur. Onun əvəzinə hg summary sına"
   },
@@ -243,7 +243,7 @@ exports.strings = {
     "pl": "Potrzebuję opcji {option} dla tego polecenia!",
     "it_IT": "Ho bisogno di {option} per quel comando!",
     "ta_IN": "எனக்கு அந்த கட்டளைக்கு மாற்று {option} தேவை",
-    "tr_TR": "Bu komut için {seçenek} seçeneğine ihtiyacım var!",
+    "tr_TR": "Bu komut için {option} seçeneğine ihtiyacım var!",
     "hu_HU": "Szükségem van a {option} opcióra ahhoz a parancshoz!",
     "az": "Bu əmr üçün mənə {option} seçimi lazımdır!"
   },
@@ -297,7 +297,7 @@ exports.strings = {
     "pl": "Odłączono HEAD!",
     "it_IT": "Testa distaccata (Detached head)!",
     "ta_IN": "பிரிக்கப்பட்ட தலை!",
-    "tr_TR": "Detached head!(Bağımsız başlık!)",
+    "tr_TR": "Detached HEAD! (Bağımsız HEAD!)",
     "hu_HU": "Leválasztott HEAD (Detached head)!",
     "az": "Ayrılmış HEAD (Detached head)!"
   },
@@ -594,7 +594,7 @@ exports.strings = {
     "pl": "Nie możesz usunąć gałezi main, gałęzi na której aktualnie pracujesz, ani która nie jest gałezią",
     "it_IT": "Non puoi eliminare il ramo main, il ramo in cui sei, o cose che non sono rami",
     "ta_IN": "பிரதான கிளை, தற்ப்போது நடப்பில் உள்ள கிளை மற்றும் கிளை அல்லாத வற்றை அழிக்க இயலாது",
-    "tr_TR": "Şu anda üzerinde çalıştığın branch olan main i veya branch olmayan Refs leri silemezsin",
+    "tr_TR": "main branch'ini, üzerinde bulunduğunuz branch'i veya branch olmayan şeyleri silemezsiniz",
     "hu_HU": "Nem törölheted a main ágat, azt az ágat amelyen éppen vagy, vagy olyan dolgokat amelyek nem ágak",
     "az": "main branch-ını, üzərində olduğun branch-ı və ya branch olmayan şeyləri silə bilmərsən"
   },
@@ -621,7 +621,7 @@ exports.strings = {
     "pl": "Łączenie {target} z {current}",
     "it_IT": "Fuso {target} in {current}",
     "ta_IN": "{target}ஐ {current} கிளையுடன் இணை",
-    "tr_TR": "{target}i {current}e birleştir",
+    "tr_TR": "{target} dalını {current} dalına merge et",
     "hu_HU": "{target} merge-elése {current} ágba",
     "az": "{target} {current}-ə birləşdirilir"
   },
@@ -648,7 +648,7 @@ exports.strings = {
     "pl": "Nie znaleziono commit-u do zmiany! Wszystkie commit-y oraz scalenia lub zmiany już są zastosowane",
     "it_IT": "Non ci sono commit da ribasare! Sono tutti commit di merge o i cambiamenti sono già stati applicati",
     "ta_IN": "`rebase` செய்ய எந்த கமிட்டும் இல்லை, அனைத்தும் இணைப்பு கமிட்கள் அல்லது முன்பே இணைக்கப்பட்டவை",
-    "tr_TR": "Rebase edilecek commit yok! Her şey birleştirme commit i ya da zaten uygulanmış değişiklikler",
+    "tr_TR": "Rebase edilecek commit yok! Her şey ya merge commit'i ya da zaten uygulanmış değişiklikler",
     "hu_HU": "Nincs commit a rebase-hez! Minden merge commit vagy a változtatások már alkalmazva lettek",
     "az": "Rebase ediləcək commit yoxdur! Hər şey merge commit-dir və ya dəyişikliklər artıq tətbiq olunub"
   },
@@ -756,7 +756,7 @@ exports.strings = {
     "pl": "Odnośnik {ref} nie istnieje lub jest nieznany",
     "it_IT": "Il riferimento (ref) {ref} non esiste o è sconosciuto",
     "ta_IN": "{ref} இல்லை அல்லது தெரியவில்லை",
-    "tr_TR": "{ref} referansı mevcut değil veya bilinmiyo",
+    "tr_TR": "{ref} referansı mevcut değil veya bilinmiyor",
     "hu_HU": "A(z) {ref} referencia nem létezik vagy ismeretlen",
     "az": "{ref} ref-i mövcud deyil və ya naməlumdur"
   },
@@ -783,7 +783,7 @@ exports.strings = {
     "pl": "Commit {commit} nie ma {match}",
     "it_IT": "Il commit {commit} non ha un {match}",
     "ta_IN": "{commit}க்கு {match} எதுவும் இல்லை",
-    "tr_TR": "{commit} commit inin {match} bulunmamaktadı",
+    "tr_TR": "{commit} commit'inin {match} referansı bulunmamaktadır",
     "hu_HU": "A(z) {commit} commit-nak nincs {match} szülője",
     "az": "{commit} commit-inin {match} yoxdur"
   },
@@ -945,7 +945,7 @@ exports.strings = {
     "pl": "Domyślnym zachowaniem dla polecenia `reset` w LearnGitBranching jest parametr --hard, więc możesz pominąć tę opcję, Pamiętaj tylko, że domyślne zachowanie rzeczywistego GIT-a jest parametr --mixed.",
     "it_IT": "Il comportamento base per i resets su LearnGitBranching è --hard, per cui puoi tranquillamente omettere quella opzione se ti sei stancato di scriverla. Ricorda però che in Git, l'opzione di default è --mixed.",
     "ta_IN": "The default behavior for resets on LearnGitBranching is a --hard, so feel free to omit that option if you get tired of typing it out in our lessons. Just remember that the default behavior on actual Git is --mixed.",
-    "tr_TR": "LearnGitBranching deki sıfırlama işlemlerinin varsayılan davranışı --hard tır, bu yüzden derslerimizde yazarken bundan sıkılırsanız bu seçeneği atlayabilirsiniz. Ancak gerçek Git teki varsayılan davranışın --mixed olduğunu unutmayın.",
+    "tr_TR": "LearnGitBranching'deki sıfırlama işlemlerinin varsayılan davranışı --hard'dır, bu yüzden derslerimizde yazarken bundan sıkılırsanız bu seçeneği atlayabilirsiniz. Ancak gerçek Git'teki varsayılan davranışın --mixed olduğunu unutmayın.",
     "hu_HU": "A LearnGitBranching alapértelmezett viselkedése reset esetén a --hard, tehát bátran kihagyhatod azt az opciót ha meguntad begépelni a leckéinkben. Csak emlékezz arra, hogy az eredeti Git alapértelmezése --mixed.",
     "az": "LearnGitBranching-də reset-in standart davranışı --hard-dır, ona görə dərslərimizdə bunu yazmaqdan yorulsan bu seçimi buraxa bilərsən. Sadəcə yadında saxla ki, əsl Git-də standart davranış --mixed-dir."
   },
@@ -972,7 +972,7 @@ exports.strings = {
     "pl": "Nie ma koncepcji na dodawanie/indeksowanie zmian, więc opcja lub polecenie jest niepoprawne.",
     "it_IT": "Non esiste il concetto di aggiungere / indicizzare i file, quindi quell'opzione o comando non è valido!",
     "ta_IN": "கோப்புகளைச் சேர்ப்பது / நிலைநிறுத்துவது என்ற கருத்து ஒன்றும் இல்லை, எனவே அந்த மற்றி அல்லது கட்டளை தவறானது",
-    "tr_TR": "Dosya ekleme / sahneleme kavramı yok, bu nedenle bu seçenek veya komut geçersiz!",
+    "tr_TR": "Dosya ekleme / stage'leme kavramı yok, bu nedenle bu seçenek veya komut geçersiz!",
     "hu_HU": "Nincs fájlok hozzáadása/állomásoztatása fogalom, tehát ez az opció vagy parancs érvénytelen!",
     "az": "Fayl əlavə etmək / staging anlayışı yoxdur, ona görə bu seçim və ya əmr etibarsızdır!"
   },
@@ -1284,7 +1284,7 @@ exports.strings = {
     "pl": "Ta nazwa gałęzi \"{branch}\" jest niedozwolona!",
     "it_IT": "Il nome \"{branch}\" per i rami non è consentito!",
     "ta_IN": "\"{branch}\" ஐ கிளையின் பெயராக ஏற்க்க இயலாது!",
-    "tr_TR": "Bu dal ismi \"{branch}\" izin verilmez!",
+    "tr_TR": "\"{branch}\" dal ismine izin verilmiyor!",
     "hu_HU": "Ez az ágnév \"{branch}\" nem megengedett!",
     "az": "\"{branch}\" branch adına icazə verilmir!"
   },
@@ -1311,7 +1311,7 @@ exports.strings = {
     "pl": "Ta nazwa tagu \"{tag}\" jest niedozwolona!",
     "it_IT": "Il nome \"{tag}\" per i tag non è consentito!",
     "ta_IN": "\"{tag}\" ஐ குறிச்சொல் பெயராக ஏற்க்க இயலாது!",
-    "tr_TR": "Bu etiket ismi \"{tag}\" izin verilmez!",
+    "tr_TR": "\"{tag}\" tag ismine izin verilmiyor!",
     "hu_HU": "Ez a tagnév \"{tag}\" nem megengedett!",
     "az": "\"{tag}\" tag adına icazə verilmir!"
   },
@@ -2759,7 +2759,7 @@ exports.strings = {
     "it_IT": "Il comando è valido, ma non supportato in questo ambiente! Prova a entrare in un livello o nel generatore di livelli per usare quel comando",
     "pl": "To polecenie jest poprawne, ale nie jest obsługiwane w obecnym środowisku! Spróbuj wybrać poziom lub włączyć konstruktor poziomów, aby użyć tej komendy",
     "vi": "Lệnh đó hợp lệ, nhưng không được hỗ trợ ở môi trường hiện tại! Hãy thử vào một cấp độ hoặc trình tạo cấp độ để sử dụng lệnh",
-    "tr_TR": "Bu komut geçerli bir komuttur, fakat bu ortamda desteklenmemektedir, bu komutu kullanmak için bir seviye (level) ya da seviye oluşturucu ekleyin (level builder).",
+    "tr_TR": "Bu komut geçerli bir komuttur, fakat bu ortamda desteklenmemektedir. Bu komutu kullanmak için bir seviyeye (level) ya da seviye oluşturucuya (level builder) girin.",
     "hu_HU": "Ez a parancs érvényes, de nem támogatott a jelenlegi környezetben! Próbálj belépni egy szintbe vagy szintépítőbe hogy használd ezt a parancsot",
     "az": "Bu əmr etibarlıdır, lakin cari mühitdə dəstəklənmir! Bu əmri istifadə etmək üçün bir bölümə və ya bölüm konstruktoruna daxil olmağı sına"
   },
@@ -2780,7 +2780,7 @@ exports.strings = {
     "it_IT": "Rebase interattivo",
     "pl": "Interaktywny Rebase",
     "vi": "Rebase tương tác",
-    "tr_TR": "Etkileşimli Yeniden Temellendirme",
+    "tr_TR": "Etkileşimli Rebase",
     "hu_HU": "Interaktív rebase",
     "az": "İnteraktiv Rebase"
   }

--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -360,24 +360,28 @@ exports.strings = {
     "en_US": "Changes to be committed:",
     "pt_BR": "Mudanças a serem commitadas:",
     "de_DE": "Änderungen, die committed werden:",
+    "tr_TR": "Commit edilecek değişiklikler:",
   },
   "git-status-unstaged-header": {
     "__desc__": "git status header for modified files that are not yet staged",
     "en_US": "Changes not staged for commit:",
     "pt_BR": "Mudanças não adicionadas ao staging:",
     "de_DE": "Folgende Änderungen wurden noch nicht zum Commit vorgemerkt:",
+    "tr_TR": "Commit için stage'lenmemiş değişiklikler:",
   },
   "git-status-clean": {
     "__desc__": "git status line when there is nothing to commit",
     "en_US": "nothing to commit, working tree clean",
     "pt_BR": "nada para commitar, diretório de trabalho limpo",
     "de_DE": "Nichts zu committen, Arbeitsverzeichnis ist sauber.",
+    "tr_TR": "commit edilecek bir şey yok, çalışma ağacı temiz",
   },
   "git-status-nothing-staged": {
     "__desc__": "shown when git commit is run but nothing has been staged yet",
     "en_US": "no changes added to commit (stage them first with \"git add <file>\")",
     "pt_BR": "nenhuma mudança adicionada ao commit (adicione-as ao staging primeiro com \"git add <arquivo>\")",
     "de_DE": "Keine Änderungen zum Commit hinzugefügt (füge sie zuerst mit \"git add <Datei>\" zum Staging-Bereich hinzu).",
+    "tr_TR": "commit'e eklenmiş değişiklik yok (önce \"git add <file>\" ile stage'leyin)",
   },
   "git-dummy-msg": {
     "__desc__": "The dummy commit message for all commits. Feel free to put in a shoutout to your school / city / whatever!",
@@ -2071,6 +2075,7 @@ exports.strings = {
     "en_US": "This level doesn't have a solution to show!",
     "az": "Bu bölümün göstəriləcək həlli yoxdur!",
     "de_DE": "Für dieses Level gibt es keine Lösung zum Anzeigen!",
+    "tr_TR": "Bu seviyenin gösterilecek bir çözümü yok!",
   },
   "solution-empty": {
     "__desc__": "If you define a solution without any commands, aka a level that is solved without doing anything",
@@ -2425,7 +2430,8 @@ exports.strings = {
     "it_IT": "Generatore di livelli",
     "ta_IN": "நிலை கட்டமைப்பான்",
     "hu_HU": "Szintépítő",
-    "az": "Bölüm Konstruktoru"
+    "az": "Bölüm Konstruktoru",
+    "tr_TR": "Seviye Oluşturucu"
   },
   "no-start-dialog": {
     "__desc__": "when the user tries to open a start dialog for a level that does not have one",
@@ -2608,12 +2614,14 @@ exports.strings = {
     "en_US": "Close window",
     "az": "Pəncərəni bağla",
     "de_DE": "Fenster schließen",
+    "tr_TR": "Pencereyi kapat",
   },
   "helper-bar-back": {
     "__desc__": "Back label in the bottom helper bar sub-menus.",
     "en_US": "Back",
     "az": "Geri",
     "de_DE": "Zurück",
+    "tr_TR": "Geri",
   },
   "command-helper-bar-levels": {
     "__desc__": "Levels command label in the bottom command helper bar.",

--- a/src/levels/advanced/multipleParents.js
+++ b/src/levels/advanced/multipleParents.js
@@ -2068,7 +2068,7 @@ exports.level = {
               "",
               "`~` modifikatörü gibi, `^` modifikatörü de ardından isteğe bağlı bir sayı alabilir.",
               "",
-              "`~`'in geri gitmek için nesil sayısını belirtmesinin aksine, `^` modifikatörü birleştirilmiş bir commit'ten hangi ebeveyn referansını takip edeceğinizi belirtir. Unutmayın ki birleştirilmiş commit'ler birden fazla ebeveyne sahip olduğundan, hangi yolu seçileceği belirsizdir.",
+              "`~`'in geri gitmek için nesil sayısını belirtmesinin aksine, `^` modifikatörü bir merge commit'inden hangi ebeveyn referansını takip edeceğinizi belirtir. Unutmayın ki merge commit'leri birden fazla ebeveyne sahip olduğundan, hangi yolun seçileceği belirsizdir.",
               "",
               "Git genellikle birleştirilmiş commit'ten \"ilk\" ebeveyni yukarı doğru takip eder, ancak `^` ile bir sayı belirtmek, bu varsayılan davranışı değiştirir.",
               "",

--- a/src/levels/index.js
+++ b/src/levels/index.js
@@ -290,7 +290,7 @@ var sequenceInfo = exports.sequenceInfo = {
       'pl'   : 'Przenoszenie pracy',
       'it_IT': "Spostare il lavoro in giro",
       'ta_IN': 'வேலைகளை பகிர்ந்து கொள்வது',
-      'tr_TR': 'İşi yürüt'
+      'tr_TR': 'Çalışmayı Taşımak ve Stage\'lemek'
     },
     about: {
       'en_US': 'Move commits around and choose exactly which file changes belong together',
@@ -315,7 +315,7 @@ var sequenceInfo = exports.sequenceInfo = {
       'pl'   : 'Git dobrze radzi sobie z modyfikacją drzewa źródłowego :P',
       'it_IT': 'Modificare l\'albero con facilità. "GIT" ready :P',
       'ta_IN': '"கிட்" மூல மரத்தை மாற்றுவதில் சிரந்தது :P',
-      'tr_TR': '"Git" kaynak ağacını (source tree) değiştirirken rahat olun :P '
+      'tr_TR': 'Commit\'leri taşıyın ve hangi dosya değişikliklerinin birlikte gideceğine tam olarak siz karar verin'
     }
   },
   mixed: {

--- a/src/levels/intro/branching.js
+++ b/src/levels/intro/branching.js
@@ -2043,12 +2043,12 @@ exports.level = {
               "Git'teki branch'ler (dallar), son derece hafif ve sadece belirli bir commit'e işaret eden işaretçilerdir - fazlası değil. -- İşte bu nedenle birçok Git tutkunu şunu söyler:",
               "",
               "```",
-              "erken branch'le, sık sık branchle",
+              "erken branch'le, sık sık branch'le",
               "```",
               "",
               "Git'te birçok branch oluşturmanın depolama/bellek açısından herhangi bir fazlalığı yoktur, bu nedenle işinizi mantıklı bir şekilde bölmek daha kolay ve akıllıca olacaktır.",
               "",
-              "Branch'leri ve commit'leri birleştirmeye başladığımızda, bu iki özelliğin nasıl bir araya geldiğini göreceğiz. Şimdilik sadece unutmayın ki bir branch, temelde \"Bu commit'te yaptığım çalımanının ve diğer tüm üst düzey commit'leri dahil etmek istiyorum.\" der."
+              "Branch'leri ve commit'leri birleştirmeye başladığımızda, bu iki özelliğin nasıl bir araya geldiğini göreceğiz. Şimdilik sadece unutmayın ki bir branch, temelde \"Bu commit'in ve onun bütün ata commit'lerinin çalışmasını dahil etmek istiyorum.\" der."
             ]
           }
         },

--- a/src/levels/intro/commits.js
+++ b/src/levels/intro/commits.js
@@ -1050,7 +1050,7 @@ exports.level = {
               "",
               "Git, commit'leri hafif tutmak ister, bu yüzden her seferinde sırf her şeyi körü körüne kopyalamaz. Mümkün olduğunda, bir commit'i değişikliklerin seti olarak sıkıştırabilir veya bir sürümün bir sonraki sürüme olan farkını, yani bir \"delta\"yı yakalayabilir.",
               "",
-              "Git aynı zamanda hangi commit'lerin ne zaman yapıldığını da kayıt altında tutar. İşte bu yüzden çoğu commit, üstünde atası olan başka commit'lerle gelir - bu görselde oklarla belirtilir. Tarih tutmak, projede çalışan herkes için harika bir şeydir!",
+              "Git aynı zamanda hangi commit'lerin ne zaman yapıldığını da kayıt altında tutar. İşte bu yüzden çoğu commit, üstünde atası olan başka commit'lerle gelir - bu görselde oklarla belirtilir. Geçmişi saklamak, projede çalışan herkes için harika bir şeydir!",
               "",
               "İlk bakışta karmaşık gelebilir, ama şimdilik commit'leri projenizin anlık fotoğrafları gibi düşünün. Commit'ler hafiftir ve aralarında çok hızlı geçiş yapılabilir!"
             ]

--- a/src/levels/intro/merging.js
+++ b/src/levels/intro/merging.js
@@ -1658,7 +1658,7 @@ exports.level = {
               "",
               "Harika! Nasıl commit yapılacağını ve branch oluşturulacağını öğrendik. Şimdi iki farklı branch'in çalışmasını birleştirmenin (merge) bir yolunu öğrenmemiz gerekiyor. Bu, yeni bir özellik geliştirmek için bir branch'i alacak ve sonra onu geri birleştirebilmemizi sağlayacak.",
               "",
-              "Birleştirme işlemini inceleyeceğimiz ilk yöntem `git merge`'dir. Git'te birleştirme işlemi, iki benzersiz üst öğesi olan özel bir commit oluşturur. İki ata'sı olan bir commit, temelde \"Bu kaynak kodun bu noktadaki tüm çalışmasını ve diğer noktadaki kaynak kodun tüm çalışmasını *ve* tüm bu kaynak kodlarının üstündeki kaynak kodlarını dahil etmek istiyorum.\" anlamına gelir.",
+              "Birleştirme işlemini inceleyeceğimiz ilk yöntem `git merge`'dir. Git'te merge işlemi, iki benzersiz ataya sahip özel bir commit oluşturur. İki atası olan bir commit, temelde \"Buradaki atanın tüm çalışmasını ve şuradaki atanın tüm çalışmasını *ve* bunların bütün atalarının kümesini dahil etmek istiyorum.\" anlamına gelir.",
               "",
               "Bu işlem görsellerle daha kolay anlaşılır, bir sonraki görünümde görelim."
             ]
@@ -1675,7 +1675,7 @@ exports.level = {
             "afterMarkdowns": [
               "Vay canına! Görüyor musunuz? İlk olarak, `main` artık iki ata'sı (Parent) olan bir commit'e işaret ediyor. `main` üzerinden commit ağacındaki okları takip ederseniz, köke giden yol boyunca her commit'e ulaşırsınız. Bu, `main`'in artık repo'nun tamamındaki tüm çalışmayı içerdiği anlamına gelir.",
               "",
-              "Ayrıca, commit'lerim renklerinin nasıl değiştiğini gördünüz mü? Öğrenmenize yardımcı olmak için bazı renk koordinasyonları ekledik. Her branch'in kendine özgü bir rengi vardır. Her commit, kendisini içeren tüm branch'lerin karışık bir kombinasyonu olan bir renge dönüşür.",
+              "Ayrıca, commit'lerin renklerinin nasıl değiştiğini gördünüz mü? Öğrenmenize yardımcı olmak için bazı renk koordinasyonları ekledik. Her branch'in kendine özgü bir rengi vardır. Her commit, kendisini içeren tüm branch'lerin karışık bir kombinasyonu olan bir renge dönüşür.",
               "",
               "Yani burada `main` branch'inin renginin tüm commit'lere karıştığını, ancak `bugFix` renginin karışmadığını görüyoruz. Şimdi bunu düzeltelim..."
             ],
@@ -1702,7 +1702,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Bu level'i tamamlamak için aşağıdaki adımları yapmanız gerekiyor:",
+              "Bu seviyeyi tamamlamak için aşağıdaki adımları yapmanız gerekiyor:",
               "",
               "* `bugFix` adında yeni bir branch oluşturun",
               "* `git checkout bugFix` komutu ile `bugFix` branch'ine geçin ",

--- a/src/levels/intro/rebasing.js
+++ b/src/levels/intro/rebasing.js
@@ -1564,9 +1564,9 @@ exports.level = {
               "Hadi bunu `git rebase` komutuyla yapalım."
             ],
             "afterMarkdowns": [
-              "Harika! Şimdi bugFix branch'indeki çalışmamız doğrudan main'in üstünde ve güzel bir doğrusal commit dizimiz var.",
+              "Harika! Artık bugFix branch'imizdeki çalışma, main'i işaret ettiği için \"main'in üstüne\" yığılmış durumda. Görselleştirmemizde ise commit ağaçlarımız aşağı doğru aktığı için main'in altında gösteriliyor.",
               "",
-              "C3 commit'inin hala bir yerde bulunduğunu (ağaçta soluk bir görünümde olduğunu) ve C3'ün main üzerine yeniden temellendiği (rebase) ve bir \"kopya\" olduğunu unutmayın.",
+              "C3 commit'inin hâlâ bir yerlerde durduğuna (ağaçta soluk görünüyor) ve C3' commit'inin ise main üzerine rebase ettiğimiz \"kopya\" olduğuna dikkat edin.",
               "",
               "Tek sorun, main'in henüz güncellenmemiş olması, hadi şimdi bunu yapalım..."
             ],
@@ -1581,7 +1581,7 @@ exports.level = {
               "Şu anda `main` branch'inde bulunuyoruz. Şimdi `bugFix` branch'ini yeniden temel alalım..."
             ],
             "afterMarkdowns": [
-              "İşte! main, bugFix'in atsı olduğu için, git sadece main dalının referansını tarihte ileri taşıdı."
+              "İşte! `main`, `bugFix`'in atası olduğu için, git sadece `main` dalının referansını geçmişte ileri taşıdı."
             ],
             "command": "git rebase bugFix",
             "beforeCommand": "git commit; git checkout -b bugFix C1; git commit; git rebase main; git checkout main"

--- a/src/levels/mixed/describe.js
+++ b/src/levels/mixed/describe.js
@@ -33,7 +33,7 @@ exports.level = {
     "sl_SI": "Git Describe",
     "it_IT": "Git Describe",
     "pl": "Git describe",
-    "tr_TR": "git describe",
+    "tr_TR": "Git Describe",
     "ta_IN": "Git விவரம்",
     "hu_HU": "Git describe",
     "az": "Git Describe"
@@ -1479,7 +1479,7 @@ exports.level = {
               "",
               "`git describe <ref>`",
               "",
-              "`<ref>` git'in bir commit'e çözümleyebileceği herhangi bir şeydir. Eğer bir ref belirtmezseniz, git şu an nereye checkout yapmışsanız (genellikle `HEAD`) onu kullanır.",
+              "`<ref>` git'in bir commit'e çözümleyebileceği herhangi bir şeydir. Eğer bir ref belirtmezseniz, git şu anda checkout yapmış olduğunuz yeri (`HEAD`) kullanır.",
               "",
               "Komutun çıktısı şu şekilde görünür:",
               "",
@@ -1514,7 +1514,7 @@ exports.level = {
             "markdowns": [
               "Git describe hakkında bilmeniz gerekenler bu kadar! Komuta alışmak için bu seviyedeki birkaç yeri tanımlamayı deneyin.",
               "",
-              "Hazır olduğunuzda, bir kez commit yaparak seviyesi tamamlayabilirsiniz. Küçük bir jest bizden size :P"
+              "Hazır olduğunuzda, bir kez commit yaparak seviyeyi tamamlayabilirsiniz. Küçük bir jest bizden size :P"
             ]
           }
         }

--- a/src/levels/mixed/grabbingOneCommit.js
+++ b/src/levels/mixed/grabbingOneCommit.js
@@ -982,7 +982,7 @@ exports.level = {
               "",
               "Bu hata ayıklama veya yazdırma ifadeleri, her biri kendi commit'lerine sahiptir. Sonunda hatayı bulurum, düzeltirim ve sevinirim!",
               "",
-              "Tek sorun şu ki şimdi `bugFix` branch'imi `main` branch'imden almalıyım. Eğer sadece `main` branch'ini süratle ileri alırsam, `main` branch'i tüm hata ayıklama ifadelerimi alır ki bu istenmeyen bir durumdur. Bunun için başka bir yol bulunmalıdır..."
+              "Tek sorun şu ki şimdi `bugFix` branch'imdeki çalışmayı `main` branch'ine geri almam gerekiyor. Eğer sadece `main` branch'ini fast-forward yaparsam, `main` branch'i tüm hata ayıklama ifadelerimi de alır ki bu istenmeyen bir durumdur. Bunun için başka bir yol bulunmalıdır..."
             ]
           }
         },
@@ -1003,7 +1003,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Bu biraz daha ileri bir seviye olduğundan hangi komutu kullanmak istediğiniz size kalmış, ancak `main` branch'inin `bugFix` tarafından atılan ve `main`'e atıfta bulunan commit'i alması gerektiğini unutmayın."
+              "Bu biraz daha ileri bir seviye olduğundan hangi komutu kullanmak istediğiniz size kalmış, ancak seviyeyi tamamlamak için `main`'in, `bugFix`'in işaret ettiği commit'i alması gerektiğinden emin olun."
             ]
           }
         }

--- a/src/levels/mixed/jugglingCommits.js
+++ b/src/levels/mixed/jugglingCommits.js
@@ -41,7 +41,7 @@ exports.level = {
     "it_IT": "Giocoliere di commit",
     "pl": "Żonglowanie commitami",
     "ta_IN": "Commitகளுடன் வித்தைகள்",
-    "tr_TR": "Commit'leri Şekillendirme",
+    "tr_TR": "Commit Hokkabazlığı",
     "hu_HU": "Commitok átrendezése",
     "az": "Commit-lərin Hoqqabazlığı"
   },
@@ -886,13 +886,13 @@ exports.level = {
               "",
               "* `git rebase -i` komutu ile değiştirmek istediğimiz commit'i en üste getireceğiz.",
               "* Küçük değişikliği yapmak için `git commit --amend` komutunu kullanacağız.",
-              "* Ardından, `git rebase -i` komutu ile komitleri önceki sıralarına geri döndüreceğiz.",
+              "* Ardından, `git rebase -i` komutu ile commit'leri önceki sıralarına geri döndüreceğiz.",
               "* Son olarak, main branch'ini ağacın bu güncellenmiş kısmına taşıyarak seviyeyi bitireceğiz (tabi sizin seçtiğiniz yöntemle).",
               "",
               "Bunu başarmak için birçok yol vardır (cherry-pick komutuna göz diktiğinizi görüyorum) ve ileride daha fazlasını göreceğiz, ancak şimdilik bu tekniğe odaklanalım.",
-              "Son olarak, buradaki hedef duruma dikkat edin - commit'leri iki kez taşıdığımızdan, her ikisi de bir tırnak işareti alıyor. Değiştirdiğimiz commit için bir tırnak işareti daha eklenir, bu da bize ağacın son halini verir. ",
+              "Son olarak, buradaki hedef duruma dikkat edin - commit'leri iki kez taşıdığımızdan, her ikisi de bir kesme işareti alıyor. Değiştirdiğimiz commit için bir kesme işareti daha eklenir, bu da bize ağacın son halini verir. ",
               "",
-              "Şunu da belirtmek isteriz ki, artık seviyeleri yapı ve göreceli tırnak işareti farklılıklarına göre karşılaştırabiliyoruz. Ağacınızın `main` branch'i aynı yapıya ve göreceli tırnak işareti farklılıklarına sahip olduğu sürece tam puan alacaksınız."
+              "Şunu da belirtmek isteriz ki, artık seviyeleri yapıya ve göreli kesme işareti farklılıklarına göre karşılaştırabiliyoruz. Ağacınızın `main` branch'i aynı yapıya ve aynı göreli kesme işareti farklılıklarına sahip olduğu sürece tam puan alacaksınız."
             ]
           }
         }

--- a/src/levels/mixed/jugglingCommits2.js
+++ b/src/levels/mixed/jugglingCommits2.js
@@ -40,7 +40,7 @@ exports.level = {
     "it_IT": "Giocoliere di commit #2",
     "pl": "Żonglowanie commitami #2",
     "ta_IN": "Commitகளுடன் வித்தைகள் #2",
-    "tr_TR": "Commit'leri Şekillendirme #2",
+    "tr_TR": "Commit Hokkabazlığı #2",
     "hu_HU": "Commitok átrendezése #2",
     "az": "Commit Hoqqabazlığı #2"
   },
@@ -1023,11 +1023,11 @@ exports.level = {
             "markdowns": [
               "## Commit Hokkabazlığı #2",
               "",
-              "*Eğer Commit Hokkabazlığı #1'i (bir önceki level) bitirmediyseniz, devam etmeden önce lütfen önce o bölümü bitirin*",
+              "*Eğer Commit Hokkabazlığı #1'i (bir önceki seviye) bitirmediyseniz, devam etmeden önce lütfen onu bitirin*",
               "",
-              "Bir önceki seviyeden hatırlayacağınız gibi, `rebase -i` kullanarak commit'leri yeniden sıralayabiliyorduk. Değiştirmek istediğimiz commit en üstte olduğunda, onu kolayca düzeltebilir `--amend` ve tercih ettiğimiz sıraya yeniden düzenleyebilirdik.",
+              "Bir önceki seviyede gördüğünüz gibi, commit'leri yeniden sıralamak için `rebase -i` kullandık. Değiştirmek istediğimiz commit en üste geldiğinde, onu kolayca `--amend` ile düzeltip tercih ettiğimiz sıraya geri döndürebiliyorduk.",
               "",
-              "Tek sorun şu ki, birçok yeniden sıralama yapıldığında, bu yeniden sıralama çatışmalarını ortaya çıkarabilir. Başka bir yöntemi, git cherry-pick ile inceleyelim."
+              "Tek sorun şu ki burada çok fazla yeniden sıralama var ve bu da rebase çakışmalarına yol açabilir. Hadi `git cherry-pick` ile başka bir yönteme bakalım."
             ]
           }
         },
@@ -1035,7 +1035,7 @@ exports.level = {
           "type": "GitDemonstrationView",
           "options": {
             "beforeMarkdowns": [
-              "Unutmayın ki git cherry-pick, HEAD'in herhangi bir yerinde (bu commit, HEAD'in atası değilse) bulunan bir commit'i HEAD üzerine bırakacaktır.",
+              "Unutmayın ki `git cherry-pick`, ağacın herhangi bir yerindeki bir commit'i (bu commit `HEAD`'in atası olmadığı sürece) `HEAD` üzerine bırakır.",
               "",
               "İşte küçük bir hatırlatma demosu:"
             ],
@@ -1052,7 +1052,7 @@ exports.level = {
             "markdowns": [
               "Bu seviyede, `C2` commit'ini düzeltmek için `rebase -i` kullanmadan aynı sonuca ulaşmaya çalışın. Nasıl ulaşabileceğimizi size bırakıyorum! :D",
               "",
-              "Unutmayın, commit'lerdeki tırnakların (') tam olarak eşleşmesi önemli değil, yalnızca göreceli farklar önemlidir. Örneğin, hedef ağaçla eşleşen ancak her yerde ekstra bir tırnak bulunan bir ağaçtan da puan alınabilir."
+              "Unutmayın, commit'lerdeki kesme işaretlerinin (') tam sayısı önemli değil, yalnızca göreli farklar önemlidir. Örneğin, hedef ağaçla eşleşen ama her yerinde bir fazla kesme işareti bulunan bir ağaca da puan veririm."
             ]
           }
         }

--- a/src/levels/mixed/tags.js
+++ b/src/levels/mixed/tags.js
@@ -1215,7 +1215,7 @@ exports.level = {
               "",
               "Önceki derslerden öğrendiğiniz gibi, branch'ler kolayca taşınabilir ve üzerlerinde çalışma tamamlandıkça farklı commitlere işaret ederler. Branch'ler kolayca değiştirilebilir, genellikle geçici ve her zaman değişkendirler.",
               "",
-              "Eğer durum buysa, projenizin tarihindeki belirli noktaları *kalıcı* olarak işaretlemenin bir yolunun olup olmadığını merak ediyor olabilirsiniz. Büyük sürümler ve önemli birleştirmeler gibi durumlar için, bunları bir branch üzerine tag'lemek yerine daha kalıcı bir şekilde nasıl tag'leyeceğinizi düşünüyor olabilirsiniz.",
+              "Eğer durum buysa, projenizin tarihindeki belirli noktaları *kalıcı* olarak işaretlemenin bir yolunun olup olmadığını merak ediyor olabilirsiniz. Büyük sürümler ve büyük merge'ler gibi durumlar için, bu commit'leri bir branch'ten daha kalıcı bir şeyle işaretlemenin bir yolu var mı?",
               ""
             ]
           }
@@ -1224,7 +1224,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Direkt olarak işaretlemek mümkün! Git tag'leri tam da bu kullanım durumunu destekler - belirli commit'leri \"milestone\" olarak (bir dereceye kadar) kalıcı olarak işaretler ve sonra bir branch gibi başvurabileceğiniz şekilde kullanabilirsiniz.",
+              "Elbette var! Git tag'leri tam da bu kullanım durumunu destekler - belirli commit'leri \"milestone\" olarak (bir dereceye kadar) kalıcı olarak işaretler ve sonra bir branch gibi başvurabileceğiniz şekilde kullanabilirsiniz.",
               "",
               "Daha da önemlisi, daha fazla commit oluşturulduğunda asla hareket etmezler. Bir etiketi \"checkout\" edemez ve sonra o etiket üzerinde çalışmayı tamamlayamazsınız - tagler, belirli noktaları belirleyen commit ağacındaki referans noktaları olarak varlıklarını sürdürürler.",
               "",

--- a/src/levels/mixed/tags.js
+++ b/src/levels/mixed/tags.js
@@ -26,7 +26,7 @@ exports.level = {
     "it_IT": "Git Tag",
     "pl": "Tagi Gita",
     "ta_IN": "Git டேக்கள்",
-    "tr_TR": "Git Tagleri",
+    "tr_TR": "Git Tag'leri",
     "hu_HU": "Git tagek",
     "az": "Git Tag-lər"
   },
@@ -1213,7 +1213,7 @@ exports.level = {
             "markdowns": [
               "## Git Tag'leri",
               "",
-              "Önceki derslerden öğrendiğiniz gibi, branch'ler kolayca taşınabilir ve üzerlerinde çalışma tamamlandıkça farklı commitlere işaret ederler. Branch'ler kolayca değiştirilebilir, genellikle geçici ve her zaman değişkendirler.",
+              "Önceki derslerden öğrendiğiniz gibi, branch'ler kolayca taşınabilir ve üzerlerinde çalışma tamamlandıkça farklı commit'lere işaret ederler. Branch'ler kolayca değiştirilebilir, genellikle geçici ve her zaman değişkendirler.",
               "",
               "Eğer durum buysa, projenizin tarihindeki belirli noktaları *kalıcı* olarak işaretlemenin bir yolunun olup olmadığını merak ediyor olabilirsiniz. Büyük sürümler ve büyük merge'ler gibi durumlar için, bu commit'leri bir branch'ten daha kalıcı bir şeyle işaretlemenin bir yolu var mı?",
               ""

--- a/src/levels/rampup/detachedHead.js
+++ b/src/levels/rampup/detachedHead.js
@@ -1754,7 +1754,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Bu bölümü tamamlamak için, HEAD'i `bugFix` dalından ayıralım ve yerine commit'e bağlayalım.",
+              "Bu seviyeyi tamamlamak için, HEAD'i `bugFix` dalından ayıralım ve yerine commit'e bağlayalım.",
               "",
               "Bu commit'i hash'i ile belirtin. Her commit'in hash'i, commit'i temsil eden dairede gösterilir."
             ]

--- a/src/levels/rampup/interactiveRebase.js
+++ b/src/levels/rampup/interactiveRebase.js
@@ -1472,7 +1472,7 @@ exports.level = {
               "* Commit'leri, UI'de sıralarını değiştirerek (fareyle sürükleyip bırakarak) yeniden sıralayabilirsiniz.",
               "* Tüm commit'leri tutabilir veya belirli olanları silebilirsiniz. İletişim kutusu açıldığında, her commit, yanındaki `pick` düğmesinin aktif olmasıyla dahil edilmek üzere ayarlanır. Bir commit'i silmek için, `pick` düğmesini kapatın.",
               "",
-              "*Gerçek git'te etkileşimli rebase ile daha birçok şey yapılabilir, örneğin commit'leri birleştirme (squash), commit mesajlarını değiştirme ve hatta commit'leri düzenleme. Ancak bizim amacımız için yalnızca yukarıdaki iki işlemi odaklanacağız.*",
+              "*Gerçek git'te etkileşimli rebase ile daha birçok şey yapılabilir, örneğin commit'leri birleştirme (squash), commit mesajlarını değiştirme ve hatta commit'leri düzenleme. Ancak bizim amacımız için yalnızca yukarıdaki iki işleme odaklanacağız.*",
               "",
               "Harika! Hadi bir örneğe bakalım."
             ]
@@ -1495,7 +1495,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Bu bölümü bitirmek için etkileşimli rebase yapın ve hedef görselleştirmesinde gösterilen sıralamayı elde edin. Unutmayın, her zaman `undo` veya `reset` komutlarını kullanarak hataları düzeltebilirsiniz :D"
+              "Bu seviyeyi bitirmek için etkileşimli rebase yapın ve hedef görselleştirmesinde gösterilen sıralamayı elde edin. Unutmayın, her zaman `undo` veya `reset` komutlarını kullanarak hataları düzeltebilirsiniz :D"
             ]
           }
         }

--- a/src/levels/rampup/relativeRefs.js
+++ b/src/levels/rampup/relativeRefs.js
@@ -24,7 +24,7 @@ exports.level = {
     "sl_SI": "Relativne Reference (^)",
     "it_IT": "Riferimenti relativi (^)",
     "pl": "Referencje względne (^)",
-    "tr_TR": "İlgili Referanslar (^)",
+    "tr_TR": "Göreli Referanslar (^)",
     "ta_IN": "உதவிக்குறிப்பு குறிப்பிடல்கள் (^)",
     "hu_HU": "Relatív hivatkozások (^)",
     "az": "Nisbi Ref-lər (^)"
@@ -1638,7 +1638,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "## Göreceli Referanslar",
+              "## Göreli Referanslar",
               "",
               "Git'te commit hash'lerini belirterek gezinmek biraz sıkıcı olabilir. Gerçek dünyada terminalin yanında güzel bir commit ağacı görselleştirmesi olmayacağı için hash'leri görmek için `git log` kullanmanız gerekecek.",
               "",
@@ -1652,11 +1652,11 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Dediğim gibi, commit'leri hash'leriyle belirtmek her zaman en pratik şey değildir, bu yüzden Git göreceli referansları sunar. Bunlar harikadır!",
+              "Dediğim gibi, commit'leri hash'leriyle belirtmek her zaman en pratik şey değildir, bu yüzden Git göreli referansları sunar. Bunlar harikadır!",
               "",
-              "Göreceli referanslarla, hatırlanması kolay bir yerden (mesela `bugFix` dalı ya da `HEAD`) başlayabilir ve buradan ilerleyebilirsiniz.",
+              "Göreli referanslarla, hatırlanması kolay bir yerden (mesela `bugFix` dalı ya da `HEAD`) başlayabilir ve buradan ilerleyebilirsiniz.",
               "",
-              "Göreceli commit'ler güçlüdür, ancak burada iki basit örneğini sunacağız:",
+              "Göreli commit'ler güçlüdür, ancak burada iki basit örneğini sunacağız:",
               "",
               "* `^` ile bir commit yukarıya hareket etmek",
               "* `~<num>` ile birden fazla commit yukarıya hareket etmek"
@@ -1686,7 +1686,7 @@ exports.level = {
           "type": "GitDemonstrationView",
           "options": {
             "beforeMarkdowns": [
-              "`HEAD`'i de göreceli bir referans olarak kullanabilirsiniz. Hadi bunu birkaç kez kullanalım ve commit ağacında yukarıya doğru hareket edelim."
+              "`HEAD`'i de göreli bir referans olarak kullanabilirsiniz. Hadi bunu birkaç kez kullanalım ve commit ağacında yukarıya doğru hareket edelim."
             ],
             "afterMarkdowns": [
               "Kolay! `HEAD^` ile zaman içinde geri gidebiliriz."
@@ -1701,7 +1701,7 @@ exports.level = {
             "markdowns": [
               "Bu seviyeyi tamamlamak için, `bugFix`'in ebeveyn commit'ine göz atın. Bu, `HEAD`'i ayıracaktır.",
               "",
-              "Hash'i belirtmek isterseniz belirtebilirsiniz, ancak göreceli referansları kullanmayı deneyin!"
+              "Hash'i belirtmek isterseniz belirtebilirsiniz, ancak göreli referansları kullanmayı deneyin!"
             ]
           }
         }

--- a/src/levels/rampup/reversingChanges.js
+++ b/src/levels/rampup/reversingChanges.js
@@ -1380,7 +1380,7 @@ exports.level = {
             "markdowns": [
               "## Git'te Değişiklikleri Geri Alma",
               "",
-              "Git'te değişiklikleri geri almanın birçok yolu vardır. Ve tıpkı commit yapmada olduğu gibi, değişiklikleri geri almak da hem düşük seviyeli bir bileşene (bireysel dosyaları veya parçaları sahneleme) hem de yüksek seviyeli bir bileşene (değişikliklerin nasıl geri alındığına) sahiptir. Uygulamamız, ikincisine odaklanacaktır.",
+              "Git'te değişiklikleri geri almanın birçok yolu vardır. Ve tıpkı commit yapmada olduğu gibi, değişiklikleri geri almak da hem düşük seviyeli bir bileşene (tek tek dosyaları veya parçaları stage'leme) hem de yüksek seviyeli bir bileşene (değişikliklerin nasıl geri alındığı) sahiptir. Uygulamamız, ikincisine odaklanacaktır.",
               "",
               "Git'te değişiklikleri geri almanın iki temel yolu vardır: birincisi `git reset` kullanmak, diğeri ise `git revert` kullanmaktır. Bunların her birine bir sonraki diyalogda göz atacağız.",
               ""
@@ -1395,7 +1395,7 @@ exports.level = {
               "",
               "`git reset`, bir dal referansını geçmişteki eski bir commit'e geri hareket ettirerek değişiklikleri geri alır. Bu anlamda, onu \"tarihi yeniden yazmak\" olarak düşünebilirsiniz; `git reset`, bir dalı, sanki commit hiç yapılmamış gibi geriye doğru hareket ettirir.",
               "",
-              "Bunu nasıl göründüğünü görelim:"
+              "Bunun nasıl göründüğüne bakalım:"
             ],
             "afterMarkdowns": [
               "Güzel! Git, main dalını `C1`'e geri taşıdı; şimdi yerel depomuz, `C2`'nin hiç olmamış gibi bir durumda."
@@ -1412,12 +1412,12 @@ exports.level = {
               "",
               "Resetleme, kendi makinenizdeki yerel dallar için mükemmel çalışırken, \"tarihi yeniden yazma\" yöntemi, başkalarının kullandığı uzak dallar için işe yaramaz.",
               "",
-              "Değişiklikleri geri almak ve *geri alınan değişiklikleri başkalarıyla paylaşmak* için `git revert` kullanmamız gerekir. Bunu nasıl çalıştığını görelim."
+              "Değişiklikleri geri almak ve *geri alınan değişiklikleri başkalarıyla paylaşmak* için `git revert` kullanmamız gerekir. Bunun nasıl çalıştığına bakalım."
             ],
             "afterMarkdowns": [
               "Tuhaf, geri almak istediğimiz commit'in altına yeni bir commit geldi. Çünkü bu yeni commit `C2'`, *değişiklikler* getiriyor -- sadece, `C2`'nin commit'ini tam olarak geri alan değişiklikler getiriyor.",
               "",
-              "Revertleme ile değişikliklerinizi başkalarına paylaşmak için push edebilirsiniz."
+              "Revert ile değişikliklerinizi başkalarıyla paylaşmak üzere push edebilirsiniz."
             ],
             "command": "git revert HEAD^",
             "beforeCommand": "git commit; git commit"

--- a/src/levels/rebase/manyRebases.js
+++ b/src/levels/rebase/manyRebases.js
@@ -510,13 +510,13 @@ exports.level = {
             "markdowns": [
               "### Birden fazla branch'ı rebase etmek",
               "",
-              "Dostum, burada bir sürü branch'imiz var! Hadi tüm işlemleri bu branchlerden maine yeniden aktaralım (rebase).",
+              "Dostum, burada bir sürü branch'imiz var! Hadi bu branch'lerdeki tüm çalışmayı `main`'e rebase edelim.",
               "",
-              "Yukarıya doğru yönetmek biraz zor gibi görünse de -- tüm commitlerin sıralı olmasını istiyorlar. Yani bu, ağacımızın son halinin en altta `C7`, onun üstünde `C6`, vs. sırayla olması gerektiği anlamına geliyor.",
+              "Ancak üst yönetim işi biraz zorlaştırıyor -- tüm commit'lerin sıralı olmasını istiyorlar. Yani bu, ağacımızın son halinin en altta `C7'`, onun üstünde `C6'`, vs. sırayla olması gerektiği anlamına geliyor.",
               "",
               "Faydalı bir ipucu: `git rebase` ikinci bir argüman alabilir. `git rebase main bugFix`, tek adımda `bugFix` branch'ine geçer ve onu `main` üzerine rebase eder -- yani `git checkout bugFix; git rebase main` komutlarının kısayoludur.",
               "",
-              "Kafan karışırsa 'reset' tuşuna basarak yeniden başlamaktan çekinme. Çözümümüze göz attığından ve bu bölümü daha az komutla bitirip bitiremeyeceğini gördüğünden emin ol!"
+              "Yolda bir şeyleri karıştırırsanız, yeniden başlamak için `reset` kullanmaktan çekinmeyin. Çözümümüze göz atmayı ve bu seviyeyi daha az komutla bitirip bitiremeyeceğinizi denemeyi unutmayın!"
             ]
           }
         }

--- a/src/levels/rebase/selectiveRebase.js
+++ b/src/levels/rebase/selectiveRebase.js
@@ -509,13 +509,13 @@ exports.level = {
             "markdowns": [
               "## Branch Spagettisi",
               "",
-              "Vay canına! Bu bölümde ulaşmamız gereken hedef oldukça büyük.",
+              "Vay canına! Bu seviyede ulaşmamız gereken hedef oldukça büyük.",
               "",
               "Burada `main`, `one` `two` ve `three` dallarından birkaç commit önde. Herhangi bir nedenden ötürü, bu diğer üç dalı main'deki son birkaç commit'in değiştirilmiş versiyonlarıyla güncellememiz gerekiyor.",
               "",
-              "`one` branchi bu commitlerin yeniden düzenlenmesine ve an `C5`'in hariç tutulması/bırakılmasına ihtiyaç duyuyor. `two` branchi sadece commitlerin yeniden sıralanmasına ihtiyaç duyuyuor, ve `three` için sadece bir commit transferi gerekiyor!",
+              "`one` branch'i bu commit'lerin yeniden sıralanmasına ve `C5`'in hariç tutulmasına/atılmasına ihtiyaç duyuyor. `two` branch'i sadece commit'lerin yeniden sıralanmasına ihtiyaç duyuyor ve `three` için sadece bir commit transferi gerekiyor!",
               "",
-              "Bunu nasıl çözeceğinizi size anlatacağız -- daha sonrasında bizim çözümümüzü `show solution` ile kontrol etmeyi unutmayın."
+              "Bunu nasıl çözeceğinizi bulmayı size bırakıyoruz -- daha sonrasında bizim çözümümüze `show solution` ile göz atmayı unutmayın."
             ]
           }
         }

--- a/src/levels/remote/clone.js
+++ b/src/levels/remote/clone.js
@@ -1290,7 +1290,7 @@ exports.level = {
               ""
             ],
             "afterMarkdowns": [
-              "İşte bu! Şimdi projemizin bir uzak deposuna sahibiz. Görünüşü oldukça benzer, ancak ayırt edici bir fark yaratmak için bazı görsel değişiklikler yapıldı -- sonraki seviyelerde bu depolar arasında nasıl çalıştığımızı paylaşacağınızı göreceksiniz."
+              "İşte bu! Şimdi projemizin bir uzak deposuna sahibiz. Görünüşü oldukça benzer, ancak ayırt edici bir fark yaratmak için bazı görsel değişiklikler yapıldı -- sonraki seviyelerde bu depolar arasında çalışmayı nasıl paylaştığımızı göreceksiniz."
             ],
             "command": "git clone",
             "beforeCommand": ""

--- a/src/levels/remote/fakeTeamwork.js
+++ b/src/levels/remote/fakeTeamwork.js
@@ -1239,7 +1239,7 @@ exports.level = {
             "markdowns": [
               "Gelecek seviyeler oldukça zorlayıcı olacak, bu yüzden bu seviyede sizden daha fazlasını istiyoruz.",
               "",
-              "Bir uzaktan depo oluşturun (`git clone` ile), o uzaktan depoda bazı değişiklikleri taklit edin, kendi commit'inizi yapın ve ardından bu değişiklikleri indirin. Bu, birkaç dersin bir araya gelmiş hali gibi!"
+              "Bir uzak depo oluşturun (`git clone` ile), o uzak depoda bazı değişiklikleri taklit edin, kendi commit'inizi yapın ve ardından uzak depodaki değişiklikleri indirip merge edin. Bu, birkaç dersin bir araya gelmiş hali gibi!"
             ]
           }
         }

--- a/src/levels/remote/fetch.js
+++ b/src/levels/remote/fetch.js
@@ -1669,7 +1669,7 @@ exports.level = {
             "markdowns": [
               "## Git Fetch",
               "",
-              "Git uzak depoları ile çalışmak aslında verileri başka depolara _göndermek_ ve _geri almak_ ile ilgilidir. Bir kez ki commit'leri birbirimize gönderebildiğimiz sürece, git tarafından izlenen her tür güncellemeyi (ve dolayısıyla işi, yeni dosyaları, yeni fikirleri, sevgi mektuplarını vb.) paylaşabiliriz.",
+              "Git uzak depoları ile çalışmak aslında verileri başka depolara _göndermek_ ve onlardan _almak_ demektir. Commit'leri ileri geri gönderebildiğimiz sürece, git tarafından izlenen her tür güncellemeyi (ve dolayısıyla işi, yeni dosyaları, yeni fikirleri, sevgi mektuplarını vb.) paylaşabiliriz.",
               "",
               "Bu derste, bir uzak depodan veri çekmeyi öğreneceğiz -- bu komut `git fetch` olarak adlandırılmıştır.",
               "",

--- a/src/levels/remote/fetchArgs.js
+++ b/src/levels/remote/fetchArgs.js
@@ -2657,7 +2657,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "## Git fetch parametreleri",
+              "## Git fetch argümanları",
               "",
               "Az önce git push parametreleri, bu havalı `<place>` parametresi ve hatta kolon referansları (`<source>:<destination>`) hakkında her şeyi öğrendik. Peki bu bilgileri `git fetch` için de kullanabilir miyiz?",
               "",
@@ -2713,7 +2713,7 @@ exports.level = {
             "markdowns": [
               "\"O zaman ne olur, eğer `<source>:<destination>` ile hem kaynağı hem de hedefi açıkça belirtirsem?\"",
               "",
-              "Eğer commit'leri *doğrudan* yerel bir dala almak için çok hevesliyseniz, o zaman evet, bunu kolon referanslarıyla belirtebilirsiniz. Ancak commit'leri aktif bir dala alamazsınız, ancak git bununla buna izin verir.",
+              "Eğer commit'leri *doğrudan* yerel bir dala almak için çok hevesliyseniz, evet, bunu kolon referansıyla belirtebilirsiniz. Şu kadarı var ki checkout yapılmış bir dala fetch yapamazsınız; bunun dışında git buna izin verir.",
               "",
               "Buradaki tek dikkat edilmesi gereken şey şu -- `<source>`, artık bir *uzak* yerde ve `<destination>` ise bu commit'leri yerleştireceğiniz *yerel* bir yerdir. Bu, `git push` komutunun tam tersidir ve bu mantıklıdır çünkü veri yönü tersine transfer ediliyordur!",
               "",
@@ -2738,7 +2738,7 @@ exports.level = {
           "type": "GitDemonstrationView",
           "options": {
             "beforeMarkdowns": [
-              "Ya hedef önceden var değilse? Hadi son slaydı `bar` olmadan görelim."
+              "Ya komutu çalıştırmadan önce hedef yoksa? Hadi son slaydı `bar` olmadan görelim."
             ],
             "afterMarkdowns": [
               "Görün! Tam olarak `git push` gibi. Git, hedefi yerel olarak oluşturdu ve fetch işlemi yaptı, tıpkı git'in uzak depoya push yaparken hedefi oluşturması gibi (eğer mevcut değilse)."

--- a/src/levels/remote/fetchRebase.js
+++ b/src/levels/remote/fetchRebase.js
@@ -23,7 +23,7 @@ exports.level = {
     "sl_SI": "Razdeljena Zgodovina",
     "pl": "Rozbieżna  historia",
     "it_IT": "Storico divergente",
-    "tr_TR": "Sapmış Tarihçe",
+    "tr_TR": "Ayrışan Geçmiş",
     "hu_HU": "Szétágazó előzmények",
     "az": "Ayrılmış Tarixçə"
   },
@@ -3070,11 +3070,11 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "## Çatışan Çalışma",
+              "## Ayrışan Çalışma",
               "",
               "Şu ana kadar başkalarından nasıl `pull` yaparak commit alacağımızı ve kendi değişikliklerimizi nasıl `push` yapacağımızı gördük. Oldukça basit görünüyor, o zaman insanlar neden bu kadar karışabiliyor?",
               "",
-              "Zorluk, depo geçmişi *çatıştığında* başlar. Bunun ayrıntılarını tartışmadan önce, bir örneğe göz atalım..."
+              "Zorluk, depo geçmişi *ayrıştığında* başlar. Bunun ayrıntılarını tartışmadan önce, bir örneğe göz atalım..."
             ]
           }
         },
@@ -3086,7 +3086,7 @@ exports.level = {
               "",
               "Bu durumda, `git push` komutu belirsizdir. `git push` komutunu çalıştırırsanız, git uzak depoyu Pazartesi günkü haline mi döndürmeli? Kodunuzu yeni kodları silmeden mi eklemeli? Yoksa tamamen geçersiz olan değişikliklerinizi yok saymalı mı?",
               "",
-              "Çünkü bu durumda çok fazla belirsizlik vardır (geçmiş çatıştığı için), git değişikliklerinizi `push` etmenize izin vermez. Gerçekten de, değişikliklerinizi paylaşmadan önce uzak deponun en son durumunu entegre etmenizi zorunlu kılar."
+              "Bu durumda çok fazla belirsizlik olduğu için (geçmiş ayrıştığı için), git değişikliklerinizi `push` etmenize izin vermez. Gerçekten de, değişikliklerinizi paylaşmadan önce uzak deponun en son durumunu entegre etmenizi zorunlu kılar."
             ]
           }
         },
@@ -3198,7 +3198,7 @@ exports.level = {
               "Bu seviyeyi çözmek için şu adımları takip etmeniz gerekiyor:",
               "",
               "* Depoyu klonlayın",
-              "* Takım çalışması sahteleyin (1 commit)",
+              "* Takım çalışmasını taklit edin (1 commit)",
               "* Kendi çalışmanızı commit edin (1 commit)",
               "* Çalışmanızı *rebase* yaparak yayınlayın"
             ]

--- a/src/levels/remote/lockedMain.js
+++ b/src/levels/remote/lockedMain.js
@@ -872,10 +872,10 @@ exports.level = {
             "markdowns": [
               "## Uzak Sunucu Reddi!",
               "",
-              "Büyük bir işbirliği ekibinde çalışıyorsanız, muhtemelen main branch'ı kilitlidir ve değişiklikleri bir Pull Request süreci ile birleştirmeniz gerekir. Eğer main'e doğrudan yerel olarak commit yapar ve push etmeye çalışırsanız, şu benzer bir mesajla karşılaşırsınız:",
+              "Büyük ve kalabalık bir ekipte çalışıyorsanız, muhtemelen main branch'i kilitlidir ve değişiklikleri bir Pull Request süreci ile birleştirmeniz gerekir. Eğer main'e doğrudan yerel olarak commit yapar ve push etmeye çalışırsanız, şuna benzer bir mesajla karşılaşırsınız:",
               "",
               "```",
-              " ! [remote rejected] main -> main (TF402455: Bu branch'a push yapılmasına izin verilmiyor; bu branch'ı güncellemek için bir pull request kullanmalısınız.)",
+              " ! [remote rejected] main -> main (TF402455: Bu branch'e push yapılmasına izin verilmiyor; bu branch'i güncellemek için bir pull request kullanmalısınız.)",
               "```"
             ]
           }
@@ -886,7 +886,7 @@ exports.level = {
             "markdowns": [
               "## Neden reddedildi?",
               "",
-              "Uzak sunucu, main branch'ına doğrudan commit gönderilmesini, main üzerinde sadece pull request ile değişiklik yapılması gerektiği politikasından dolayı reddetti.",
+              "Uzak sunucu, main branch'ine doğrudan commit gönderilmesini, main üzerinde yalnızca pull request ile değişiklik yapılması gerektiği politikası nedeniyle reddetti.",
               "",
               "Branch oluşturup, o branch'i push edip pull request yapmak amacıyla bu süreci takip etmeliydiniz ama unutup doğrudan main'e commit yaptınız. Şimdi sıkıştınız ve değişikliklerinizi push edemiyorsunuz."
             ]

--- a/src/levels/remote/mergeManyFeatures.js
+++ b/src/levels/remote/mergeManyFeatures.js
@@ -1028,7 +1028,7 @@ exports.level = {
               "",
               "* Rebase, commit ağacının (görünürdeki) geçmişini değiştirir.",
               "",
-              "Örneğin, `C1` commit'i, `C3`'ün *öncesine* rebase edilebilir. Bu durumda `C1'`in çalışması aslında daha önce yapılmışken, sanki `C3`ten sonra yapılmış gibi görünür.",
+              "Örneğin, `C1` commit'i `C3`'ün *ötesine* rebase edilebilir. Bu durumda `C1'`in çalışması aslında daha önce tamamlanmışken, sanki `C3`'ten sonra yapılmış gibi görünür.",
               "",
               "Bazı geliştiriciler tarihi korumayı sever ve bu yüzden merge yapmayı tercih eder. Diğerleri (benim gibi) temiz bir commit ağacını tercih eder ve rebase yapmayı sever. Sonuçta bu tamamen tercihe bağlı :D"
             ]

--- a/src/levels/remote/pullArgs.js
+++ b/src/levels/remote/pullArgs.js
@@ -24,7 +24,7 @@ exports.level = {
     "sl_SI": "Pull argumenti",
     "pl": "Argumenty pull",
     "it_IT": "Parametri di git pull",
-    "tr_TR": "Git pull komutunun parametreleri",
+    "tr_TR": "Git pull argümanları",
     "hu_HU": "Pull argumentumok",
     "az": "Pull arqumentləri"
   },
@@ -1552,7 +1552,7 @@ exports.level = {
             "markdowns": [
               "## Git pull argümanları",
               "",
-              "Artık `git fetch` ve `git push` için argümanlarla ilgili bilmeniz gereken hemen hemen *her şey* öğrendiniz, geriye neredeyse hiçbir şey kalmadı :)",
+              "Artık `git fetch` ve `git push` argümanları hakkında bilinmesi gereken hemen hemen *her şeyi* öğrendiniz; `git pull` için anlatılacak neredeyse hiçbir şey kalmadı :)",
               "",
               "Çünkü git pull, nihayetinde *gerçekten* sadece bir fetch ve ardından alınan değişikliklerin birleştirilmesi için kullanılan kısa bir komuttur. Bunu, `git fetch` komutunu *aynı* argümanlarla çalıştırmak ve sonra bu commitlerin nereye yerleştiğine bakarak birleştirmek gibi düşünebilirsiniz.",
               "",
@@ -1589,7 +1589,7 @@ exports.level = {
               "Eğer fetch edilecek yeri belirtirsek, her şey daha önce fetch ile olduğu gibi gerçekleşir, ancak yeni alınan değişiklikleri birleştiririz."
             ],
             "afterMarkdowns": [
-              "Görüyorsunuz! `main`'i belirterek `o/main` üzerindeki commitleri normal şekilde indirdik. Sonra `o/main`'i şu anda üzerinde çalıştığımız konumla birleştirdik, bu da *yerel main branşı* değil. Bu nedenle aslında git pull'ü farklı konumlardan (aynı argümanlarla) birden fazla kez çalıştırmak, birden fazla branşı güncellemek için mantıklı olabilir."
+              "Görüyorsunuz! `main`'i belirterek commit'leri normal şekilde `o/main` üzerine indirdik. Sonra `o/main`'i şu anda checkout yaptığımız konuma merge ettik; bu konum yerel `main` dalı *değil*. Bu nedenle birden fazla dalı güncellemek için `git pull`'ü farklı konumlardan (aynı argümanlarla) birden fazla kez çalıştırmak aslında mantıklı olabilir."
             ],
             "command": "git pull origin main",
             "beforeCommand": "git clone; go -b bar; git commit; git fakeTeamwork"
@@ -1612,7 +1612,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Tamam, bitirmek için hedef görselleştirmesinin durumuna ulaşın. Bazı commitleri indirmeniz, yeni branşlar oluşturmanız ve bu branşları diğer branşlara birleştirmeniz gerekecek, ancak bu çok fazla komut almaz :P"
+              "Tamam, bitirmek için hedef görselleştirmesindeki duruma ulaşın. Bazı commit'leri indirmeniz, yeni branch'ler oluşturmanız ve bu branch'leri diğer branch'lere merge etmeniz gerekecek, ama çok fazla komut gerektirmemeli :P"
             ]
           }
         }

--- a/src/levels/remote/push.js
+++ b/src/levels/remote/push.js
@@ -990,7 +990,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Bu bölümü bitirmek için, uzak depoya iki yeni commit paylaşmanız yeterli. Ancak dikkatli olun, çünkü bu dersler çok daha zorlaşacak!"
+              "Bu seviyeyi bitirmek için, uzak depoya iki yeni commit paylaşmanız yeterli. Ancak dikkatli olun, çünkü bu dersler çok daha zorlaşacak!"
             ]
           }
         }

--- a/src/levels/remote/pushArgs.js
+++ b/src/levels/remote/pushArgs.js
@@ -1619,7 +1619,7 @@ exports.level = {
               "",
               "Harika! Şimdi uzaktan izleme dallarını bildiğine göre, git push, fetch ve pull komutlarının nasıl çalıştığının ardındaki bazı gizemleri keşfetmeye başlayabiliriz. Her seferinde bir komut ele alacağız, ancak bu komutlar arasındaki kavramlar oldukça benzer.",
               "",
-              "Öncelikle `git push` komutuna bakalım. Uzaktan izleme dersinde öğrendiğin gibi, git, şu anda kontrol edilen dalın (takip ettiği uzak dal) özelliklerine bakarak, hangi uzak sunucuya ve hangi dalına push yapılacağını anlar. Bu, herhangi bir argüman belirtilmediğinde görülen davranıştır, ancak git push, şu şekilde argümanlar alabilir:",
+              "Öncelikle `git push` komutuna bakalım. Uzaktan izleme dersinde öğrendiğiniz gibi git, şu anda checkout yapılmış dalın (izlediği uzak dalın) özelliklerine bakarak hangi uzak depoya *ve* hangi dala push yapılacağını anlar. Bu, herhangi bir argüman belirtilmediğinde görülen davranıştır, ancak `git push` şu şekilde argümanlar alabilir:",
               "",
               "`git push <remote> <place>`",
               ""
@@ -1640,7 +1640,7 @@ exports.level = {
               "",
               "Burada `main`'i \"place\" parametresi olarak belirtmemiz, git'e commit'lerin nereden geleceğini ve nereye gideceğini söyledik. Aslında bu, iki depo arasında senkronize edilecek \"yer\" veya \"konum\"dur.",
               "",
-              "Unutmayın ki git'e her şeyi bildirdiğimiz için (her iki argümanı da belirterek), nerede olduğumuzu kontrol etmez!"
+              "Unutmayın ki git'e her şeyi bildirdiğimiz için (her iki argümanı da belirterek), nerede checkout yapmış olduğumuzu tamamen yok sayar!"
             ]
           }
         },
@@ -1648,7 +1648,7 @@ exports.level = {
           "type": "GitDemonstrationView",
           "options": {
             "beforeMarkdowns": [
-              "Argümanları belirttiğimiz bir örneği görelim. Bu örnekte kontrol edilen konuma dikkat edin."
+              "Argümanları belirttiğimiz bir örneği görelim. Bu örnekte checkout yapmış olduğumuz konuma dikkat edin."
             ],
             "afterMarkdowns": [
               "İşte böyle! `main` dalı, bu argümanları belirttiğimiz için uzak depoda güncellendi."
@@ -1664,7 +1664,7 @@ exports.level = {
               "Ya argümanları belirtmeseydik? Ne olurdu?"
             ],
             "afterMarkdowns": [
-              "Komut başarısız olur (gördüğünüz gibi), çünkü `HEAD` uzak izleme dalında kontrol edilmiyor."
+              "Komut başarısız olur (gördüğünüz gibi), çünkü `HEAD` uzak izleme dalına checkout yapılmış durumda değil."
             ],
             "command": "git checkout C0; git push",
             "beforeCommand": "git clone; git commit"

--- a/src/levels/remote/remoteBranches.js
+++ b/src/levels/remote/remoteBranches.js
@@ -1358,11 +1358,11 @@ exports.level = {
               "",
               "`git clone` komutunun nasıl çalıştığını gördükten sonra, yapılan değişikliklere biraz daha yakından bakalım.",
               "",
-              "İlk fark ettiğiniz şey, yerel deposunda `o/main` adında yeni bir dalın görünmesidir. Bu tür dallara _uzak_ dal denir; uzak dallar özel özelliklere sahiptir çünkü özel bir amaca hizmet ederler.",
+              "İlk fark edeceğiniz şey, yerel deponuzda `o/main` adında yeni bir dalın belirmesidir. Bu tür dallara _uzak_ dal denir; uzak dallar özel özelliklere sahiptir çünkü özel bir amaca hizmet ederler.",
               "",
               "Uzak dallar, uzak depoların _durumunu_ yansıtır (son kez bu uzak depolarla iletişim kurduğunuzdan itibaren). Bu dallar, yerel çalışmanızla kamuya açık çalışmanız arasındaki farkı anlamanıza yardımcı olur — başkalarıyla çalışmanızı paylaşmadan önce atılacak kritik bir adımdır.",
               "",
-              "Uzak dalların özel bir özelliği vardır; onları kontrol ettiğinizde, `HEAD` moduna geçersiniz. Git bunu bilerek yapar çünkü bu dallarda doğrudan çalışamazsınız; başka bir yerde çalışıp ardından çalışmanızı uzak depo ile paylaşmalısınız (ve bundan sonra uzak dallarınız güncellenir).",
+              "Uzak dalların özel bir özelliği vardır; onlara checkout yaptığınızda, ayrık (detached) `HEAD` moduna geçersiniz. Git bunu bilerek yapar çünkü bu dallarda doğrudan çalışamazsınız; başka bir yerde çalışıp ardından çalışmanızı uzak depo ile paylaşmalısınız (ve bundan sonra uzak dallarınız güncellenir).",
               "",
               "Açık olmak gerekirse: Uzak dallar yerel deponuzda bulunur, uzak depoda değil."
             ]
@@ -1405,7 +1405,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Bu seviyeyi bitirmek için, önce `main` dalından bir commit yapın ve sonra `o/main`'i kontrol ettikten sonra bir commit daha yapın. Bu, uzak dalların nasıl farklı davrandığını ve yalnızca uzak depo durumunu yansıtacak şekilde nasıl güncellendiklerini anlamanıza yardımcı olacaktır."
+              "Bu seviyeyi bitirmek için, önce `main` dalından bir commit yapın ve sonra `o/main`'e checkout yapıp bir commit daha yapın. Bu, uzak dalların nasıl farklı davrandığını ve yalnızca uzak depo durumunu yansıtacak şekilde nasıl güncellendiklerini anlamanıza yardımcı olacaktır."
             ]
           }
         }

--- a/src/levels/remote/sourceNothing.js
+++ b/src/levels/remote/sourceNothing.js
@@ -1184,7 +1184,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "### `<source>` Anomalleri",
+              "### `<source>` Tuhaflıkları",
               "",
               "Git, `<source>` parametresini iki tuhaf şekilde kullanır. Bu iki tuhaf kullanım, teknik olarak git push ve git fetch için \"hiçbir şey\"i geçerli bir `source` olarak belirleyebilmenizi sağlayan bir durumdan kaynaklanır. Hiçbir şey belirlemenin yolu, boş bir argüman kullanmaktır:",
               "",

--- a/src/levels/remote/tracking.js
+++ b/src/levels/remote/tracking.js
@@ -2592,7 +2592,7 @@ exports.level = {
           "type": "GitDemonstrationView",
           "options": {
             "beforeMarkdowns": [
-              "Yeterince konuştuk, şimdi bir gösterim izleyelim! Yeni bir dal olan `foo`'yu kontrol ederek, bunu uzak `main` dalını izlemeye ayarlayacağız."
+              "Yeterince konuştuk, şimdi bir gösterim izleyelim! `foo` adında yeni bir dala checkout yapıp, bunu uzak depodaki `main` dalını izlemeye ayarlayacağız."
             ],
             "afterMarkdowns": [
               "Gördüğünüz gibi, `o/main`'in dolaylı birleştirme hedefini kullanarak `foo` dalını güncelledik. Dikkat edin, `main` güncellenmedi!"
@@ -2608,7 +2608,7 @@ exports.level = {
               "Bu aynı şekilde git push için de geçerlidir."
             ],
             "afterMarkdowns": [
-              "Boom. Çalışmamızı `foo` adında bir dal olsa bile uzak `main` dalına ittik."
+              "Boom. Dalımızın adı tamamen farklı olmasına rağmen çalışmamızı uzak depodaki `main` dalına push ettik."
             ],
             "command": "git checkout -b foo o/main; git commit; git push",
             "beforeCommand": "git clone"
@@ -2624,7 +2624,7 @@ exports.level = {
               "",
               "`git branch -u o/main foo`",
               "",
-              "`foo` dalını `o/main`'i izlemeye ayarlar. Eğer `foo` şu anda kontrol ediliyorsa, hatta bunu dışarıda bırakabilirsiniz:",
+              "`foo` dalını `o/main`'i izlemeye ayarlar. Eğer `foo` şu anda checkout yapılmışsa, bunu hiç yazmayabilirsiniz bile:",
               "",
               "`git branch -u o/main`"
             ]

--- a/src/levels/workingDir/restore.js
+++ b/src/levels/workingDir/restore.js
@@ -330,7 +330,7 @@ exports.level = {
               "",
               "Herkes ara sıra ortalığı biraz dağıtır. İstemediğiniz bir dosyayı stage'lersiniz ya da sonradan çöpe atmak isteyeceğiniz bir denemeye girişirsiniz. `git restore`, working directory ve staging area için özel olarak tasarlanmış modern geri alma düğmesidir.",
               "",
-              "İki farklı tadı vardır:",
+              "İki çeşidi vardır:",
               "",
               "* `git restore --staged <file>`: bir dosyayı **stage'den çıkarır** (düzenlemelerinizi koruyarak staging area'nın dışına geri taşır)",
               "* `git restore <file>`: bir dosyadaki düzenlemelerinizi tamamen **atar** (dikkat, bu değişiklikleri çöpe atar!)",
@@ -343,7 +343,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Şu anda masanızdaki dağınıklık şöyle:",
+              "İşte şu anda masanızdaki dağınıklık:",
               "",
               "```",
               "Commit edilecek değişiklikler:",
@@ -360,7 +360,7 @@ exports.level = {
               "  modified:   experiment.js",
               "```",
               "",
-              "`app.js` dosyasını commit'lemek istiyorsunuz, ama `secret.env` yanlışlıkla erkenden stage'lenmiş (onun üstte ayrı bir commit olması gerekiyor), o yüzden onu sonraya saklayalım. Ayrıca `experiment.js` değişiklikleri işe yaramadı, öyleyse onları tamamen çöpe atalım."
+              "`app.js` dosyasını commit'lemek istiyorsunuz, ama `secret.env` kazara erkenden stage'lendi (onun üstte gelen bir commit olması gerekiyor), o yüzden onu sonraya saklayalım. Ayrıca `experiment.js` değişiklikleri işe yaramadı, o yüzden onları tamamen çöpe atalım."
             ]
           }
         },
@@ -368,7 +368,7 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Ortalığı toplayın, sonra commit'leyin:",
+              "Ortalığı toparlayın, sonra commit'leyin:",
               "",
               "* Gizli dosyayı stage'den çıkarın: `git restore --staged secret.env`",
               "* Denemeyi atın: `git restore experiment.js`",

--- a/src/levels/workingDir/restore.js
+++ b/src/levels/workingDir/restore.js
@@ -8,14 +8,16 @@ exports.level = {
     "zh_CN": "使用 git restore 撤销修改",
     "zh_TW": "使用 git restore 復原變更",
     "pt_BR": "Desfazendo com git restore",
-    "ru_RU": "Отмена изменений с помощью git restore"
+    "ru_RU": "Отмена изменений с помощью git restore",
+    "tr_TR": "git restore ile Geri Alma"
   },
   "hint": {
     "en_US": "Unstage with `git restore --staged secret.env`, throw away the experiment with `git restore experiment.js`, then `git commit`.",
     "zh_CN": "使用 `git restore --staged secret.env` 取消暂存，使用 `git restore experiment.js` 丢弃实验性修改，然后执行 `git commit`。",
     "zh_TW": "使用 `git restore --staged secret.env` 取消暫存，使用 `git restore experiment.js` 捨棄實驗性變更，然後執行 `git commit`。",
     "pt_BR": "Tire do staging com `git restore --staged secret.env`, jogue fora o experimento com `git restore experiment.js` e depois faça `git commit`.",
-    "ru_RU": "Уберите из подготовленной области с помощью `git restore --staged secret.env`, отбросьте эксперимент командой `git restore experiment.js`, а затем выполните `git commit`."
+    "ru_RU": "Уберите из подготовленной области с помощью `git restore --staged secret.env`, отбросьте эксперимент командой `git restore experiment.js`, а затем выполните `git commit`.",
+    "tr_TR": "`git restore --staged secret.env` ile stage'den çıkarın, `git restore experiment.js` ile denemeyi çöpe atın, sonra `git commit` yapın."
   },
   "startDialog": {
     "en_US": {
@@ -313,6 +315,66 @@ exports.level = {
               "* Закоммитьте то, что осталось: `git commit`",
               "",
               "В результате получится один аккуратный коммит, содержащий только ту работу, которую вы действительно хотели сохранить."
+            ]
+          }
+        }
+      ]
+    },
+    "tr_TR": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## `git restore` ile Geri Alma",
+              "",
+              "Herkes ara sıra ortalığı biraz dağıtır. İstemediğiniz bir dosyayı stage'lersiniz ya da sonradan çöpe atmak isteyeceğiniz bir denemeye girişirsiniz. `git restore`, working directory ve staging area için özel olarak tasarlanmış modern geri alma düğmesidir.",
+              "",
+              "İki farklı tadı vardır:",
+              "",
+              "* `git restore --staged <file>`: bir dosyayı **stage'den çıkarır** (düzenlemelerinizi koruyarak staging area'nın dışına geri taşır)",
+              "* `git restore <file>`: bir dosyadaki düzenlemelerinizi tamamen **atar** (dikkat, bu değişiklikleri çöpe atar!)",
+              "",
+              "*(Bunlar eski `git reset HEAD <file>` ve `git checkout -- <file>` numaralarının yerini alıyor. Fikir aynı, isimler çok daha net.)*"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Şu anda masanızdaki dağınıklık şöyle:",
+              "",
+              "```",
+              "Commit edilecek değişiklikler:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   secret.env",
+              "```",
+              "",
+              "```",
+              "Commit için stage'lenmemiş değişiklikler:",
+              "  modified:   experiment.js",
+              "```",
+              "",
+              "`app.js` dosyasını commit'lemek istiyorsunuz, ama `secret.env` yanlışlıkla erkenden stage'lenmiş (onun üstte ayrı bir commit olması gerekiyor), o yüzden onu sonraya saklayalım. Ayrıca `experiment.js` değişiklikleri işe yaramadı, öyleyse onları tamamen çöpe atalım."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Ortalığı toplayın, sonra commit'leyin:",
+              "",
+              "* Gizli dosyayı stage'den çıkarın: `git restore --staged secret.env`",
+              "* Denemeyi atın: `git restore experiment.js`",
+              "* Kalanı commit'leyin: `git commit`",
+              "",
+              "Bu, yalnızca saklamak istediğiniz çalışmayı içeren tertemiz tek bir commit bırakır."
             ]
           }
         }

--- a/src/levels/workingDir/staging.js
+++ b/src/levels/workingDir/staging.js
@@ -321,7 +321,7 @@ exports.level = {
               "",
               "Her commit'e neyin dahil olacağını `git add` ile *tam olarak* siz seçersiniz. Commit'ler işte böyle derli toplu kalır ve hiçbir zaman her şeyi tek seferde commit'lemek zorunda kalmazsınız.",
               "",
-              "*(Bu bölümlerden itibaren, hangi dosyaların hangi commit'lerin parçası olduğunu göstereceğiz.)*"
+              "*(Bu seviyelerden itibaren, hangi dosyaların hangi commit'lerin parçası olduğunu göstereceğiz.)*"
             ]
           }
         },
@@ -351,12 +351,12 @@ exports.level = {
           "type": "ModalAlert",
           "options": {
             "markdowns": [
-              "Sıra sizde! Her commit odaklı kalsın diye, çalışmanızı **her seferinde tek dosya** olacak şekilde stage'leyip commit'leyin:",
+              "Sıra sizde! Çalışmanızı **her seferinde tek dosya** olacak şekilde stage'leyip commit'leyin; böylece her commit tek bir işe odaklanmış olur:",
               "",
               "* `git add app.js`, sonra `git commit`",
               "* `git add styles.css`, sonra `git commit`",
               "",
-              "Hedefteki her commit'in yanındaki dosya adları, her değişikliğin tam olarak nereye ait olduğunu gösteriyor. İki temiz commit ve bölüm sizindir."
+              "Hedefteki her commit'in yanındaki dosya adları, her değişikliğin tam olarak nereye ait olduğunu gösteriyor. İki temiz commit ve seviye sizin olur."
             ]
           }
         }

--- a/src/levels/workingDir/staging.js
+++ b/src/levels/workingDir/staging.js
@@ -8,14 +8,16 @@ exports.level = {
     "zh_CN": "暂存区 Staging Area",
     "zh_TW": "暫存區 Staging Area",
     "pt_BR": "A área de staging",
-    "ru_RU": "Область подготовленных файлов (Индекс)"
+    "ru_RU": "Область подготовленных файлов (Индекс)",
+    "tr_TR": "Staging Area (Hazırlık Alanı)"
   },
   "hint": {
     "en_US": "Stage a file with `git add <file>`, then snapshot it with `git commit`. Do that twice, once per file.",
     "zh_CN": "使用 `git add <file>` 暂存一个文件，再用 `git commit` 将其保存为快照。每个文件各执行一次，共执行两次。",
     "zh_TW": "使用 `git add <file>` 暫存一個檔案，再用 `git commit` 將它儲存為快照。每個檔案各執行一次，共執行兩次。",
     "pt_BR": "Adicione um arquivo ao staging com `git add <arquivo>` e depois tire uma fotografia (snapshot) dele com `git commit`. Faça isso duas vezes, uma para cada arquivo.",
-    "ru_RU": "Подготовьте файл с помощью 'git add <файл>', затем зафиксируйте его с помощью 'git commit'. Сделайте это дважды — по одному разу для каждого файла."
+    "ru_RU": "Подготовьте файл с помощью 'git add <файл>', затем зафиксируйте его с помощью 'git commit'. Сделайте это дважды — по одному разу для каждого файла.",
+    "tr_TR": "Bir dosyayı `git add <file>` ile stage'leyin, sonra `git commit` ile anlık fotoğrafını çekin. Bunu her dosya için birer kez olmak üzere iki defa yapın."
   },
   "startDialog": {
     "en_US": {
@@ -298,6 +300,63 @@ exports.level = {
               "* `git add styles.css`, затем `git commit`",
               "",
               "Имена файлов рядом с каждым целевым коммитом показывают, куда именно относится каждое изменение. Два аккуратных коммита — и уровень ваш."
+            ]
+          }
+        }
+      ]
+    },
+    "tr_TR": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Staging Area (Hazırlık Alanı)",
+              "",
+              "Bu öğrenme sürecinde şimdiye kadar, bir commit *yapmanın* aslında neleri kapsadığı konusunun üzerinden hızlıca geçtik. Commit'lerin bir dosya kümesindeki değişiklikleri temsil ettiğini biliyor olabilirsiniz; ama aslında *hangi* dosya değişikliklerinin *hangi* commit'e gireceğini seçmek başlı başına bir süreçtir.",
+              "",
+              "Git, değişen bütün dosyaları otomatik olarak her commit'e dahil etmek istemez -- bu kötü olurdu! Kalıcı hale getirmek istemediğiniz bir değişikliği, hatta commit geçmişinizin bir parçası olarak GitHub'a sızabilecek bir API anahtarı gibi gizli bir şeyi içine alabilirdi.",
+              "",
+              "Bu yüzden bir dosyadaki değişiklik bir commit'in parçası olmadan önce, özellikle seçilmesi gerekir. Git'in bunun için üç bölgesi vardır: **working directory** (çalışma dizini, düzenleme yaptığınız yer), **staging area** (bir sonraki commit'e neyin gireceğini bekleten yükleme rampası) ve **repository** (kalıcı geçmişiniz).",
+              "",
+              "Her commit'e neyin dahil olacağını `git add` ile *tam olarak* siz seçersiniz. Commit'ler işte böyle derli toplu kalır ve hiçbir zaman her şeyi tek seferde commit'lemek zorunda kalmazsınız.",
+              "",
+              "*(Bu bölümlerden itibaren, hangi dosyaların hangi commit'lerin parçası olduğunu göstereceğiz.)*"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Durumun ne olduğunu görmek için istediğiniz zaman `git status` çalıştırabilirsiniz. Şu anda, düzenlediğiniz ama henüz stage'lemediğiniz iki dosyayı gösteriyor:",
+              "",
+              "```",
+              "Commit için stage'lenmemiş değişiklikler:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   styles.css",
+              "```",
+              "",
+              "Tek bir dosyayı `git add app.js` ile stage'leyin, ya da hepsini birden `git add .` ile alın. Bir dosya stage'lendikten sonra, `git commit` onu bir anlık fotoğrafın içine mühürler.",
+              "",
+              "Gizli bilgiler, log'lar veya build çöpleri gibi asla commit'lemek istemediğiniz dosyalar mı var? Onları bir `.gitignore` dosyasına yazın, git de sessizce onlara dokunmasın."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Sıra sizde! Her commit odaklı kalsın diye, çalışmanızı **her seferinde tek dosya** olacak şekilde stage'leyip commit'leyin:",
+              "",
+              "* `git add app.js`, sonra `git commit`",
+              "* `git add styles.css`, sonra `git commit`",
+              "",
+              "Hedefteki her commit'in yanındaki dosya adları, her değişikliğin tam olarak nereye ait olduğunu gösteriyor. İki temiz commit ve bölüm sizindir."
             ]
           }
         }


### PR DESCRIPTION
Two things, in four commits: `tr_TR` was missing content, and a fair amount of what was already there did not match the English.

## Part 1 — completing the translation

`tr_TR` was missing the two `workingDir` levels entirely, plus 8 UI strings.

- `src/levels/workingDir/staging.js` — `name`, `hint`, `startDialog` (3 modals)
- `src/levels/workingDir/restore.js` — `name`, `hint`, `startDialog` (3 modals)

New UI strings in `src/js/intl/strings.js`:

| key | tr_TR |
|---|---|
| `git-status-staged-header` | Commit edilecek değişiklikler: |
| `git-status-unstaged-header` | Commit için stage'lenmemiş değişiklikler: |
| `git-status-clean` | commit edilecek bir şey yok, çalışma ağacı temiz |
| `git-status-nothing-staged` | commit'e eklenmiş değişiklik yok (önce "git add \<file\>" ile stage'leyin) |
| `no-solution-defined` | Bu seviyenin gösterilecek bir çözümü yok! |
| `level-builder` | Seviye Oluşturucu |
| `close-window` | Pencereyi kapat |
| `helper-bar-back` | Geri |

The `move` sequence copy in `src/levels/index.js` was also stale — the English had been updated to "Moving and Staging Work" but the translation still rendered the older text. Refreshed `tr_TR` only; the other locales are stale there too if anyone wants to follow up.

## Part 2 — fixing what was already there

I went through all 34 levels and all 111 UI strings line by line against the English, cross-checking anything suspicious against `pt_BR`, `ru_RU` and `de_DE`.

### Broken at runtime

- **`hg-error-need-option` translated the placeholder itself**, `{option}` to `{seçenek}`. The underscore template interpolates on the literal name, so rendering it throws `ReferenceError: seçenek is not defined`. The key is currently unreferenced, so it has not fired yet — but it is a live landmine. `TRANSLATING.md` rule 4 covers exactly this.
- **`hg-error-no-status` pointed users at `hg summit`**, which is not a command. The English says `hg summary`.

### Reversed or wrong meaning

| Level / key | English | was translated as |
|---|---|---|
| `selectiveRebase` | We will **let you figure out** how to solve this one | we will **tell you** how to solve it |
| `grabbingOneCommit` | get my `bugFix` back **into** the `main` branch | take it **from** main |
| `mergeManyFeatures` | `C1` can be rebased ***past*** `C3` | ***before*** `C3` (also contradicting the next sentence) |
| `manyRebases` | **Upper management** is making this trickier | **managing upwards**; goal commits also lost their apostrophes |
| `git-error-branch` | three things you can't delete | collapsed into one wrong claim |
| `error-command-currently-not-supported` | try **entering** a level | **add** a level |
| `merging` | a commit with two **parents** | two **source codes** |
| `jugglingCommits2` | a commit from anywhere **in the tree** | anywhere **in HEAD** |

### Dropped content

- `remoteBranches` lost **"detached"** from "detached `HEAD` mode" — the concept the level exists to teach
- `fakeTeamwork` dropped **"and merge them"** from the closing task, leaving the instruction incomplete
- `rebasing` dropped the explanation of why the visualization draws rebased work *below* main, and replaced it with a sentence that is not in the source
- `clone` garbled "see how we share work across these repositories"

### Terminology

- **"staging" → "sahneleme"**, the theatrical sense of the word
- **"check out" → "kontrol etmek"** ("to verify") in nine places
- **"diverged" → "çatışan"**, conflating it with git conflicts
- **"branch" → "branş"**, which in Turkish means an academic or professional discipline
- **HEAD → "başlık"** (a title) in `git-status-detached`
- **"apostrophe" → "tırnak işareti"** (a quotation mark)

### Typos, grammar, consistency

Eighteen typos and grammar errors (`çalımanının`, `atsı`, `bilinmiyo`, `bulunmamaktadı`, `Anomalleri`, `komitleri`, a stray word in `selectiveRebase`, and so on), plus terms that were rendered several different ways: "relative" appeared as *İlgili*, *Göreli* and *Göreceli* — *İlgili* is simply the wrong word; two level names did not match their own dialog headings; "level" alternated between *seviye*, *bölüm* and *level*.

## Deliberately left alone

- **`branch` is rendered as "dal" in roughly 149 places** (140 across 21 level files, 9 in `strings.js`), although `TRANSLATING.md` lists `branch` among the terms to keep in English. Too wide to bundle here, and a mechanical replace does not work because Turkish suffixes change.
- **`hide-goal`, `hide-start` and `goal-only-main`** tell users to type `hedefi gizle` / `başlangıcı gizle`, but the command matches on `/^hide goal$/`, so the translated form never works. `de_DE` and `ru_RU` correctly keep the command in English. Pre-existing, and worth its own PR.

Happy to send either as a follow-up.

## Checks

- `node scripts/validate-locale.js tr_TR` → 111/111 UI strings, 34/34 levels
- `yarn test` → 354/354 specs pass
- `npx gulp lint` (jshint) → clean
- Verified in the browser under `tr_TR`: the two new levels, the tags level, renamed levels, the sequence cards, and live `git status` output
- Checked that every `{placeholder}` in a `tr_TR` string still matches its English counterpart — no other locale-side placeholder drift

## One note for maintainers

`TRANSLATING.md` and `CLAUDE.md` both tell contributors to run `yarn gulp lintStrings`, but there is no `lintStrings` task in `gulpfile.js` — it fails with "Task never defined". I ran `node src/js/intl/checkStrings.js` directly instead, which reports no missing keys. Might be worth re-adding the task or updating the docs.
