### PR TITLE
Add de_DE for restore level & complete UI strings

### DIFF
--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -852,6 +852,7 @@ exports.strings = {
   "git-error-switch-detach": {
     "__desc__": "the error when the user tries to 'git switch' to a commit or tag (which would detach HEAD) without passing -d / --detach",
     "en_US": "fatal: a branch is required to switch to. '{ref}' is not a branch -- use 'git switch --detach {ref}' (or '-d') if you want to check it out and detach HEAD.",
+    "de_DE": "fatal: Zum Wechseln wird ein Branch benötigt. '{ref}' ist kein Branch -- benutze 'git switch --detach {ref}' (oder '-d'), wenn du ihn auschecken und den HEAD abkoppeln willst.",
     "vi": "lỗi khi người dùng cố gắng 'git switch' sang một commit hoặc tag (thao tác này sẽ làm tách rời HEAD) mà không truyền tham số -d / --detach",
     "uk": "помилка: для перемикання потрібна гілка. '{ref}' не є гілкою -- використовуйте 'git switch --detach {ref}' (або '-d'), якщо хочете перейти й від'єднати HEAD."
   },
@@ -1737,19 +1738,23 @@ exports.strings = {
   },
   "share-progress": {
     "__desc__": "Button label prompting user to share their level completion on social media",
-    "en_US": "Share your progress!"
+    "en_US": "Share your progress!",
+    "de_DE": "Teile deinen Fortschritt!"
   },
   "share-progress-twitter": {
     "__desc__": "Button label to share level completion on Twitter / X",
-    "en_US": "X (Twitter)"
+    "en_US": "X (Twitter)",
+    "de_DE": "X (Twitter)"
   },
   "share-progress-linkedin": {
     "__desc__": "Button label to share level completion on LinkedIn",
-    "en_US": "LinkedIn"
+    "en_US": "LinkedIn",
+    "de_DE": "LinkedIn"
   },
   "share-progress-facebook": {
     "__desc__": "Button label to share level completion on Facebook",
-    "en_US": "Facebook"
+    "en_US": "Facebook",
+    "de_DE": "Facebook"
   },
   "paste-json": {
     "__desc__": "When you are importing a level or tree",

--- a/src/levels/workingDir/restore.js
+++ b/src/levels/workingDir/restore.js
@@ -5,6 +5,7 @@ exports.level = {
   "startTree": '{"branches":{"main":{"target":"C1","id":"main"}},"commits":{"C0":{"parents":[],"id":"C0","rootCommit":true},"C1":{"parents":["C0"],"id":"C1"}},"HEAD":{"target":"main","id":"HEAD"},"workingChanges":{"app.js":"staged","secret.env":"staged","experiment.js":"modified"}}',
   "name": {
     "en_US": "Undoing with git restore",
+    "de_DE": "Rückgängig machen mit git restore",
     "zh_CN": "使用 git restore 撤销修改",
     "zh_TW": "使用 git restore 復原變更",
     "pt_BR": "Desfazendo com git restore",
@@ -15,6 +16,7 @@ exports.level = {
   },
   "hint": {
     "en_US": "Unstage with `git restore --staged secret.env`, throw away the experiment with `git restore experiment.js`, then `git commit`.",
+    "de_DE": "Entferne `secret.env` aus der Staging Area mit `git restore --staged secret.env`, verwerfe die Änderungen an experiment mit `git restore experiment.js`, dann mach einen Commit mit `git commit`.",
     "zh_CN": "使用 `git restore --staged secret.env` 取消暂存，使用 `git restore experiment.js` 丢弃实验性修改，然后执行 `git commit`。",
     "zh_TW": "使用 `git restore --staged secret.env` 取消暫存，使用 `git restore experiment.js` 捨棄實驗性變更，然後執行 `git commit`。",
     "pt_BR": "Tire do staging com `git restore --staged secret.env`, jogue fora o experimento com `git restore experiment.js` e depois faça `git commit`.",
@@ -79,6 +81,66 @@ exports.level = {
               "* Commit what's left: `git commit`",
               "",
               "That lands one clean commit, with only the work you meant to keep."
+            ]
+          }
+        }
+      ]
+    },
+    "de_DE": {
+      "childViews": [
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "## Rückgängig machen mit `git restore`",
+              "",
+              "Jeder ist mal unachtsam und verursacht etwas Chaos. Man fügt versehentlich eine Datei zur Staging Area hinzu oder macht ein kleines Experiment, das man lieber wieder verwirft. `git restore` ist der moderne, genau dafür gemachte Weg solche Sachen rückgängig zu machen. Er ist nutzbar im Arbeitsbereich und in der Staging Area.",
+              "",
+              "Du kannst es auf zwei Arten nutzen:",
+              "",
+              "* `git restore --staged <Datei>`: **entferne** eine Datei aus der Staging Area, wobei die Änderung an der Datei aber erhalten bleibt.",
+              "* `git restore <Datei>`: **verwerfe** deine Änderungen komplett (sei vorsichtig, alle deine Änderungen sind dann wirklich weg!)",
+              "",
+              "*(Diese zwei Befehle ersetzen die älteren `git reset HEAD <Datei>` und `git checkout -- <Datei>` Tricks. Gleiche Funktion, aber klarere Namen.)*"
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Wir haben hier so ein kleines Durcheinander:",
+              "",
+              "```",
+              "Changes to be committed:",
+              "```",
+              "```",
+              "  modified:   app.js",
+              "```",
+              "```",
+              "  modified:   secret.env",
+              "```",
+              "",
+              "```",
+              "Changes not staged for commit:",
+              "  modified:   experiment.js",
+              "```",
+              "",
+              "Du möchtest `app.js` committen, aber hast `secret.env` auch versehentlich in die Staging Area geschoben (es müsste eigentlich zum Commit davor gehören), aber lass uns das später machen. Außerdem hast du ein kleines Experiment in `experiment.js` probiert. Aber das hat nicht so geklappt, wie du es dir vorgestellt hast, also lass uns das komplett verwerfen."
+            ]
+          }
+        },
+        {
+          "type": "ModalAlert",
+          "options": {
+            "markdowns": [
+              "Kümmere dich um das kleine Chaos, dann committe:",
+              "",
+              "* Entferne das secret aus der Staging Area: `git restore --staged secret.env`",
+              "* Verwerfe das kleine Experiment: `git restore experiment.js`",
+              "* Committe den Rest: `git commit`",
+              "",
+              "Das resultiert in einem sauberen Commit, der nur das enthält, was du wirklich drin haben wolltest."
             ]
           }
         }


### PR DESCRIPTION
 - src/levels/workingDir/restore.js — added German (de_DE) translations for name, hint, and startDialog.
 - src/js/intl/strings.js — added the last 5 missing de_DE UI strings:
   - git-error-switch-detach
   - share-progress
   - share-progress-twitter
   - share-progress-linkedin
   - share-progress-facebook

 The German locale is now fully translated.