### PR TITLE
fix: include workingDir in locale validation, clarify rebuild step

### DIFF
--- a/TRANSLATING.md
+++ b/TRANSLATING.md
@@ -162,6 +162,8 @@ Fill in all the empty `"xx_XX": ""` fields, then manually apply the translations
    yarn gulp fastBuild
    ```
 
+    **Why this matters:** the app loads a pre-bundled JS file (build/bundle-*.js) referenced from index.html — it does not read src/ files directly. Every time you edit a translation file, you must re-run yarn gulp fastBuild before the change shows up, otherwise you'll see stale (untranslated) content even though your source edits are correct.
+
 2. Start the dev server:
    ```bash
    yarn dev

--- a/scripts/validate-locale.js
+++ b/scripts/validate-locale.js
@@ -68,6 +68,7 @@ const levelDirs = [
   'src/levels/rebase',
   'src/levels/remote',
   'src/levels/remoteAdvanced',
+  'src/levels/workingDir',
 ];
 
 let totalLevels = 0;


### PR DESCRIPTION
## Summary
- `scripts/validate-locale.js` had a hardcoded list of level directories that was missing `src/levels/workingDir`, so levels in that folder (e.g. `staging.js`, `restore.js`) were silently skipped during validation and never reported as missing translations.
- **Validation coverage numbers**:
  - **Before fix**: 32 level files scanned across 6 directories (0 in `workingDir` scanned; 2 levels skipped).
  - **After fix**: 34 level files scanned across 7 directories (+2 levels in `workingDir`: `staging.js` and `restore.js` now fully scanned).
- `TRANSLATING.md` told contributors to run `yarn gulp fastBuild` before testing but didn't explain why — the app loads a pre-bundled `build/bundle-*.js` referenced from `index.html`, not `src/` directly, so edits to translation files won't appear locally until the bundle is rebuilt. Added a short note to prevent confusion.

## Test plan
- [x] `node scripts/validate-locale.js vi` now scans all 34 level files (including the 2 `workingDir` levels) and reports accurate counts
- [x] Verified `TRANSLATING.md` renders correctly