### PR TITLE
feat: Linux-style Tab autocomplete -- LCP on first press + cycle through matches on repeated Tab

### DIFF
--- a/src/js/views/commandViews.js
+++ b/src/js/views/commandViews.js
@@ -36,11 +36,35 @@ const allCommandsSorted = autoCompleteSuggestionOrder.concat(
   .filter(command => !!command)
 );
 
+/**
+ * Compute the longest common prefix of an array of strings.
+ * e.g. ['git cherry-pick', 'git clone'] => 'git c'
+ */
+function longestCommonPrefix(strings) {
+  if (!strings || !strings.length) return '';
+  let prefix = strings[0];
+  for (let i = 1; i < strings.length; i++) {
+    let j = 0;
+    while (j < prefix.length && j < strings[i].length && prefix[j] === strings[i][j]) {
+      j++;
+    }
+    prefix = prefix.substring(0, j);
+    if (!prefix) return '';
+  }
+  return prefix;
+}
+
 class CommandPromptView {
   constructor(options) {
     options = options || {};
     this.el = options.el;
     this.$el = $(this.el);
+
+    // Tab-cycle autocomplete state
+    this._tabMatches = null;       // currently matched commands array
+    this._tabIndex = -1;           // current index within the cycle (-1 = not yet cycling)
+    this._tabLastPrefix = '';      // last prefix used to trigger Tab (used to detect reset)
+    this._tabLastFullPrefix = '';  // last full prefix (anything before the final ;) for reassembly
 
     this.initialize();
   }
@@ -99,7 +123,11 @@ class CommandPromptView {
     const allCommand = currentValue.split(';');
     const lastCommand = allCommand[allCommand.length - 1]
       .replace(/\s\s+/g, ' ').replace(/^\s/, '');
+    // everything before the last command (keep earlier commands intact when using ';' separator)
+    const prefixBeforeLast = allCommand.slice(0, -1).join(';') +
+      (allCommand.length > 1 ? ';' : '');
 
+    // ---- Step 1: update the shadow hint (grey preview of the first match's suffix) ----
     shadowEl.innerHTML = '';
     if (lastCommand.length) {
       for (const c of allCommandsSorted) {
@@ -110,11 +138,88 @@ class CommandPromptView {
       }
     }
 
-    if (e.keyCode === 9) {
+    // ---- Step 2: Tab-completion logic (Linux-style: LCP on first press, cycle on repeats) ----
+    if (e.keyCode === 9 && e.type === 'keydown') {
       e.preventDefault();
-      if (shadowEl.innerHTML) {
-        el.value = shadowEl.innerHTML.replace(/&nbsp;/g, ' ');
+
+      // Prefix changed (user edited input or it is not a repeated Tab) -> reset matches
+      if (lastCommand !== this._tabLastPrefix ||
+          prefixBeforeLast !== this._tabLastFullPrefix) {
+        this._tabMatches = null;
+        this._tabIndex = -1;
       }
+
+      if (lastCommand.length === 0) {
+        // empty input: nothing to do, just record state
+        this._tabLastPrefix = lastCommand;
+        this._tabLastFullPrefix = prefixBeforeLast;
+      } else {
+        // collect all commands matching the current prefix
+        if (this._tabMatches === null) {
+          this._tabMatches = allCommandsSorted.filter(
+            c => c.startsWith(lastCommand)
+          );
+          this._tabIndex = -1;
+        }
+
+        const matches = this._tabMatches;
+
+        if (matches.length === 0) {
+          // no matches: do nothing
+        } else if (matches.length === 1) {
+          // only one match: complete it fully
+          el.value = prefixBeforeLast + matches[0];
+          // after completing, clear the shadow hint
+          shadowEl.innerHTML = '';
+          this._tabIndex = 0;
+        } else {
+          // multiple matches
+          if (this._tabIndex === -1) {
+            // first Tab: complete up to the longest common prefix
+            const lcp = longestCommonPrefix(matches);
+            if (lcp.length > lastCommand.length) {
+              // a longer common prefix exists, fill it in
+              el.value = prefixBeforeLast + lcp;
+              // record the new prefix we just expanded to
+              this._tabLastPrefix = lcp;
+              // update the shadow hint with the first match's remainder
+              const remain = matches[0].substring(lcp.length) || '';
+              if (remain) {
+                shadowEl.innerHTML = (el.value + remain).replace(/ /g, '&nbsp;');
+              } else {
+                shadowEl.innerHTML = '';
+              }
+              // re-filter _tabMatches against the new LCP so subsequent Tabs cycle correctly
+              this._tabMatches = allCommandsSorted.filter(
+                c => c.startsWith(lcp)
+              );
+              this._tabIndex = -1;
+            } else {
+              // LCP equals the input itself: enter the cycle, show first match
+              this._tabIndex = 0;
+              el.value = prefixBeforeLast + matches[0];
+              shadowEl.innerHTML = '';
+            }
+          } else {
+            // repeated Tab: advance to the next match (cycle)
+            this._tabIndex = (this._tabIndex + 1) % matches.length;
+            el.value = prefixBeforeLast + matches[this._tabIndex];
+            shadowEl.innerHTML = '';
+          }
+        }
+
+        // update prefix record (when we've landed on a concrete command)
+        if (this._tabIndex >= 0) {
+          this._tabLastPrefix = matches[this._tabIndex];
+        }
+        this._tabLastFullPrefix = prefixBeforeLast;
+      }
+    } else if (e.type === 'keydown') {
+      // any non-Tab keydown: reset Tab-cycle state (prefix effectively changed)
+      this._tabMatches = null;
+      this._tabIndex = -1;
+      this._tabLastPrefix = lastCommand;
+      this._tabLastFullPrefix = prefixBeforeLast;
     }
 
     // lets also handle control + U to clear the line


### PR DESCRIPTION
Builds on #842.

## Background
In #842 there was a good discussion about Tab-completion UX:

- Users typing `git che<Tab>` would land on `git cherry-pick` when they actually
  wanted `git checkout`.
- @Ashark favored a **bash-style UX** — complete up to the longest common
  prefix first, don't "guess" a single match when there are multiple.
- @pcottle said he was **"supportive of something like an additional tab to
  swap over to another suggestion"** (cycle-through).
- Eventually @pcottle closed #842 via commit `095ba99` ("Resolves #842 -- better
  ordering for suggestions"), which re-ordered the suggestion list so common
  commands like `git commit` / `git checkout` rank ahead of `git cherry-pick`.
  That fixed the 80% case, but the cycle-through + LCP UX from the same
  discussion was never implemented.

This PR implements that remaining part, so the ordering hotfix and the UX
improvement stack on top of each other rather than being alternatives.

## What this PR does
Hybrid UX that should feel familiar to users of real shells:

| Situation | Before (after 095ba99 ordering fix) | After |
|---|---|---|
| First Tab press — 1 match only | completes it | completes it (unchanged) |
| First Tab press — N matches + shared LCP longer than input | **picks the 1st match (by order)** | expands input to the **longest common prefix** (bash-style, no guessing) |
| First Tab press — N matches + LCP equals the current input | picks the 1st match by order | enters cycle mode, shows 1st match by order |
| Repeated consecutive Tab presses | **keeps picking the 1st match** (noop after first) | **cycles through all matches** (cycle order = already-improved suggestion order from 095ba99) |
| Any non-Tab keydown between Tabs | — | resets cycle state so the next Tab is a "fresh" first press |
| Semi-separated multi-command input (`cmd1; cmd2<Tab>`) | completes only last token | still only completes last token; prefix before `;` stays intact |

## Implementation
- Small `longestCommonPrefix(strings)` helper.
- 4 new state fields on `CommandPromptView`:
  `_tabMatches`, `_tabIndex`, `_tabLastPrefix`, `_tabLastFullPrefix`.
- Reuses the already-sorted `autoCompleteSuggestionOrder` (so 095ba99's
  ordering improvement feeds directly into the cycle order).
- The existing grey inline hint in `#shadow` is preserved.

## Verification steps
1. Type `git c` then Tab → input expands to the shared LCP `git c` (no guess).
2. Press Tab again → cycles through `git cherry-pick` → `git clone` → `git commit` → …
3. Type `git clo<Tab>` (single match) → completes to `git clone` immediately.
4. Type `git reb<Tab>` → expands to the longest shared prefix; further Tabs cycle.
5. Type `git commit; git ch<Tab>` → only the last command is completed; the
   `git commit; ` prefix is untouched.
6. After cycling, press any letter key (e.g. `o`) then Tab → cycle resets and
   a fresh LCP / match list is computed for the new input.

All 366 Jasmine specs pass: