### PR TITLE
Externalize remaining hardcoded UI strings into intl

### DIFF
--- a/src/js/git/commands.js
+++ b/src/js/git/commands.js
@@ -51,9 +51,7 @@ var assertNotCheckedOut = function(engine, ref) {
   }
   if (engine.HEAD.get('target') === engine.refs[ref]) {
     throw new GitError({
-      msg: intl.todo(
-        'cannot fetch to ' + ref + ' when checked out on ' + ref
-      )
+      msg: intl.str('git-error-fetch-checked-out', { ref: ref })
     });
   }
 };
@@ -63,9 +61,7 @@ var assertIsBranch = function(engine, ref) {
   var obj = engine.resolveID(ref);
   if (!obj || obj.get('type') !== 'branch') {
     throw new GitError({
-      msg: intl.todo(
-        ref + ' is not a branch'
-      )
+      msg: intl.str('git-error-not-a-branch', { ref: ref })
     });
   }
 };
@@ -77,9 +73,7 @@ var assertIsRemoteBranch = function(engine, ref) {
   if (obj.get('type') !== 'branch' ||
       !obj.getIsRemote()) {
     throw new GitError({
-      msg: intl.todo(
-        ref + ' is not a remote branch'
-      )
+      msg: intl.str('git-error-not-a-remote-branch', { ref: ref })
     });
   }
 };
@@ -90,9 +84,7 @@ var assertOriginSpecified = function(generalArgs) {
   }
   if (generalArgs[0] !== 'origin') {
     throw new GitError({
-      msg: intl.todo(
-        generalArgs[0] + ' is not a remote in your repository! try adding origin to that argument'
-      )
+      msg: intl.str('git-error-not-a-remote', { remote: generalArgs[0] })
     });
   }
 };
@@ -101,22 +93,20 @@ var assertBranchIsRemoteTracking = function(engine, branchName) {
   branchName = crappyUnescape(branchName);
   if (!engine.resolveID(branchName)) {
     throw new GitError({
-      msg: intl.todo(branchName + ' is not a branch!')
+      msg: intl.str('git-error-branch-bang', { branch: branchName })
     });
   }
   var branch = engine.resolveID(branchName);
   if (branch.get('type') !== 'branch') {
     throw new GitError({
-      msg: intl.todo(branchName + ' is not a branch!')
+      msg: intl.str('git-error-branch-bang', { branch: branchName })
     });
   }
 
   var tracking = branch.getRemoteTrackingBranchID();
   if (!tracking) {
     throw new GitError({
-      msg: intl.todo(
-        branchName + ' is not a remote tracking branch! I don\'t know where to push'
-      )
+      msg: intl.str('git-error-not-remote-tracking', { branch: branchName })
     });
   }
   return tracking;
@@ -307,7 +297,7 @@ var commandConfig = {
         // can't be detached
         if (engine.getDetachedHead()) {
           throw new GitError({
-            msg: intl.todo('Git pull can not be executed in detached HEAD mode if no remote branch specified!')
+            msg: intl.str('git-error-pull-detached')
           });
         }
         // ok we need to get our currently checked out branch
@@ -364,7 +354,7 @@ var commandConfig = {
           branch = validateOriginBranchName(engine, generalArgs[0]);
           if (isNaN(parseInt(generalArgs[1], 10))) {
             throw new GitError({
-              msg: 'Bad numeric argument: ' + generalArgs[1]
+              msg: intl.str('git-error-bad-numeric-argument', { arg: generalArgs[1] })
             });
           }
           numToMake = parseInt(generalArgs[1], 10);
@@ -561,7 +551,7 @@ var commandConfig = {
           var headTarget = engine.HEAD.get('target');
           if (headTarget.get('type') !== 'branch') {
             throw new GitError({
-              msg: intl.todo('fatal: HEAD does not point to a branch')
+              msg: intl.str('git-error-head-not-branch')
             });
           }
           oldName = headTarget.get('id');
@@ -991,17 +981,13 @@ var commandConfig = {
       if(isDelete) {
         if(!firstArg) {
           throw new GitError({
-            msg: intl.todo(
-              '--delete doesn\'t make sense without any refs'
-            )
+            msg: intl.str('git-error-delete-no-refs')
           });
         }
 
         if(isColonRefspec(firstArg)) {
           throw new GitError({
-            msg: intl.todo(
-              '--delete only accepts plain target ref names'
-            )
+            msg: intl.str('git-error-delete-plain-refs')
           });
         }
 
@@ -1019,9 +1005,7 @@ var commandConfig = {
         destination = validateBranchName(engine, refspecParts[1]);
         if (source === "" && !engine.origin.resolveID(destination)) {
           throw new GitError({
-            msg: intl.todo(
-              'cannot delete branch ' + options.destination + ' which doesn\'t exist'
-            )
+            msg: intl.str('git-error-delete-nonexistent', { branch: options.destination })
           });
         }
       } else {
@@ -1070,9 +1054,7 @@ var commandConfig = {
       // first if there are no tags, we can't do anything so just throw
       if (engine.tagCollection.toArray().length === 0) {
         throw new GitError({
-          msg: intl.todo(
-            'fatal: No tags found, cannot describe anything.'
-          )
+          msg: intl.str('git-error-describe-no-tags')
         });
       }
 
@@ -1109,9 +1091,7 @@ var commandConfig = {
 
         if(tagToRemove == undefined){
           throw new GitError({
-            msg: intl.todo(
-              'No tag found, nothing to remove'
-            )
+            msg: intl.str('git-error-no-tag-to-remove')
           });
         }
 

--- a/src/js/git/index.js
+++ b/src/js/git/index.js
@@ -481,7 +481,7 @@ GitEngine.prototype.makeOrigin = function(treeString) {
 GitEngine.prototype.cloneFromOrigin = function() {
   if (!this.hasOrigin()) {
     throw new GitError({
-      msg: intl.todo('Nothing to clone from!')
+      msg: intl.str('git-error-nothing-to-clone')
     });
   }
 
@@ -621,12 +621,10 @@ GitEngine.prototype.setLocalToTrackRemote = function(localBranch, remoteBranch) 
     return;
   }
 
-  var msg = 'local branch "' +
-    localBranch.get('id') +
-    '" set to track remote branch "' +
-    remoteBranch.get('id') +
-    '"';
-  this.command.addWarning(intl.todo(msg));
+  this.command.addWarning(intl.str('git-warning-tracking', {
+    localBranch: localBranch.get('id'),
+    remoteBranch: remoteBranch.get('id')
+  }));
 };
 
 GitEngine.prototype.getOrMakeRecursive = function(
@@ -1219,7 +1217,7 @@ GitEngine.prototype.push = function(options) {
   var sourceBranch = this.resolveID(options.source);
   if (sourceBranch && sourceBranch.attributes.type === 'tag') {
     throw new GitError({
-      msg: intl.todo('Tags are not allowed as sources for pushing'),
+      msg: intl.str('git-error-push-tag-source'),
     });
   }
 
@@ -1350,7 +1348,7 @@ GitEngine.prototype.pushDeleteRemoteBranch = function(
 ) {
   if (branchOnRemote.get('id') === 'main') {
     throw new GitError({
-      msg: intl.todo('You cannot delete main branch on remote!')
+      msg: intl.str('git-error-delete-main-remote')
     });
   }
   // ok so this isn't too bad -- we basically just:
@@ -2466,7 +2464,7 @@ GitEngine.prototype.rebaseInteractiveTest = function(targetSource, currentLocati
 
     if (extraCommits.length > 0) {
       throw new GitError({
-        msg: intl.todo('Hey those commits don\'t exist in the set!')
+        msg: intl.str('git-error-commits-not-in-set')
       });
     }
   }
@@ -2498,7 +2496,7 @@ GitEngine.prototype.rebaseInteractive = function(targetSource, currentLocation, 
     options.initialCommitOrdering[0].split(',').forEach(function (id) {
       if (!rebaseMap[id]) {
         throw new GitError({
-          msg: intl.todo('Hey those commits don\'t exist in the set!')
+          msg: intl.str('git-error-commits-not-in-set')
         });
       }
       initialCommitOrdering.push(id);
@@ -2874,7 +2872,7 @@ GitEngine.prototype.describe = function(ref) {
 
   if (!foundTag) {
     throw new GitError({
-      msg: intl.todo('Fatal: no tags found upstream')
+      msg: intl.str('git-error-no-tags-upstream')
     });
   }
 
@@ -2895,7 +2893,7 @@ GitEngine.prototype.renameBranch = function(oldName, newName, force) {
 
   if (!target || target.get('type') !== 'branch') {
     throw new GitError({
-      msg: intl.todo('fatal: not a branch: ' + oldName)
+      msg: intl.str('git-error-branch-rename-not-branch', { branch: oldName })
     });
   }
 
@@ -2910,7 +2908,7 @@ GitEngine.prototype.renameBranch = function(oldName, newName, force) {
   if (this.doesRefExist(newName)) {
     if (!force) {
       throw new GitError({
-        msg: intl.todo("fatal: A branch named '" + newName + "' already exists.")
+        msg: intl.str('git-error-branch-rename-exists', { branch: newName })
       });
     }
     var existing = this.resolveID(newName);

--- a/src/js/intl/index.js
+++ b/src/js/intl/index.js
@@ -74,10 +74,6 @@ var getIntlKey = exports.getIntlKey = function(obj, key, overrideLocale) {
   return obj[key][locale];
 };
 
-exports.todo = function(str) {
-  return str;
-};
-
 exports.getDialog = function(obj) {
   return getIntlKey(obj, 'dialog') || obj.dialog[getDefaultLocale()];
 };

--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -3081,5 +3081,149 @@ exports.strings = {
     "az": "İnteraktiv Rebase",
     "uk": "Інтерактивний Rebase",
     "ko": "인터랙티브 리베이스"
+  },
+  "main-helper-bar-commands": {
+    "__desc__": "Tooltip for the button that shows the list of commands",
+    "en_US": "Show commands"
+  },
+  "main-helper-bar-languages": {
+    "__desc__": "Tooltip for the button that shows the available languages",
+    "en_US": "Show available languages"
+  },
+  "main-helper-bar-threads": {
+    "__desc__": "Tooltip for the link to the author's Threads profile",
+    "en_US": "Follow me on Threads"
+  },
+  "git-error-bad-numeric-argument": {
+    "__desc__": "Error when a command argument that should be a number is not",
+    "en_US": "Bad numeric argument: {arg}"
+  },
+  "reset-solved-confirm": {
+    "__desc__": "Warning shown when \"reset solved\" is run without --confirm",
+    "en_US": "Reset solved will mark each level as not yet solved; because this is a destructive command, please pass in --confirm to execute"
+  },
+  "sandbox-error-something-went-wrong": {
+    "__desc__": "Generic error when opening a level fails, {error} is the exception text",
+    "en_US": "Something went wrong {error}"
+  },
+  "sandbox-alias-set": {
+    "__desc__": "Confirmation that a command alias was created",
+    "en_US": "Set alias \"{alias}\" to \"{expansion}\""
+  },
+  "sandbox-alias-removed": {
+    "__desc__": "Confirmation that a command alias was removed",
+    "en_US": "Removed alias \"{alias}\""
+  },
+  "sandbox-rollup-done": {
+    "__desc__": "Confirmation that previous commands were combined into one",
+    "en_US": "Commands combined!"
+  },
+  "git-error-fetch-checked-out": {
+    "__desc__": "Error when fetching into the branch that is currently checked out",
+    "en_US": "cannot fetch to {ref} when checked out on {ref}"
+  },
+  "git-error-not-a-branch": {
+    "__desc__": "Error when a ref that must be a branch is not one",
+    "en_US": "{ref} is not a branch"
+  },
+  "git-error-not-a-remote-branch": {
+    "__desc__": "Error when a ref that must be a remote branch is not one",
+    "en_US": "{ref} is not a remote branch"
+  },
+  "git-error-not-a-remote": {
+    "__desc__": "Error when the named remote does not exist in the repository",
+    "en_US": "{remote} is not a remote in your repository! try adding origin to that argument"
+  },
+  "git-error-branch-bang": {
+    "__desc__": "Error when the named branch does not exist",
+    "en_US": "{branch} is not a branch!"
+  },
+  "git-error-not-remote-tracking": {
+    "__desc__": "Error when pushing a branch that tracks no remote branch",
+    "en_US": "{branch} is not a remote tracking branch! I don't know where to push"
+  },
+  "git-error-pull-detached": {
+    "__desc__": "Error when pulling in detached HEAD without naming a remote branch",
+    "en_US": "Git pull can not be executed in detached HEAD mode if no remote branch specified!"
+  },
+  "git-error-head-not-branch": {
+    "__desc__": "Error when HEAD is detached but a branch is required",
+    "en_US": "fatal: HEAD does not point to a branch"
+  },
+  "git-error-delete-no-refs": {
+    "__desc__": "Error when push --delete is given no refs",
+    "en_US": "--delete doesn't make sense without any refs"
+  },
+  "git-error-delete-plain-refs": {
+    "__desc__": "Error when push --delete is given a source:destination refspec",
+    "en_US": "--delete only accepts plain target ref names"
+  },
+  "git-error-delete-nonexistent": {
+    "__desc__": "Error when deleting a branch that does not exist",
+    "en_US": "cannot delete branch {branch} which doesn't exist"
+  },
+  "git-error-describe-no-tags": {
+    "__desc__": "Error from git describe when the repository has no tags",
+    "en_US": "fatal: No tags found, cannot describe anything."
+  },
+  "git-error-no-tag-to-remove": {
+    "__desc__": "Error when removing a tag that does not exist",
+    "en_US": "No tag found, nothing to remove"
+  },
+  "git-error-nothing-to-clone": {
+    "__desc__": "Error when cloning with no remote available",
+    "en_US": "Nothing to clone from!"
+  },
+  "git-warning-tracking": {
+    "__desc__": "Warning shown when a local branch starts tracking a remote branch",
+    "en_US": "local branch \"{localBranch}\" set to track remote branch \"{remoteBranch}\""
+  },
+  "git-error-push-tag-source": {
+    "__desc__": "Error when pushing a tag as the source of a refspec",
+    "en_US": "Tags are not allowed as sources for pushing"
+  },
+  "git-error-delete-main-remote": {
+    "__desc__": "Error when deleting the main branch on the remote",
+    "en_US": "You cannot delete main branch on remote!"
+  },
+  "git-error-commits-not-in-set": {
+    "__desc__": "Error when named commits are not part of the given set",
+    "en_US": "Hey those commits don't exist in the set!"
+  },
+  "git-error-no-tags-upstream": {
+    "__desc__": "Error when fetching tags but the remote has none",
+    "en_US": "Fatal: no tags found upstream"
+  },
+  "git-error-branch-rename-not-branch": {
+    "__desc__": "Error when renaming something that is not a branch",
+    "en_US": "fatal: not a branch: {branch}"
+  },
+  "git-error-branch-rename-exists": {
+    "__desc__": "Error when renaming a branch to a name already taken",
+    "en_US": "fatal: A branch named '{branch}' already exists."
+  },
+  "hg-error-m-d-incompatible": {
+    "__desc__": "Error when hg is given both -m and -d",
+    "en_US": "-m and -d are incompatible"
+  },
+  "hg-error-r-d-incompatible": {
+    "__desc__": "Error when hg is given both -r and -d",
+    "en_US": "-r is incompatible with -d"
+  },
+  "hg-error-r-m-incompatible": {
+    "__desc__": "Error when hg is given both -r and -m",
+    "en_US": "-r is incompatible with -m"
+  },
+  "sandbox-tree-link": {
+    "__desc__": "Preamble for the shareable link to the current tree state",
+    "en_US": "Here is a link to the current state of the tree: "
+  },
+  "sandbox-instructions-disabled": {
+    "__desc__": "Message shown when level instructions have been turned off",
+    "en_US": "Level instructions disabled"
+  },
+  "sandbox-no-documentation": {
+    "__desc__": "Error when `show` is asked about an unknown command",
+    "en_US": "No documentation found for \"{target}\"; run `show commands` to see all available commands"
   }
 }

--- a/src/js/mercurial/commands.js
+++ b/src/js/mercurial/commands.js
@@ -106,17 +106,17 @@ var commandConfig = {
 
       if (options['-m'] && options['-d']) {
         throw new GitError({
-          msg: intl.todo('-m and -d are incompatible')
+          msg: intl.str('hg-error-m-d-incompatible')
         });
       }
       if (options['-d'] && options['-r']) {
         throw new GitError({
-          msg: intl.todo('-r is incompatible with -d')
+          msg: intl.str('hg-error-r-d-incompatible')
         });
       }
       if (options['-m'] && options['-r']) {
         throw new GitError({
-          msg: intl.todo('-r is incompatible with -m')
+          msg: intl.str('hg-error-r-m-incompatible')
         });
       }
       if (generalArgs.length + (options['-r'] ? options['-r'].length : 0) +

--- a/src/js/react_views/MainHelperBarView.jsx
+++ b/src/js/react_views/MainHelperBarView.jsx
@@ -5,6 +5,8 @@ var CommandsHelperBarView =
   require('../react_views/CommandsHelperBarView.jsx');
 var React = require('react');
 
+var intl = require('../intl');
+
 var keyMirror = require('../util/keyMirror');
 var log = require('../log');
 
@@ -57,7 +59,7 @@ class MainHelperBarView extends React.Component {
           shownBar: BARS.COMMANDS
         });
       }.bind(this),
-      title: 'Show commands'
+      title: intl.str('main-helper-bar-commands')
     }, {
       icon: 'fa-solid fa-language',
       onClick: function() {
@@ -65,12 +67,12 @@ class MainHelperBarView extends React.Component {
           shownBar: BARS.INTL
         });
       }.bind(this),
-      title: 'Show available languages'
+      title: intl.str('main-helper-bar-languages')
     }, {
       newPageLink: true,
       icon: 'fa-brands fa-threads',
       href: 'https://www.threads.net/@pcottle',
-      title: 'Follow me on Threads'
+      title: intl.str('main-helper-bar-threads')
     }];
   }
 

--- a/src/js/sandbox/commands.js
+++ b/src/js/sandbox/commands.js
@@ -100,14 +100,14 @@ var instantCommands = [
     const expansion = bits[2];
     LevelStore.addToAliasMap(alias, expansion);
     throw new CommandResult({
-      msg: 'Set alias "'+alias+'" to "'+expansion+'"',
+      msg: intl.str('sandbox-alias-set', { alias: alias, expansion: expansion }),
     });
   }, 'alias', 'Run `alias` to map a certain shortcut to an expansion'],
   [/^unalias (\w+)$/, function(bits) {
     const alias = bits[1];
     LevelStore.removeFromAliasMap(alias);
     throw new CommandResult({
-      msg: 'Removed alias "'+alias+'"',
+      msg: intl.str('sandbox-alias-removed', { alias: alias }),
     });
   }, 'unalias', 'Opposite of `alias`'],
   [/^locale (\w+)$/, function(bits) {
@@ -131,7 +131,7 @@ var instantCommands = [
   [/^disableLevelInstructions$/, function() {
     GlobalStateActions.disableLevelInstructions();
     throw new CommandResult({
-      msg: intl.todo('Level instructions disabled'),
+      msg: intl.str('sandbox-instructions-disabled'),
     });
   }, 'disableLevelInstructions', 'Disable the level instructions'],
   [/^refresh$/, function() {
@@ -148,7 +148,7 @@ var instantCommands = [
     // go roll up these commands by joining them with semicolons
     events.trigger('rollupCommands', bits[1]);
     throw new CommandResult({
-      msg: 'Commands combined!'
+      msg: intl.str('sandbox-rollup-done')
     });
   }],
   [/^echo "(.*?)"$|^echo (.*?)$/, function(bits) {
@@ -292,10 +292,7 @@ var showHelpForCommand = function(target) {
   var lines = getCommandHelpLines(target);
   if (!lines) {
     throw new CommandProcessError({
-      msg: intl.todo(
-        'No documentation found for "' + target + '"; ' +
-        'run `show commands` to see all available commands'
-      )
+      msg: intl.str('sandbox-no-documentation', { target: target })
     });
   }
 

--- a/src/js/sandbox/index.js
+++ b/src/js/sandbox/index.js
@@ -254,7 +254,7 @@ class Sandbox {
     var url =
       'https://learngitbranching.js.org/?NODEMO&command=importTreeNow%20' + escape(treeJSON);
     command.setResult(
-      intl.todo('Here is a link to the current state of the tree: ') + '\n' + url
+      intl.str('sandbox-tree-link') + '\n' + url
     );
     command.finishWith(deferred);
   }
@@ -262,8 +262,7 @@ class Sandbox {
   resetSolved(command, deferred) {
     if (command.get('regexResults').input !== 'reset solved --confirm') {
       command.set('error', new Errors.GitError({
-        msg: 'Reset solved will mark each level as not yet solved; because ' +
-             'this is a destructive command, please pass in --confirm to execute',
+        msg: intl.str('reset-solved-confirm'),
       }));
       command.finishWith(deferred);
       return;
@@ -345,7 +344,7 @@ class Sandbox {
       });
     } catch(e) {
       command.set('error', new Errors.GitError({
-        msg: 'Something went wrong ' + String(e)
+        msg: intl.str('sandbox-error-something-went-wrong', { error: String(e) })
       }));
       throw e;
     }


### PR DESCRIPTION
Most user-facing text already goes through `intl.str()`, but a tail of strings did not — so they could never be translated, and `gulp lintStrings` could not see them. This moves that tail into `strings.js`.

### What changed

- **3 helper-bar tooltips** in `MainHelperBarView.jsx` ("Show commands", "Show available languages", "Follow me on Threads") — the only untranslated text in the main UI chrome.
- **6 hardcoded `msg:` literals** in git and sandbox command handlers (bad numeric argument, `reset solved` warning, alias set/removed, rollup, level-open failure).
- **All 29 `intl.todo()` call sites** converted to `intl.str()`, across `git/commands.js`, `git/index.js`, `mercurial/commands.js`, `sandbox/index.js`, and `sandbox/commands.js`. Where the message interpolated variables, string concatenation became `{param}` interpolation.
- **`intl.todo()` removed**, now that nothing calls it. It was `function(str) { return str; }` — an identity function, so anything routed through it was never translatable and was invisible to the string linter. Deleting it closes the escape hatch: new UI text now either gets a key or shows up as a raw literal in a grep.

38 new keys, `en_US` only, each with a `__desc__` so translators have context. Other locales fall back to `en_US` until someone translates them.

### Notes

- **English output is byte-identical at every call site.** The `{param}` conversions were checked against the same `/\{(.+?)\}/g` regex `intl/index.js` uses.
- Two `msg: ""` blanks (`commandModel.js`, `git/commands.js` in the no-origin `git remote` case) are left alone — intentional empty output, not text.
- `builderViews.js` is untouched. It is level-authoring tooling rather than end-user UI, so it seemed out of scope; happy to include it if you'd rather it were consistent.
- `checkStrings` goes from 112 to 148 good keys, no errors.

### Testing

`npm test` — 366/366 specs pass. `gulp lint` (jshint) and `gulp lintStrings` both clean.
