### PR TITLE
Fix blurry doubled text in the command prompt autocomplete hint

### DIFF
--- a/src/js/views/commandViews.js
+++ b/src/js/views/commandViews.js
@@ -54,6 +54,46 @@ function longestCommonPrefix(strings) {
   return prefix;
 }
 
+/**
+ * The prompt renders spaces as non-breaking so that the fake cursor lines up
+ * with the real characters; the hint has to do the same or the two get out
+ * of sync.
+ */
+function shadowSafeText(text) {
+  return text.replace(/ /g, '\u00a0').replace(/\n/g, '');
+}
+
+/**
+ * Render the grey inline autocomplete hint into #shadow.
+ *
+ * #shadow sits directly on top of the real prompt text, so the characters
+ * the user already typed still need to be laid out (they push the suggested
+ * remainder over to the right spot) but must not be painted -- otherwise we
+ * draw a second, semi-transparent copy of every typed character on top of
+ * the real one, which reads as blurry / doubled text. Hence the hidden
+ * span for the typed part.
+ *
+ * We also use textContent rather than innerHTML: the typed text is
+ * arbitrary user input (anything before a ';' ends up here verbatim) and
+ * the real prompt escapes it, so the hint has to escape it too -- both to
+ * keep the two copies the same width and to keep markup out of the DOM.
+ */
+function renderShadowHint(shadowEl, typed, remainder) {
+  shadowEl.innerHTML = '';
+  if (!remainder) {
+    return;
+  }
+
+  const typedSpan = document.createElement('span');
+  typedSpan.className = 'shadowTyped';
+  typedSpan.textContent = shadowSafeText(typed);
+  shadowEl.appendChild(typedSpan);
+
+  const remainderSpan = document.createElement('span');
+  remainderSpan.textContent = shadowSafeText(remainder);
+  shadowEl.appendChild(remainderSpan);
+}
+
 class CommandPromptView {
   constructor(options) {
     options = options || {};
@@ -132,7 +172,7 @@ class CommandPromptView {
     if (lastCommand.length) {
       for (const c of allCommandsSorted) {
         if (c.startsWith(lastCommand)) {
-          shadowEl.innerHTML = (currentValue + c.replace(lastCommand, '')).replace(/ /g, '&nbsp;');
+          renderShadowHint(shadowEl, currentValue, c.substring(lastCommand.length));
           break;
         }
       }
@@ -184,11 +224,7 @@ class CommandPromptView {
               this._tabLastPrefix = lcp;
               // update the shadow hint with the first match's remainder
               const remain = matches[0].substring(lcp.length) || '';
-              if (remain) {
-                shadowEl.innerHTML = (el.value + remain).replace(/ /g, '&nbsp;');
-              } else {
-                shadowEl.innerHTML = '';
-              }
+              renderShadowHint(shadowEl, el.value, remain);
               // re-filter _tabMatches against the new LCP so subsequent Tabs cycle correctly
               this._tabMatches = allCommandsSorted.filter(
                 c => c.startsWith(lcp)

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -1491,8 +1491,24 @@ div.gitDemonstrationView {
 #shadow{
   position: absolute;
   bottom: 0px;
-  left: 21px;
+  /* match the box of #prompt p.command exactly (margin-left: 20px), so the
+   * hint wraps identically and the suggested remainder lands right after
+   * the text the user actually typed */
+  left: 20px;
+  right: 0px;
+  /* p.command gets this from the generic `p` rule -- the hint has to break
+   * lines the same way or a long command line puts the hint on the wrong
+   * line entirely */
+  word-wrap: break-word;
+  overflow-wrap: break-word;
   opacity: 0.4;
+  pointer-events: none;
+}
+
+/* the already-typed part of the hint only exists to take up space --
+ * painting it would double up on the real prompt text */
+#shadow .shadowTyped {
+  visibility: hidden;
 }
 
 .upsellImage {


### PR DESCRIPTION
The grey inline suggestion in #shadow contained the *entire* command line (typed characters + suggested remainder) and was painted on top of the real prompt text at 40% opacity, one pixel to the right of it (left: 21px vs p.command's margin-left: 20px). Every character the user had already typed was therefore drawn twice with a 1px horizontal offset, which reads as subtly blurry text -- and it disappears as soon as the input stops matching a command (e.g. once you type arguments after `git commit`), which is exactly the reported symptom.

Two related problems in the same overlay:

- The typed text was inserted with innerHTML while the real prompt escapes it, so anything before a ';' (e.g. `<b>x</b>; git comm`) rendered as markup in the hint, shifting the ghost text out of alignment and putting user-controlled markup into the DOM.
- #shadow did not wrap like p.command (which gets word-wrap: break-word from the generic `p` rule), so a command line long enough to wrap smeared the whole hint across the last visual line and overflowed the bar.

Now the hint renders the typed part in a visibility: hidden span -- it still takes up space so the remainder lands in the right spot, but nothing is painted over the real text -- and the remainder in a visible one, both via textContent. #shadow is aligned and wrapped to match p.command exactly.


Claude-Session: https://claude.ai/code/session_017FgUroE5ouv2N9EkEitzX7