### PR TITLE
equire -d / --detach for git switch detached HEAD (#1240)

### DIFF
--- a/__tests__/git.spec.js
+++ b/__tests__/git.spec.js
@@ -82,11 +82,27 @@ describe('Git', function() {
   });
 
   describe('Switches', function() {
-    it("to a commit", function () {
+    it("to a commit with -d option", function () {
       return expectTreeAsync(
-        'git switch C0',
+        'git switch -d C0',
         '{"branches":{"main":{"target":"C1","id":"main"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"C0","id":"HEAD"}}'
       );
+    });
+
+    it("to a commit with --detach option", function () {
+      return expectTreeAsync(
+        'git switch --detach C0',
+        '{"branches":{"main":{"target":"C1","id":"main"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"C0","id":"HEAD"}}'
+      );
+    });
+
+    it("refuses to detach onto a commit without -d / --detach", function () {
+      return runCommand('git switch C0', function(commandMsg) {
+        expect(commandMsg).toEqual(intl.str(
+          'git-error-switch-detach',
+          { ref: 'C0' }
+        ));
+      });
     });
 
     it("to a branch", function () {

--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -1122,6 +1122,8 @@ var commandConfig = {
       '--force-create',
       '-t',
       '--track',
+      '-d',
+      '--detach',
       '-'
     ],
     execute: function(engine, command) {
@@ -1177,9 +1179,31 @@ var commandConfig = {
         return;
       }
 
+      let detachOption = commandOptions['-d'] ? commandOptions['-d'] : commandOptions['--detach'];
+      if (detachOption) {
+        // "-d" / "--detach" explicitly asks to check out a commit-ish and leave
+        // HEAD detached there. Like "-t" above, a ref sitting right after the
+        // flag gets attached to it by the greedy option parser, so fold it back
+        // into the general args before we read it.
+        let args = detachOption.concat(generalArgs);
+        command.validateArgBounds(args, 1, 1, '-d');
+        engine.checkout(engine.crappyUnescape(args[0]));
+        return;
+      }
+
       command.validateArgBounds(generalArgs, 1, 1);
 
-      engine.checkout(engine.crappyUnescape(generalArgs[0]));
+      // Unlike "git checkout", "git switch" will not silently leave you on a
+      // detached HEAD. If the target isn't a branch (i.e. it's a commit or a
+      // tag), refuse and point the user at "--detach", matching real git.
+      var target = engine.crappyUnescape(generalArgs[0]);
+      if (engine.getType(target) !== 'branch') {
+        throw new GitError({
+          msg: intl.str('git-error-switch-detach', { ref: generalArgs[0] })
+        });
+      }
+
+      engine.checkout(target);
     }
   }
 };

--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -837,6 +837,10 @@ exports.strings = {
     "hu_HU": "Ebben a demóban nincs szükség fájlok hozzáadására",
     "az": "Bu demoda fayl əlavə etməyə ehtiyac yoxdur"
   },
+  "git-error-switch-detach": {
+    "__desc__": "the error when the user tries to 'git switch' to a commit or tag (which would detach HEAD) without passing -d / --detach",
+    "en_US": "fatal: a branch is required to switch to. '{ref}' is not a branch -- use 'git switch --detach {ref}' (or '-d') if you want to check it out and detach HEAD."
+  },
   "git-error-options": {
     "__desc__": "One of the error messages for git",
     "en_US": "Those options you specified are incompatible or incorrect",


### PR DESCRIPTION
Closes #1240

Related issue: [#1240](https://github.com/pcottle/learnGitBranching/issues/1240)

### What
`git switch` now behaves like real git when the target would detach HEAD:

- Added `-d` and `--detach` to the `switch` options.
- `git switch -d <commit>` / `git switch --detach <commit>` checks out the commit and leaves HEAD detached.
- A plain `git switch <commit>` (or a tag) no longer silently detaches. It throws a git-style error pointing the user to `--detach`.
- Switching to a branch is unchanged.

### Why
As noted in #1240, real git refuses to switch onto anything that would result in a detached HEAD unless `-d` / `--detach` is passed, and it accepts those flags. The app previously accepted neither flag and detached silently.

### Changes
- `src/js/git/commands.js`: added the two options and the detach / branch-required logic in the `switch` command.
- `src/js/intl/strings.js`: added the `git-error-switch-detach` message (en_US).
- `__tests__/git.spec.js`: updated the existing "switch to a commit" test to use `-d`, and added tests for `--detach` and for the refusal case.

### Testing
- `npx jasmine "__tests__/**/*.spec.js" --random=false` passes (356 specs, 0 failures).
- No new jshint findings versus the base tree.