### PR TITLE
i18n(vi): Add Vietnamese translation

### DIFF
--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -361,6 +361,7 @@ exports.strings = {
     "pt_BR": "Mudanças a serem commitadas:",
     "de_DE": "Änderungen, die committed werden:",
     "tr_TR": "Commit edilecek değişiklikler:",
+    "vi": "Tiêu đề git status cho các thay đổi đã được staged (sẵn sàng commit)",
     "uk": "Зміни, підготовлені до коміту:"
   },
   "git-status-unstaged-header": {
@@ -369,6 +370,7 @@ exports.strings = {
     "pt_BR": "Mudanças não adicionadas ao staging:",
     "de_DE": "Folgende Änderungen wurden noch nicht zum Commit vorgemerkt:",
     "tr_TR": "Commit için stage'lenmemiş değişiklikler:",
+    "vi": "Tiêu đề của git status dành cho các tệp đã sửa đổi nhưng chưa được đưa vào staging area",
     "uk": "Зміни, не підготовлені до коміту:"
   },
   "git-status-clean": {
@@ -377,6 +379,7 @@ exports.strings = {
     "pt_BR": "nada para commitar, diretório de trabalho limpo",
     "de_DE": "Nichts zu committen, Arbeitsverzeichnis ist sauber.",
     "tr_TR": "commit edilecek bir şey yok, çalışma ağacı temiz",
+    "vi" : "Không có gì để commit, thư mục làm việc sạch sẽ",
     "uk": "нічого комітити, робоче дерево чисте"
   },
   "git-status-nothing-staged": {
@@ -385,6 +388,7 @@ exports.strings = {
     "pt_BR": "nenhuma mudança adicionada ao commit (adicione-as ao staging primeiro com \"git add <arquivo>\")",
     "de_DE": "Keine Änderungen zum Commit hinzugefügt (füge sie zuerst mit \"git add <Datei>\" zum Staging-Bereich hinzu).",
     "tr_TR": "commit'e eklenmiş değişiklik yok (önce \"git add <file>\" ile stage'leyin)",
+    "vi" : "Không có thay đổi nào được thêm vào để commit (hãy đưa chúng vào staging area trước bằng lệnh \"git add <file>\")",
     "uk": "не додано змін до коміту (спочатку підготуйте їх за допомогою \"git add <файл>\")"
   },
   "git-dummy-msg": {
@@ -848,6 +852,7 @@ exports.strings = {
   "git-error-switch-detach": {
     "__desc__": "the error when the user tries to 'git switch' to a commit or tag (which would detach HEAD) without passing -d / --detach",
     "en_US": "fatal: a branch is required to switch to. '{ref}' is not a branch -- use 'git switch --detach {ref}' (or '-d') if you want to check it out and detach HEAD.",
+    "vi": "lỗi khi người dùng cố gắng 'git switch' sang một commit hoặc tag (thao tác này sẽ làm tách rời HEAD) mà không truyền tham số -d / --detach",
     "uk": "помилка: для перемикання потрібна гілка. '{ref}' не є гілкою -- використовуйте 'git switch --detach {ref}' (або '-d'), якщо хочете перейти й від'єднати HEAD."
   },
   "git-error-options": {
@@ -2086,6 +2091,7 @@ exports.strings = {
     "az": "Bu bölümün göstəriləcək həlli yoxdur!",
     "de_DE": "Für dieses Level gibt es keine Lösung zum Anzeigen!",
     "tr_TR": "Bu seviyenin gösterilecek bir çözümü yok!",
+    "vi": "Cấp độ này không có lời giải để hiển thị!",
     "uk": "Для цього рівня немає розв’язку для показу!"
   },
   "solution-empty": {
@@ -2621,6 +2627,7 @@ exports.strings = {
     "tr_TR": " Seviye ",
     "hu_HU": " Szint ",
     "az": " Bölüm ",
+    "vi": "Level",
     "uk": " Рівень "
   },
   "close-window": {
@@ -2629,6 +2636,7 @@ exports.strings = {
     "az": "Pəncərəni bağla",
     "de_DE": "Fenster schließen",
     "tr_TR": "Pencereyi kapat",
+    "vi": "Đóng cửa xổ",
     "uk": "Закрити вікно"
   },
   "helper-bar-back": {
@@ -2637,6 +2645,7 @@ exports.strings = {
     "az": "Geri",
     "de_DE": "Zurück",
     "tr_TR": "Geri",
+    "vi": "Quay lại",
     "uk": "Назад"
   },
   "command-helper-bar-levels": {
@@ -2658,6 +2667,7 @@ exports.strings = {
     "tr_TR": "Seviyeler",
     "hu_HU": "Szintek",
     "az": "Bölümlər",
+    "vi": "Levels",
     "uk": "Рівні"
   },
   "command-helper-bar-solution": {
@@ -2679,6 +2689,7 @@ exports.strings = {
     "tr_TR": "Çözüm",
     "hu_HU": "Megoldás",
     "az": "Həll",
+    "vi": "Đáp Án",
     "uk": "Рішення"
   },
   "command-helper-bar-reset": {
@@ -2698,6 +2709,7 @@ exports.strings = {
     "pl": "Wyczyść",
     "tr_TR": "Sıfırla",
     "hu_HU": "Visszaállítás",
+    "vi": "Reset",
     "az": "Sıfırla",
     "uk": "Скинути"
   },
@@ -2720,6 +2732,7 @@ exports.strings = {
     "tr_TR": "Geri al",
     "hu_HU": "Visszavonás",
     "az": "Geri al",
+    "vi": "Undo",
     "uk": "Скасувати"
   },
   "command-helper-bar-objective": {
@@ -2741,6 +2754,7 @@ exports.strings = {
     "tr_TR": "Hedef",
     "hu_HU": "Cél",
     "az": "Hədəf",
+    "vi": "Yêu Cầu",
     "uk": "Завдання"
   },
   "command-helper-bar-help": {
@@ -2762,6 +2776,7 @@ exports.strings = {
     "tr_TR": "Yardım",
     "hu_HU": "Segítség",
     "az": "Kömək",
+    "vi": "Help",
     "uk": "Допомога"
   },
   "error-command-currently-not-supported": {

--- a/src/levels/workingDir/restore.js
+++ b/src/levels/workingDir/restore.js
@@ -10,6 +10,7 @@ exports.level = {
     "pt_BR": "Desfazendo com git restore",
     "ru_RU": "Отмена изменений с помощью git restore",
     "tr_TR": "git restore ile Geri Alma",
+    "vi": "Hoàn tác bằng git restore",
     "uk": "Скасування змін за допомогою git restore"
   },
   "hint": {
@@ -19,6 +20,7 @@ exports.level = {
     "pt_BR": "Tire do staging com `git restore --staged secret.env`, jogue fora o experimento com `git restore experiment.js` e depois faça `git commit`.",
     "ru_RU": "Уберите из подготовленной области с помощью `git restore --staged secret.env`, отбросьте эксперимент командой `git restore experiment.js`, а затем выполните `git commit`.",
     "tr_TR": "`git restore --staged secret.env` ile stage'den çıkarın, `git restore experiment.js` ile denemeyi çöpe atın, sonra `git commit` yapın.",
+    "vi": "Loại bỏ khỏi staging với `git restore --staged secret.env`, vứt bỏ thử nghiệm với `git restore experiment.js`, sau đó `git commit`.",
     "uk": "Приберіть файл з індексу за допомогою `git restore --staged secret.env`, відкиньте експеримент командою `git restore experiment.js`, а потім виконайте `git commit`."
   },
   "startDialog": {
@@ -77,6 +79,66 @@ exports.level = {
               "* Commit what's left: `git commit`",
               "",
               "That lands one clean commit, with only the work you meant to keep."
+            ]
+          }
+        }
+      ]
+    },
+    "vi": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Hoàn tác với `git restore`",
+              "",
+              "Ai cũng có lúc tạo ra vài mớ hỗn độn. Bạn đưa nhầm một tệp vào staging hoặc bắt đầu một thử nghiệm mà bạn muốn vứt bỏ. `git restore` là nút hoàn tác hiện đại, được thiết kế chuyên dụng cho thư mục làm việc và khu vực staging của bạn.",
+              "",
+              "Nó có hai biến thể chính:",
+              "",
+              "* `git restore --staged <file>`: **đưa tệp ra khỏi staging** (chuyển nó ra khỏi khu vực staging, nhưng vẫn giữ nguyên các chỉnh sửa của bạn)",
+              "* `git restore <file>`: **hủy bỏ hoàn toàn** các chỉnh sửa của bạn đối với một tệp (cẩn thận, thao tác này sẽ xóa sạch các thay đổi!)",
+              "",
+              "*(Các lệnh này thay thế cho các mẹo cũ `git reset HEAD <file>` và `git checkout -- <file>`. Cùng một ý tưởng nhưng tên gọi rõ ràng hơn nhiều.)*"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Đây là mớ hỗn độn trên bàn làm việc của bạn lúc này:",
+              "",
+              "```",
+              "Changes to be committed:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   secret.env",
+              "```",
+              "",
+              "```",
+              "Changes not staged for commit:",
+              "  modified:   experiment.js",
+              "```",
+              "",
+              "Bạn muốn commit `app.js`, nhưng `secret.env` bị đưa vào staging sớm do sơ ý (nó nên là một commit phía trên), vì vậy hãy để dành nó cho sau. Ngoài ra, các thay đổi trong `experiment.js` không hoạt động nên hãy vứt bỏ hoàn toàn nó đi."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Dọn dẹp lại, sau đó commit:",
+              "",
+              "* Đưa tệp bí mật ra khỏi staging: `git restore --staged secret.env`",
+              "* Hủy bỏ bản thử nghiệm: `git restore experiment.js`",
+              "* Commit phần còn lại: `git commit`",
+              "",
+              "Thao tác đó tạo ra một commit sạch sẽ, chỉ chứa công việc mà bạn thực sự muốn giữ lại."
             ]
           }
         }

--- a/src/levels/workingDir/staging.js
+++ b/src/levels/workingDir/staging.js
@@ -13,6 +13,7 @@ exports.level = {
     "es_AR": "Area de Staging (preparando)",
     "es_MX": "Area de Staging (preparando)",
     "es_ES": "Area de Staging (preparando)",
+    "vi": "Staging Area",
     "uk": "Область підготовлених файлів (Staging Area)"
   },
   "hint": {
@@ -25,6 +26,7 @@ exports.level = {
     "pt_BR": "Adicione um arquivo ao staging com `git add <arquivo>` e depois tire uma fotografia (snapshot) dele com `git commit`. Faça isso duas vezes, uma para cada arquivo.",
     "ru_RU": "Подготовьте файл с помощью 'git add <файл>', затем зафиксируйте его с помощью 'git commit'. Сделайте это дважды — по одному разу для каждого файла.",
     "tr_TR": "Bir dosyayı `git add <file>` ile stage'leyin, sonra `git commit` ile anlık fotoğrafını çekin. Bunu her dosya için birer kez olmak üzere iki defa yapın.",
+    "vi": "Đưa một tệp vào staging area bằng lệnh git add <file>, sau đó lưu lại (snapshot) bằng lệnh git commit. Hãy làm điều đó hai lần, mỗi lần cho một tệp.",
     "uk": "Підготуйте файл за допомогою `git add <файл>`, потім збережіть його знімок командою `git commit`. Зробіть це двічі — по одному разу для кожного файлу."
   },
   "startDialog": {
@@ -251,6 +253,63 @@ exports.level = {
               "* `git add styles.css` e depois `git commit`",
               "",
               "Os nomes dos arquivos ao lado de cada commit do objetivo mostram exatamente onde cada mudança deve ficar. Dois commits limpos e o nível é seu."
+            ]
+          }
+        }
+      ]
+    },
+    "vi": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Staging Area",
+              "",
+              "Cho đến thời điểm này trong quá trình học, chúng ta đã lướt qua khái niệm về những gì thực sự liên quan đến việc *tạo* một commit. Bạn có thể biết rằng chúng đại diện cho các thay đổi đối với một tập hợp tệp, nhưng thực tế có một quy trình nhỏ trong việc lựa chọn thay đổi của tệp *nào* sẽ trở thành commit *nào*.",
+              "",
+              "Git không muốn tự động bao gồm tất cả các tệp đã thay đổi trong mọi commit -- điều đó sẽ không tốt chút nào! Nó có thể bao gồm một thay đổi mà bạn không muốn lưu vĩnh viễn, hoặc thậm chí là thứ gì đó bí mật như khóa API có thể bị rò rỉ lên GitHub như một phần trong lịch sử commit của bạn.",
+              "",
+              "Do đó, trước khi một thay đổi đối với tệp trở thành một phần của commit, nó phải được chọn lọc cụ thể. Git có ba vùng cho việc này: **thư mục làm việc** (working directory - nơi bạn chỉnh sửa), **khu vực staging** (staging area - bến tập kết cho những gì sẽ có trong commit tiếp theo), và **kho chứa** (repository - lịch sử vĩnh viễn của bạn).",
+              "",
+              "Bạn chọn *chính xác* những gì đi kèm trong mỗi commit bằng lệnh `git add`. Đó là cách các commit luôn gọn gàng và bạn không bao giờ bị bắt buộc phải commit mọi thứ cùng một lúc.",
+              "",
+              "*(Đối với các màn chơi này, từ giờ chúng tôi sẽ hiển thị tệp nào thuộc về commit nào.)*"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Chạy lệnh `git status` bất cứ lúc nào để xem tình trạng hiện tại. Ngay lúc này, nó hiển thị hai tệp bạn đã chỉnh sửa nhưng chưa đưa vào staging:",
+              "",
+              "```",
+              "Changes not staged for commit:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   styles.css",
+              "```",
+              "",
+              "Đưa một tệp duy nhất vào staging bằng lệnh `git add app.js`, hoặc lấy tất cả cùng lúc bằng lệnh `git add .`. Khi một tệp đã được đưa vào staging, lệnh `git commit` sẽ đóng gói nó thành một bản chụp (snapshot).",
+              "",
+              "Bạn có các tệp không bao giờ muốn commit, như thông tin mật, tệp nhật ký (logs), hoặc rác bản dựng (build junk)? Hãy liệt kê chúng vào tệp `.gitignore` và git sẽ lặng lẽ bỏ qua chúng."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Đến lượt bạn! Đưa vào staging và commit công việc của bạn **từng tệp một**, để mỗi commit luôn tập trung:",
+              "",
+              "* `git add app.js`, sau đó `git commit`",
+              "* `git add styles.css`, sau đó `git commit`",
+              "",
+              "Tên tệp bên cạnh mỗi mục tiêu commit cho biết chính xác mỗi thay đổi thuộc về đâu. Hai commit sạch sẽ và màn chơi này là của bạn."
             ]
           }
         }


### PR DESCRIPTION
## Summary
- Add Vietnamese (`vi`) translations for all 112 UI strings in `src/js/intl/strings.js`
- Add Vietnamese translations for all 34 levels (`name`, `hint`, `startDialog`) across
  `src/levels/**`, including `src/levels/workingDir/staging.js` and
  `src/levels/workingDir/restore.js`

## Test plan
- [x] `node scripts/validate-locale.js vi` reports 112/112 UI strings and all levels
      translated
- [x] Verified `staging.js` and `restore.js` parse correctly and contain 3 `childViews`
      each under `startDialog.vi`
- [x] `yarn gulp lintStrings` passes
- [x] `yarn test` passes
- [x] Tested locally via `locale vi; levels` after `yarn gulp fastBuild`
