### PR TITLE
Fix undo/gitCommandsIssued desync in Level (#1298)

### DIFF
--- a/__tests__/levelUndoBookkeeping.spec.js
+++ b/__tests__/levelUndoBookkeeping.spec.js
@@ -1,0 +1,107 @@
+var undoBookkeeping = require('../src/js/level/undoBookkeeping');
+
+// Regression test for issue #1298 ("Undo Bug in Juggling Commits #1"): after
+// a few undo/redo cycles, commits went missing and further undos couldn't
+// bring them back.
+//
+// Level (src/js/level/index.js) keeps two arrays in lockstep: undoStack
+// (tree snapshots to restore) and gitCommandsIssued (command strings, used
+// for the git-golf command count and level-completion tracking). The actual
+// bug lived in that class's undo()/afterCommandCB(), but that file also
+// requires a .jsx React view, which this test runner can't transpile -- so
+// the lockstep logic was pulled into its own plain module
+// (level/undoBookkeeping.js) that Level now delegates to. This tests that
+// module directly.
+function issueCommand(state, rawStr, newTree, counts) {
+  var treeBefore = state.tree;
+  if (newTree !== undefined) {
+    state.tree = newTree;
+  }
+  undoBookkeeping.recordCommand({
+    gitCommandsIssued: state.gitCommandsIssued,
+    undoStack: state.undoStack,
+    treeBefore: treeBefore,
+    treeAfter: state.tree,
+    rawStr: rawStr,
+    counts: counts === undefined ? true : counts
+  });
+}
+
+function undo(state) {
+  if (undoBookkeeping.shouldPopIssuedCommand(state.undoStack)) {
+    state.gitCommandsIssued.pop();
+  }
+  var toRestore = state.undoStack.pop();
+  if (toRestore !== undefined) {
+    state.tree = toRestore;
+  }
+}
+
+function makeState() {
+  return { tree: 'TREE_0', gitCommandsIssued: [], undoStack: [] };
+}
+
+describe('Level undo bookkeeping (issue #1298)', function() {
+  it('does not push undo state for a command that left the tree unchanged', function() {
+    var state = makeState();
+
+    // a command that "counts" by name (e.g. an interactive rebase the user
+    // cancelled) but doesn't actually change the tree
+    issueCommand(state, 'git rebase -i HEAD~2' /* no newTree: unchanged */);
+
+    expect(state.gitCommandsIssued.length).toBe(0);
+    expect(state.undoStack.length).toBe(0);
+  });
+
+  it('keeps gitCommandsIssued and undoStack in lockstep across undo', function() {
+    var state = makeState();
+
+    issueCommand(state, 'git commit', 'TREE_1');
+    issueCommand(state, 'git commit', 'TREE_2');
+    expect(state.gitCommandsIssued.length).toBe(2);
+    expect(state.undoStack.length).toBe(2);
+
+    undo(state);
+    expect(state.gitCommandsIssued.length).toBe(1);
+    expect(state.undoStack.length).toBe(1);
+    expect(state.tree).toBe('TREE_1');
+
+    undo(state);
+    expect(state.gitCommandsIssued.length).toBe(0);
+    expect(state.undoStack.length).toBe(0);
+    expect(state.tree).toBe('TREE_0');
+  });
+
+  it('does not drop a gitCommandsIssued entry when undo is called with nothing left to undo', function() {
+    var state = makeState();
+
+    issueCommand(state, 'git commit', 'TREE_1');
+    undo(state);
+    expect(state.gitCommandsIssued.length).toBe(0);
+
+    // undoStack is now empty; calling undo again must be a safe no-op
+    undo(state);
+    expect(state.gitCommandsIssued.length).toBe(0);
+    expect(state.tree).toBe('TREE_0');
+  });
+
+  it('never lets gitCommandsIssued outrun the real number of undoable states', function() {
+    // the scenario that actually bites: commands that count towards the
+    // total without changing the tree (cancelled/no-op interactive rebases)
+    // interleaved with real changes and undos -- "a couple of wrong
+    // commands, undo, then the real ones" in practice
+    var state = makeState();
+
+    issueCommand(state, 'git rebase -i HEAD~2' /* cancelled: no tree change */);
+    issueCommand(state, 'git commit', 'TREE_1');
+    issueCommand(state, 'git rebase -i HEAD~2' /* cancelled again */);
+    issueCommand(state, 'git commit --amend', 'TREE_2');
+
+    expect(state.gitCommandsIssued.length).toBe(state.undoStack.length);
+
+    undo(state);
+    undo(state);
+    expect(state.gitCommandsIssued.length).toBe(state.undoStack.length);
+    expect(state.tree).toBe('TREE_0');
+  });
+});

--- a/src/js/level/index.js
+++ b/src/js/level/index.js
@@ -29,6 +29,7 @@ var TreeCompare = require('../graph/treeCompare');
 // regex map lives in its own JSX-free module so it can be required by the parse
 // waterfall / tests without loading the level's React views
 var regexMap = require('./levelRegexMap').regexMap;
+var undoBookkeeping = require('./undoBookkeeping');
 
 var parse = util.genParseCommand(regexMap, 'processLevelCommand');
 
@@ -407,7 +408,11 @@ class Level extends Sandbox {
   }
 
   undo() {
-    this.gitCommandsIssued.pop();
+    // only pop a command off gitCommandsIssued if there's really a tree
+    // snapshot for the base class's undo to restore -- see #1298
+    if (undoBookkeeping.shouldPopIssuedCommand(this.undoStack)) {
+      this.gitCommandsIssued.pop();
+    }
     super.undo.apply(this, arguments);
   }
 
@@ -420,14 +425,18 @@ class Level extends Sandbox {
   }
 
   afterCommandCB(command) {
-    if (this.doesCommandCountTowardsTotal(command)) {
-      // Count it as a command AND...
-      this.gitCommandsIssued.push(command.get('rawStr'));
-      // add our state for undo since our undo pops a command.
-      //
-      // Ugly inheritance overriding on private implementations ahead!
-      this.undoStack.push(this._treeBeforeCommand);
-    }
+    // only count/record a command if it actually changed the tree -- a
+    // command that "counts" by name (e.g. an interactive rebase) but was
+    // cancelled or was a no-op reorder must not push a real undo entry,
+    // or gitCommandsIssued and undoStack drift apart -- see #1298
+    undoBookkeeping.recordCommand({
+      gitCommandsIssued: this.gitCommandsIssued,
+      undoStack: this.undoStack,
+      treeBefore: this._treeBeforeCommand,
+      treeAfter: this.mainVis.gitEngine.exportTreeString(),
+      rawStr: command.get('rawStr'),
+      counts: this.doesCommandCountTowardsTotal(command)
+    });
   }
 
   doesCommandCountTowardsTotal(command) {

--- a/src/js/level/undoBookkeeping.js
+++ b/src/js/level/undoBookkeeping.js
@@ -1,0 +1,43 @@
+// Level's undo bookkeeping, pulled out of level/index.js so it can be unit
+// tested without pulling in the React view files that class also imports
+// (level/index.js requires a .jsx view, which the plain jasmine test runner
+// can't transpile -- see levelUndoBookkeeping.spec.js).
+//
+// Level tracks two parallel arrays that must stay in lockstep:
+//   - undoStack: tree snapshots to restore, one per undoable command
+//   - gitCommandsIssued: the raw command strings, used for the git-golf
+//     command count and level-completion tracking
+//
+// Regression fix for issue #1298 ("Undo Bug in Juggling Commits #1"): both
+// bugs below let the two arrays drift apart, which is what made commits
+// "disappear" and stay gone even after undoing everything.
+
+// Only push undo state for a command that both counts towards the total AND
+// actually changed the tree. Previously this pushed unconditionally for any
+// counted command, so a command that counted but left the tree unchanged
+// (e.g. a cancelled/no-op interactive rebase) still pushed a real undo entry
+// pointing at a tree identical to the one already there.
+function recordCommand({ gitCommandsIssued, undoStack, treeBefore, treeAfter, rawStr, counts }) {
+  if (!counts) {
+    return;
+  }
+  if (treeBefore === treeAfter) {
+    return;
+  }
+  gitCommandsIssued.push(rawStr);
+  undoStack.push(treeBefore);
+}
+
+// Sandbox.undo() (the base class) already pops undoStack itself and
+// restores the tree, or errors out harmlessly if undoStack is empty. This
+// only decides whether gitCommandsIssued should ALSO lose an entry.
+// Previously gitCommandsIssued.pop() ran unconditionally in Level.undo(), so
+// calling undo with an empty undoStack (nothing left to restore) still
+// silently discarded an entry from gitCommandsIssued -- desyncing the two
+// arrays' lengths from then on.
+function shouldPopIssuedCommand(undoStack) {
+  return undoStack.length > 0;
+}
+
+exports.recordCommand = recordCommand;
+exports.shouldPopIssuedCommand = shouldPopIssuedCommand;


### PR DESCRIPTION
## What's going on

`Level.afterCommandCB()` pushes to `undoStack`/`gitCommandsIssued` for any command that "counts" by name (`doesCommandCountTowardsTotal`), even if the command left the tree completely unchanged — e.g. a cancelled or no-op `git rebase -i` reorder. `Level.undo()` separately pops `gitCommandsIssued` **unconditionally**, even when `undoStack` is already empty and the base `Sandbox.undo()` has nothing left to restore.

Either path lets the two arrays drift out of lockstep with each other and with the real number of undoable tree states. That matches what's described in #1298 on the "Juggling Commits" level (which revolves around `git rebase -i`): commits disappearing after a few undo/redo cycles, and further undos not bringing them back.

## The fix

Pulled the lockstep bookkeeping into its own module, `level/undoBookkeeping.js`:
- `recordCommand()` only pushes an undo entry if the command both counts *and* actually changed the tree.
- `shouldPopIssuedCommand()` tells `Level.undo()` to only pop `gitCommandsIssued` when `undoStack` genuinely has something for the base class to restore.

`level/index.js` now delegates to these instead of doing the bookkeeping inline.

## Why a new file instead of editing in place

`level/index.js` requires a `.jsx` React view (`LevelToolbarView`), which the plain jasmine test runner can't transpile — so nothing that imports that file has ever been directly unit tested (`levels.spec.js` even explicitly skips any level whose solution uses `git rebase -i`, for the same underlying reason). This follows the same pattern already used for `levelRegexMap.js` (see the comment above it) to keep pure logic testable without pulling in the view layer.

## Testing

New `__tests__/levelUndoBookkeeping.spec.js` exercises the real logic `Level` now delegates to, including the exact "a command that counts but no-ops, then undo" sequence from the bug report.

Verified red→green: the two bug-specific tests fail against the old inline logic and pass against the fix. Confirmed no regressions: `yarn build` (jasmine + jshint + string lint) is fully green — all 366 prior specs pass unmodified, plus the 4 new ones.

```
Executed 370 of 370 specs SUCCESS
```