### PR TITLE
fix(i18n): support RTL locales

### DIFF
--- a/src/js/app/index.js
+++ b/src/js/app/index.js
@@ -37,6 +37,7 @@ var commandUI;
 var sandbox;
 var eventBaton;
 var levelDropdown;
+var RTL_LOCALES = ['ar', 'fa'];
 
 ///////////////////////////////////////////////////////////////////////
 
@@ -62,6 +63,7 @@ var init = function() {
   });
 
   LocaleStore.subscribe(intlRefresh);
+  intlRefresh();
   events.on('vcsModeChange', vcsModeRefresh);
 
   initRootEvents(eventBaton);
@@ -115,14 +117,22 @@ var insertAlternateLinks = function(pageId) {
 
 var intlRefresh = function() {
   if (!window.$) { return; }
-  var countryCode = LocaleStore.getLocale().split("_")[0];
-  $("html").attr('lang', countryCode);
+  var locale = LocaleStore.getLocale();
+  var countryCode = locale.split("_")[0];
+  document.documentElement.setAttribute('lang', countryCode);
+  document.documentElement.setAttribute('dir', exports.getLocaleDirection(locale));
   $("meta[http-equiv='content-language']").attr("content", countryCode);
   $('span.intl-aware').each(function(i, el) {
     var intl = require('../intl');
     var key = $(el).attr('data-intl');
     $(el).text(intl.str(key));
   });
+};
+
+exports.getLocaleDirection = function(locale) {
+  if (typeof locale !== 'string') { return 'ltr'; }
+  var language = locale.split(/[-_]/)[0].toLowerCase();
+  return RTL_LOCALES.indexOf(language) !== -1 ? 'rtl' : 'ltr';
 };
 
 var initRootEvents = function(eventBaton) {

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -58,6 +58,50 @@ div.modalTerminal p {
   margin: 1.5em 0;
 }
 
+/* Keep translated prose in its natural reading order for RTL locales. */
+html[dir='rtl'] .modalTerminal .inside,
+html[dir='rtl'] .demonstrationText .beforeText,
+html[dir='rtl'] .demonstrationText .afterText,
+html[dir='rtl'] .levelDropdownView .displayName,
+html[dir='rtl'] .levelDropdownView .about,
+html[dir='rtl'] .levelDropdownView .levelInfo,
+html[dir='rtl'] div.commandLineResult,
+html[dir='rtl'] div.commandLineWarnings,
+html[dir='rtl'] .intl-aware {
+  direction: rtl;
+  text-align: right;
+}
+
+/* Keep the structural shell, graph, and command-entry layout left-to-right. */
+html[dir='rtl'] #interfaceWrapper,
+html[dir='rtl'] #canvasHolder,
+html[dir='rtl'] .canvasTerminalHolder .terminal-window-holder,
+html[dir='rtl'] .gitDemonstrationView .visHolder,
+html[dir='rtl'] #commandLineBar,
+html[dir='rtl'] #commandLineHistory,
+html[dir='rtl'] #prompt {
+  direction: ltr;
+  text-align: left;
+}
+
+/* Git commands and Markdown code spans must retain their natural LTR order
+ * when they appear inside RTL instructional text. */
+html[dir='rtl'] code,
+html[dir='rtl'] pre,
+html[dir='rtl'] #commandTextField,
+html[dir='rtl'] #prompt p.command,
+html[dir='rtl'] p.commandLine,
+html[dir='rtl'] div.commandLineResult code,
+html[dir='rtl'] div.commandLineWarnings code,
+html[dir='rtl'] .canvasTerminalHolder .terminal-text,
+html[dir='rtl'] .canvasTerminalHolder .terminal-text p,
+html[dir='rtl'] #prompt span.promptSign,
+html[dir='rtl'] #prompt span.cursor {
+  direction: ltr;
+  text-align: left;
+  unicode-bidi: isolate;
+}
+
 .textAlignCenter {
   text-align: center;
 }


### PR DESCRIPTION
## Summary

- Set the document language and direction from the active locale.
- Support RTL rendering for Persian and Arabic locale subtags.
- Render translated prose RTL while preserving LTR Git diagrams, terminal output, commands, prompts, and Markdown code.

## Testing

- `git diff --check upstream/main...HEAD`
- `node --check src/js/app/index.js`
- `npx --no-install gulp lint`
- `node src/js/intl/checkStrings.js`

## Limitations

- Full browser visual regression checks were unavailable locally; Persian and Arabic UI surfaces should be visually verified in the deploy preview.
