### PR TITLE
Add a shareable completion certificate

### DIFF
--- a/__tests__/LevelStore.spec.js
+++ b/__tests__/LevelStore.spec.js
@@ -93,6 +93,28 @@ describe('this store', function() {
 
     LevelActions.resetLevelsSolved();
   });
+
+  it('reports completion only after every level is solved', function() {
+    var sequenceMap = LevelStore.getSequenceToLevels();
+    var levelIDs = [];
+    Object.keys(sequenceMap).forEach(function(sequenceName) {
+      sequenceMap[sequenceName].forEach(function(level) {
+        levelIDs.push(level.id);
+      });
+    });
+
+    LevelActions.resetLevelsSolved();
+    expect(LevelStore.getTotalLevelCount()).toBe(levelIDs.length);
+    expect(LevelStore.areAllLevelsSolved()).toBe(false);
+
+    levelIDs.forEach(function(levelID) {
+      LevelActions.setLevelSolved(levelID, false);
+    });
+    expect(LevelStore.getSolvedLevelCount()).toBe(levelIDs.length);
+    expect(LevelStore.areAllLevelsSolved()).toBe(true);
+
+    LevelActions.resetLevelsSolved();
+  });
   
 
 });

--- a/__tests__/certificate.spec.js
+++ b/__tests__/certificate.spec.js
@@ -1,0 +1,46 @@
+var certificate = require('../src/js/util/certificate');
+
+describe('completion certificate', function() {
+  it('centers the recipient name in the SVG', function() {
+    var svg = certificate.buildCertificateSVG({
+      name: 'Peter Cottle',
+      levelsTotal: 36,
+      dateString: 'September 11, 2026'
+    });
+
+    expect(svg).toContain('x="50%"');
+    expect(svg).toContain('text-anchor="middle"');
+    expect(svg).toContain('>Peter Cottle</text>');
+  });
+
+  it('centers the commit graph independently of the seal', function() {
+    var svg = certificate.buildCertificateSVG({
+      name: 'Peter Cottle',
+      levelsTotal: 36
+    });
+
+    // The node range plus the right-hand branch label balance around the
+    // canvas center, while the seal remains a separate element.
+    expect(svg).toContain('cx="300" cy="610"');
+    expect(svg).toContain('cx="810" cy="610"');
+    // The seal remains separate on the right rather than shifting the graph.
+    expect(svg).toContain('cx="1030" cy="556"');
+  });
+
+  it('escapes recipient names and renders the completed level count', function() {
+    var svg = certificate.buildCertificateSVG({
+      name: '<Ada & Grace>',
+      levelsTotal: 36
+    });
+
+    expect(svg).toContain('&lt;Ada &amp; Grace&gt;');
+    expect(svg).toContain('>36/36</text>');
+    expect(svg).not.toContain('><Ada & Grace></text>');
+  });
+
+  it('builds a safe filename from the recipient name', function() {
+    expect(certificate.filenameForName('  Peter Cottle  ')).toBe(
+      'learn-git-branching-certificate-peter-cottle.png'
+    );
+  });
+});

--- a/__tests__/certificate.spec.js
+++ b/__tests__/certificate.spec.js
@@ -11,6 +11,8 @@ describe('completion certificate', function() {
     expect(svg).toContain('x="50%"');
     expect(svg).toContain('text-anchor="middle"');
     expect(svg).toContain('>Peter Cottle</text>');
+    expect(svg).toContain('>TOPICS COVERED</text>');
+    expect(svg).toContain('>Commits &amp; Branches  •  Merging &amp; Rebasing');
   });
 
   it('centers the commit graph independently of the seal', function() {
@@ -21,10 +23,10 @@ describe('completion certificate', function() {
 
     // The node range plus the right-hand branch label balance around the
     // canvas center, while the seal remains a separate element.
-    expect(svg).toContain('cx="300" cy="610"');
-    expect(svg).toContain('cx="810" cy="610"');
+    expect(svg).toContain('cx="300" cy="630"');
+    expect(svg).toContain('cx="810" cy="630"');
     // The seal remains separate on the right rather than shifting the graph.
-    expect(svg).toContain('cx="1030" cy="556"');
+    expect(svg).toContain('cx="1030" cy="576"');
   });
 
   it('escapes recipient names and renders the completed level count', function() {

--- a/__tests__/certificate.spec.js
+++ b/__tests__/certificate.spec.js
@@ -13,20 +13,22 @@ describe('completion certificate', function() {
     expect(svg).toContain('>Peter Cottle</text>');
     expect(svg).toContain('>TOPICS COVERED</text>');
     expect(svg).toContain('>Commits &amp; Branches  •  Merging &amp; Rebasing');
+    expect(svg).toContain('>Undoing Changes  •  Tags &amp; History');
+    expect(svg).not.toContain('This certifies that');
+    expect(svg).not.toContain('from the basic concepts');
   });
 
-  it('centers the commit graph independently of the seal', function() {
+  it('renders a compact centered commit graph without a seal', function() {
     var svg = certificate.buildCertificateSVG({
       name: 'Peter Cottle',
       levelsTotal: 36
     });
 
     // The node range plus the right-hand branch label balance around the
-    // canvas center, while the seal remains a separate element.
-    expect(svg).toContain('cx="300" cy="630"');
-    expect(svg).toContain('cx="810" cy="630"');
-    // The seal remains separate on the right rather than shifting the graph.
-    expect(svg).toContain('cx="1030" cy="576"');
+    // canvas center without crowding the footer.
+    expect(svg).toContain('cx="350" cy="625"');
+    expect(svg).toContain('cx="775" cy="625"');
+    expect(svg).not.toContain('>36/36</text>');
   });
 
   it('escapes recipient names and renders the completed level count', function() {
@@ -36,7 +38,7 @@ describe('completion certificate', function() {
     });
 
     expect(svg).toContain('&lt;Ada &amp; Grace&gt;');
-    expect(svg).toContain('>36/36</text>');
+    expect(svg).toContain('all 36 levels');
     expect(svg).not.toContain('><Ada & Grace></text>');
   });
 

--- a/__tests__/sandboxCommands.spec.js
+++ b/__tests__/sandboxCommands.spec.js
@@ -2,6 +2,20 @@ var SandboxCommands = require('../src/js/sandbox/commands');
 var GitCommands = require('../src/js/git/commands');
 
 describe('Sandbox Commands', function() {
+  describe('certificate preview', function() {
+    it('is enabled only for pages loaded directly from the filesystem', function() {
+      expect(SandboxCommands.isCertificatePreviewEnabled({
+        protocol: 'file:'
+      })).toBe(true);
+      expect(SandboxCommands.isCertificatePreviewEnabled({
+        protocol: 'https:'
+      })).toBe(false);
+      expect(SandboxCommands.isCertificatePreviewEnabled({
+        protocol: 'http:'
+      })).toBe(false);
+    });
+  });
+
   describe('help {command}', function() {
     var getHelpTuple = function() {
       return SandboxCommands.instantCommands.filter(function(tuple) {

--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -79,6 +79,14 @@ exports.strings = {
     "__desc__": "Smaller flourish line printed on the certificate below the achievement line",
     "en_US": "from the basic concepts of a branch to mastery of remote pulls"
   },
+  "certificate-svg-topics-label": {
+    "__desc__": "Label above the compact list of Git topics on the certificate. Shown in capital letters",
+    "en_US": "TOPICS COVERED"
+  },
+  "certificate-svg-topics": {
+    "__desc__": "Compact list of the main Git concepts taught by Learn Git Branching",
+    "en_US": "Commits & Branches  •  Merging & Rebasing  •  Cherry-pick & Relative Refs  •  Undoing Changes  •  Tags & History  •  Fetch, Pull & Push"
+  },
   "certificate-svg-issued": {
     "__desc__": "Label before the issue date in the certificate footer. Shown in capital letters",
     "en_US": "ISSUED"

--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -63,10 +63,6 @@ exports.strings = {
     "__desc__": "Large title printed on the certificate itself. Shown in capital letters",
     "en_US": "CERTIFICATE OF COMPLETION"
   },
-  "certificate-svg-certifies": {
-    "__desc__": "Line printed on the certificate above the recipient name",
-    "en_US": "This certifies that"
-  },
   "certificate-svg-name-placeholder": {
     "__desc__": "Faded placeholder printed on the certificate before a name is entered",
     "en_US": "YOUR NAME HERE"
@@ -75,29 +71,21 @@ exports.strings = {
     "__desc__": "Line printed on the certificate below the name. {levels} is the total number of levels",
     "en_US": "has completed all {levels} levels of Learn Git Branching"
   },
-  "certificate-svg-flourish": {
-    "__desc__": "Smaller flourish line printed on the certificate below the achievement line",
-    "en_US": "from the basic concepts of a branch to mastery of remote pulls"
-  },
   "certificate-svg-topics-label": {
     "__desc__": "Label above the compact list of Git topics on the certificate. Shown in capital letters",
     "en_US": "TOPICS COVERED"
   },
-  "certificate-svg-topics": {
-    "__desc__": "Compact list of the main Git concepts taught by Learn Git Branching",
-    "en_US": "Commits & Branches  •  Merging & Rebasing  •  Cherry-pick & Relative Refs  •  Undoing Changes  •  Tags & History  •  Fetch, Pull & Push"
+  "certificate-svg-topics-first": {
+    "__desc__": "First row of the main Git concepts taught by Learn Git Branching",
+    "en_US": "Commits & Branches  •  Merging & Rebasing  •  Cherry-pick & Relative Refs"
+  },
+  "certificate-svg-topics-second": {
+    "__desc__": "Second row of the main Git concepts taught by Learn Git Branching",
+    "en_US": "Undoing Changes  •  Tags & History  •  Fetch, Pull & Push"
   },
   "certificate-svg-issued": {
     "__desc__": "Label before the issue date in the certificate footer. Shown in capital letters",
     "en_US": "ISSUED"
-  },
-  "certificate-svg-seal-top": {
-    "__desc__": "Top line of the seal badge on the certificate. Shown in capital letters",
-    "en_US": "COMPLETED"
-  },
-  "certificate-svg-seal-bottom": {
-    "__desc__": "Bottom line of the seal badge on the certificate. Shown in capital letters",
-    "en_US": "LEVELS"
   },
   "finish-dialog-finished": {
     "__desc__": "One of the lines in the next level dialog",

--- a/src/js/intl/strings.js
+++ b/src/js/intl/strings.js
@@ -1,4 +1,96 @@
 exports.strings = {
+  "certificate-title": {
+    "__desc__": "Title of the modal window that shows the completion certificate",
+    "en_US": "Certificate of Completion"
+  },
+  "certificate-headline": {
+    "__desc__": "Headline inside the certificate modal, celebrating finishing every level",
+    "en_US": "You finished every single level!"
+  },
+  "certificate-subhead": {
+    "__desc__": "Sub-headline inside the certificate modal. {levels} is the total number of levels",
+    "en_US": "All {levels} of them. Put your name on it and take it with you."
+  },
+  "certificate-name-label": {
+    "__desc__": "Label for the text field where you type the name that appears on the certificate",
+    "en_US": "Your name"
+  },
+  "certificate-name-placeholder": {
+    "__desc__": "Placeholder for the certificate name text field",
+    "en_US": "Type your name here"
+  },
+  "certificate-copy": {
+    "__desc__": "Button that copies the certificate image to the clipboard",
+    "en_US": "Copy image"
+  },
+  "certificate-copied": {
+    "__desc__": "Status message after the certificate image is copied to the clipboard",
+    "en_US": "Copied! Paste it wherever you like."
+  },
+  "certificate-copy-failed": {
+    "__desc__": "Status message when copying the certificate image to the clipboard fails",
+    "en_US": "Copying failed. Try downloading it instead."
+  },
+  "certificate-copy-unsupported": {
+    "__desc__": "Status message when the browser cannot copy images to the clipboard at all",
+    "en_US": "This browser cannot copy images. Try downloading it instead."
+  },
+  "certificate-download": {
+    "__desc__": "Button that downloads the certificate as a PNG file",
+    "en_US": "Download PNG"
+  },
+  "certificate-downloaded": {
+    "__desc__": "Status message after the certificate PNG has been downloaded",
+    "en_US": "Saved to your downloads."
+  },
+  "certificate-download-failed": {
+    "__desc__": "Status message when downloading the certificate PNG fails",
+    "en_US": "Download failed, sorry about that."
+  },
+  "certificate-close": {
+    "__desc__": "Button that closes the completion certificate modal",
+    "en_US": "Close"
+  },
+  "certificate-cta": {
+    "__desc__": "Button in the level-complete dialog that opens the completion certificate",
+    "en_US": "\ud83c\udfc6  View your certificate"
+  },
+  "certificate-share": {
+    "__desc__": "Heading above the social share buttons in the certificate modal",
+    "en_US": "Share the news"
+  },
+  "certificate-svg-title": {
+    "__desc__": "Large title printed on the certificate itself. Shown in capital letters",
+    "en_US": "CERTIFICATE OF COMPLETION"
+  },
+  "certificate-svg-certifies": {
+    "__desc__": "Line printed on the certificate above the recipient name",
+    "en_US": "This certifies that"
+  },
+  "certificate-svg-name-placeholder": {
+    "__desc__": "Faded placeholder printed on the certificate before a name is entered",
+    "en_US": "YOUR NAME HERE"
+  },
+  "certificate-svg-achievement": {
+    "__desc__": "Line printed on the certificate below the name. {levels} is the total number of levels",
+    "en_US": "has completed all {levels} levels of Learn Git Branching"
+  },
+  "certificate-svg-flourish": {
+    "__desc__": "Smaller flourish line printed on the certificate below the achievement line",
+    "en_US": "from the basic concepts of a branch to mastery of remote pulls"
+  },
+  "certificate-svg-issued": {
+    "__desc__": "Label before the issue date in the certificate footer. Shown in capital letters",
+    "en_US": "ISSUED"
+  },
+  "certificate-svg-seal-top": {
+    "__desc__": "Top line of the seal badge on the certificate. Shown in capital letters",
+    "en_US": "COMPLETED"
+  },
+  "certificate-svg-seal-bottom": {
+    "__desc__": "Bottom line of the seal badge on the certificate. Shown in capital letters",
+    "en_US": "LEVELS"
+  },
   "finish-dialog-finished": {
     "__desc__": "One of the lines in the next level dialog",
     "ja": "最後のレベルをクリアしました！すごい！！",

--- a/src/js/level/index.js
+++ b/src/js/level/index.js
@@ -22,6 +22,7 @@ var MultiView = require('../views/multiView').MultiView;
 var CanvasTerminalHolder = require('../views').CanvasTerminalHolder;
 var ConfirmCancelTerminal = require('../views').ConfirmCancelTerminal;
 var NextLevelConfirm = require('../views').NextLevelConfirm;
+var CertificateView = require('../views/certificateView').CertificateView;
 var LevelToolbarView = require('../react_views/LevelToolbarView.jsx');
 
 var TreeCompare = require('../graph/treeCompare');
@@ -553,15 +554,32 @@ class Level extends Sandbox {
       }
     }
 
+    // Every single level is now solved -- that unlocks the certificate.
+    var allLevelsSolved = LevelStore.areAllLevelsSolved();
+    // Only pop the certificate on its own the first time somebody clears the
+    // whole game. It remains available from the button in this dialog when a
+    // completed level is replayed.
+    var showCertificate = allLevelsSolved &&
+      !skipFinishDialog &&
+      !LevelStore.hasSeenCertificate();
+
     if (!skipFinishDialog) {
       finishAnimationChain = finishAnimationChain.then(function() {
         // we want to ask if they will move onto the next level
         // while giving them their results...
+        //
+        // ...unless this solve was the one that completed the whole game, in
+        // which case offering "move on to the next level" would be a lie --
+        // celebrate and hand over the certificate instead.
         var nextDialog = new NextLevelConfirm({
-          nextLevel: nextLevel,
+          nextLevel: showCertificate ? null : nextLevel,
           numCommands: numCommands,
           best: best,
-          levelName: levelName
+          levelName: levelName,
+          showCertificateCta: allLevelsSolved,
+          onCertificateRequest: function() {
+            showCertificate = true;
+          }
         });
 
         return nextDialog.getPromise();
@@ -570,7 +588,7 @@ class Level extends Sandbox {
 
     finishAnimationChain
     .then(function() {
-      if (!skipFinishDialog && nextLevel) {
+      if (!skipFinishDialog && nextLevel && !showCertificate) {
         log.choseNextLevel(nextLevel.id);
         Main.getEventBaton().trigger(
           'commandSubmitted',
@@ -583,6 +601,10 @@ class Level extends Sandbox {
     })
     .then(function() {
       GlobalStateActions.changeIsAnimating(false);
+      if (showCertificate) {
+        LevelStore.markCertificateSeen();
+        new CertificateView({});
+      }
       defer.resolve();
     });
   }

--- a/src/js/sandbox/commands.js
+++ b/src/js/sandbox/commands.js
@@ -49,6 +49,17 @@ var sandboxCommandDescriptions = {
   'help builder': 'Show help for the level builder'
 };
 
+// Keep the certificate command as a local preview affordance without making
+// it possible to bypass completion on the hosted app.
+var isCertificatePreviewEnabled = function(location) {
+  return !!location && location.protocol === 'file:';
+};
+
+if (util.isBrowser() && isCertificatePreviewEnabled(window.location)) {
+  sandboxCommandDescriptions.certificate =
+    'Preview the certificate of completion';
+}
+
 var instantCommands = [
   // Add a third and fourth item in the tuple if you want this to show
   // up in the `show commands` function
@@ -262,6 +273,10 @@ var regexMap = {
   'share permalink': /^share( +permalink)?$/
 };
 
+if (util.isBrowser() && isCertificatePreviewEnabled(window.location)) {
+  regexMap.certificate = /^certificate($|\s)/;
+}
+
 var getAllCommands = function() {
   var toDelete = [
     'mobileAlert'
@@ -366,6 +381,7 @@ var getCommandHelpLines = function(target) {
 
 exports.getAllCommands = getAllCommands;
 exports.getCommandHelpLines = getCommandHelpLines;
+exports.isCertificatePreviewEnabled = isCertificatePreviewEnabled;
 exports.instantCommands = instantCommands;
 exports.parse = util.genParseCommand(regexMap, 'processSandboxCommand');
 

--- a/src/js/sandbox/index.js
+++ b/src/js/sandbox/index.js
@@ -259,6 +259,14 @@ class Sandbox {
     command.finishWith(deferred);
   }
 
+  showCertificate(command, deferred) {
+    var CertificateView = require('../views/certificateView').CertificateView;
+    var certificateView = new CertificateView({});
+    certificateView.getPromise().then(function() {
+      command.finishWith(deferred);
+    });
+  }
+
   resetSolved(command, deferred) {
     if (command.get('regexResults').input !== 'reset solved --confirm') {
       command.set('error', new Errors.GitError({
@@ -298,6 +306,7 @@ class Sandbox {
       'import level': this.importLevel,
       'importLevelNow': this.importLevelNow,
       'share permalink': this.sharePermalink,
+      'certificate': this.showCertificate,
     };
 
     var method = commandMap[command.get('method')];

--- a/src/js/stores/LevelStore.js
+++ b/src/js/stores/LevelStore.js
@@ -10,6 +10,7 @@ var util = require('../util');
 var ActionTypes = AppConstants.ActionTypes;
 var SOLVED_MAP_STORAGE_KEY = 'solvedMap';
 var ALIAS_STORAGE_KEY = 'aliasMap';
+var CERTIFICATE_SEEN_STORAGE_KEY = 'certificateSeen';
 
 var _levelMap = {};
 var _solvedMap = {};
@@ -124,6 +125,28 @@ function removeFromAliasMap(alias) {
   localStorage.setItem(ALIAS_STORAGE_KEY, JSON.stringify(aliasMap));
 }
 
+/**
+ * Whether the completion certificate has already popped up on its own.
+ * We only auto-show it the first time somebody clears every level, so that
+ * replaying levels afterwards does not nag them.
+ * @returns {boolean}
+ */
+function hasSeenCertificate() {
+  try {
+    return localStorage.getItem(CERTIFICATE_SEEN_STORAGE_KEY) === 'true';
+  } catch (e) {
+    return false;
+  }
+}
+
+function markCertificateSeen() {
+  try {
+    localStorage.setItem(CERTIFICATE_SEEN_STORAGE_KEY, 'true');
+  } catch (e) {
+    console.warn('local storage failed on set', e);
+  }
+}
+
 var validateLevel = function(level) {
   level = level || {};
   var requiredFields = [
@@ -184,6 +207,9 @@ AppConstants.StoreSubscribePrototype,
   addToAliasMap: addToAliasMap,
   removeFromAliasMap: removeFromAliasMap,
 
+  hasSeenCertificate: hasSeenCertificate,
+  markCertificateSeen: markCertificateSeen,
+
   getSequenceToLevels: function() {
     return levelSequences;
   },
@@ -236,6 +262,32 @@ AppConstants.StoreSubscribePrototype,
     return null;
   },
 
+  /**
+   * How many levels exist across every sequence.
+   * @returns {number}
+   */
+  getTotalLevelCount: function() {
+    return Object.keys(_levelMap).length;
+  },
+
+  /**
+   * How many distinct levels have been solved.
+   * @returns {number}
+   */
+  getSolvedLevelCount: function() {
+    return Object.keys(_levelMap).filter(function(levelID) {
+      return LevelStore.isLevelSolved(levelID);
+    }).length;
+  },
+
+  /**
+   * Whether every single level has been solved.
+   * @returns {boolean}
+   */
+  areAllLevelsSolved: function() {
+    return LevelStore.getSolvedLevelCount() === LevelStore.getTotalLevelCount();
+  },
+
   isLevelSolved: function(levelID) {
     var levelData = _solvedMap[levelID];
     if (levelData === true) {
@@ -260,6 +312,11 @@ AppConstants.StoreSubscribePrototype,
       case ActionTypes.RESET_LEVELS_SOLVED:
         _solvedMap = {};
         _syncToStorage();
+        try {
+          localStorage.removeItem(CERTIFICATE_SEEN_STORAGE_KEY);
+        } catch (e) {
+          console.warn('local storage failed on remove', e);
+        }
         shouldInform = true;
         break;
       case ActionTypes.SET_LEVEL_SOLVED:       

--- a/src/js/util/certificate.js
+++ b/src/js/util/certificate.js
@@ -46,6 +46,10 @@ var DEFAULT_STRINGS = {
   // {levels} is substituted with the level count.
   achievement: 'has completed all {levels} levels of Learn Git Branching',
   flourish: 'from the basic concepts of a branch to mastery of remote pulls',
+  topicsLabel: 'TOPICS COVERED',
+  topics: 'Commits & Branches  •  Merging & Rebasing  •  ' +
+    'Cherry-pick & Relative Refs  •  Undoing Changes  •  ' +
+    'Tags & History  •  Fetch, Pull & Push',
   issued: 'ISSUED',
   site: 'learngitbranching.js.org',
   sealTop: 'COMPLETED',
@@ -212,8 +216,8 @@ function refLabel(label, cx, cy, options) {
  * @returns {string}
  */
 function commitGraph(options) {
-  var mainY = 610;
-  var sideY = 536;
+  var mainY = 630;
+  var sideY = 556;
 
   // Center the visual bounds of the whole graph, including its ref labels.
   // Centering only the merge commit made the diagram read as left-aligned.
@@ -271,7 +275,7 @@ function commitGraph(options) {
 function seal(options) {
   // Leave a comfortable gap beside the now-centered commit graph.
   var cx = 1030;
-  var cy = 556;
+  var cy = 576;
   var gold = COLORS.mergeCommit;
 
   return [
@@ -497,6 +501,16 @@ function buildCertificateSVG(options) {
   }));
   parts.push(text(strings.flourish, {
     x: 600, y: 438, size: 15, fill: COLORS.dim
+  }));
+
+  // A compact skills summary adds context without competing with the name or
+  // turning the certificate into a syllabus.
+  parts.push(text(strings.topicsLabel, {
+    x: 600, y: 458, size: 9, spacing: 2, fill: COLORS.mergeCommit,
+    weight: 'bold'
+  }));
+  parts.push(text(strings.topics, {
+    x: 600, y: 478, size: 10, fill: COLORS.body
   }));
 
   // --- decorative graph + seal -----------------------------------------

--- a/src/js/util/certificate.js
+++ b/src/js/util/certificate.js
@@ -1,0 +1,698 @@
+/**
+ * Certificate of completion.
+ *
+ * Renders a shareable "you finished every level" certificate as a single
+ * self-contained SVG string, plus helpers to rasterize that SVG into a PNG
+ * blob for copying to the clipboard or downloading.
+ *
+ * This module is deliberately dependency-free (no jQuery, no underscore, no
+ * intl) so the SVG and filename behavior can be tested without a browser.
+ *
+ * Everything user-visible is passed in via options so the caller can supply
+ * translated strings; the defaults below are the English copy.
+ */
+
+var WIDTH = 1200;
+var HEIGHT = 800;
+
+// Monospace everywhere -- it is the house style of the app, and it also makes
+// text width estimation (used for underline sizing) reliable.
+var MONO = "Menlo, Monaco, Consolas, 'Droid Sans Mono', monospace";
+
+// Roughly the advance width of one glyph in a monospace face, as a fraction
+// of the font size. Used only for centering/underline math, so approximate
+// is fine.
+var MONO_ADVANCE = 0.6;
+
+var COLORS = {
+  // Commit node colors, borrowed from the app's own visual language.
+  mainCommit: '#47B2B2',
+  sideCommit: '#A277D9',
+  mergeCommit: '#E3B341',
+  branchLabel: '#FF66C4',
+  headLabel: '#7278FF',
+  tagLabel: '#E6E6E6',
+  edge: '#8B949E',
+  dim: '#7D8590',
+  body: '#C9D1D9',
+  bright: '#FFFFFF'
+};
+
+var DEFAULT_STRINGS = {
+  wordmark: 'LEARN GIT BRANCHING',
+  title: 'CERTIFICATE OF COMPLETION',
+  certifies: 'This certifies that',
+  namePlaceholder: 'YOUR NAME HERE',
+  // {levels} is substituted with the level count.
+  achievement: 'has completed all {levels} levels of Learn Git Branching',
+  flourish: 'from the basic concepts of a branch to mastery of remote pulls',
+  issued: 'ISSUED',
+  site: 'learngitbranching.js.org',
+  sealTop: 'COMPLETED',
+  sealBottom: 'LEVELS'
+};
+
+/**
+ * Escape a string for inclusion in XML text content or an attribute value.
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeXML(str) {
+  return String(str === undefined || str === null ? '' : str)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+/**
+ * Serialize an attribute map into an SVG attribute string.
+ * @param {Object} attrs
+ * @returns {string}
+ */
+function attrs(map) {
+  var out = [];
+  Object.keys(map).forEach(function(key) {
+    var value = map[key];
+    if (value === undefined || value === null || value === false) {
+      return;
+    }
+    out.push(key + '="' + escapeXML(value) + '"');
+  });
+  return out.join(' ');
+}
+
+/**
+ * Estimated rendered width of a run of monospace text.
+ * @param {string} str
+ * @param {number} fontSize
+ * @param {number} [letterSpacing]
+ * @returns {number}
+ */
+function monoWidth(str, fontSize, letterSpacing) {
+  var length = String(str).length;
+  if (!length) { return 0; }
+  return length * fontSize * MONO_ADVANCE + (length - 1) * (letterSpacing || 0);
+}
+
+/**
+ * Build an SVG <text> element.
+ *
+ * @param {string} str    Text content
+ * @param {Object} options  x, y, size, fill, weight, anchor, spacing, opacity
+ * @returns {string}
+ */
+function text(str, options) {
+  var spacing = options.spacing || 0;
+  var anchor = options.anchor || 'middle';
+
+  return '<text ' + attrs({
+    x: options.x,
+    y: options.y,
+    'font-family': options.family || MONO,
+    'font-size': options.size,
+    'font-weight': options.weight || null,
+    'letter-spacing': spacing || null,
+    'text-anchor': anchor,
+    fill: options.fill,
+    opacity: options.opacity === undefined ? null : options.opacity
+  }) + '>' + escapeXML(str) + '</text>';
+}
+
+/**
+ * A commit node: a filled circle with a white ring, matching how commits are
+ * drawn in the main visualization.
+ * @param {number} x
+ * @param {number} y
+ * @param {string} fill
+ * @param {number} [radius]
+ * @returns {string}
+ */
+function commitNode(x, y, fill, radius) {
+  var r = radius || 14;
+  return '<circle ' + attrs({
+    cx: x, cy: y, r: r + 6, fill: fill, opacity: 0.18
+  }) + '/>' +
+  '<circle ' + attrs({
+    cx: x, cy: y, r: r, fill: fill, stroke: '#FFFFFF', 'stroke-width': 2.5
+  }) + '/>';
+}
+
+/**
+ * An edge between two commits. Horizontal edges are straight lines; edges
+ * that change lanes get a gentle S-curve, the way the app draws them.
+ * @param {number} x1
+ * @param {number} y1
+ * @param {number} x2
+ * @param {number} y2
+ * @returns {string}
+ */
+function commitEdge(x1, y1, x2, y2) {
+  var d;
+  if (y1 === y2) {
+    d = 'M' + x1 + ',' + y1 + ' L' + x2 + ',' + y2;
+  } else {
+    var midX = (x1 + x2) / 2;
+    d = 'M' + x1 + ',' + y1 +
+      ' C' + midX + ',' + y1 + ' ' + midX + ',' + y2 + ' ' + x2 + ',' + y2;
+  }
+  return '<path ' + attrs({
+    d: d,
+    fill: 'none',
+    stroke: COLORS.edge,
+    'stroke-width': 2.5,
+    'stroke-linecap': 'round',
+    opacity: 0.75
+  }) + '/>';
+}
+
+/**
+ * A branch or tag label: a rounded pill centered on (cx, cy).
+ * @param {string} label
+ * @param {number} cx
+ * @param {number} cy
+ * @param {Object} options  fill, textFill, dashed
+ * @returns {string}
+ */
+function refLabel(label, cx, cy, options) {
+  options = options || {};
+  var fontSize = 15;
+  var padding = 13;
+  var width = Math.round(monoWidth(label, fontSize) + padding * 2);
+  var height = 30;
+
+  return '<rect ' + attrs({
+    x: cx - width / 2,
+    y: cy - height / 2,
+    width: width,
+    height: height,
+    rx: 6,
+    fill: options.fill || COLORS.branchLabel,
+    stroke: '#FFFFFF',
+    'stroke-width': 2,
+    'stroke-dasharray': options.dashed ? '4 3' : null
+  }) + '/>' +
+  text(label, {
+    x: cx,
+    y: cy + 5,
+    size: fontSize,
+    weight: 'bold',
+    fill: options.textFill || '#FFFFFF'
+  });
+}
+
+/**
+ * The decorative commit graph across the lower half of the certificate.
+ *
+ * It is the metaphor of the whole thing: you branched off `life` to go
+ * `learning`, put in some commits, and merged the work back in.
+ *
+ * @param {Object} options  branchName, sideBranchName, tagName
+ * @returns {string}
+ */
+function commitGraph(options) {
+  var mainY = 610;
+  var sideY = 536;
+
+  // Center the visual bounds of the whole graph, including its ref labels.
+  // Centering only the merge commit made the diagram read as left-aligned.
+  var main = [300, 390, 480, 570];
+  var side = [570, 660];
+  var mergeX = 720;
+  var tipX = 810;
+
+  var parts = [];
+
+  // Edges first so the nodes paint on top of them.
+  parts.push(commitEdge(main[0], mainY, main[1], mainY));
+  parts.push(commitEdge(main[1], mainY, main[2], mainY));
+  parts.push(commitEdge(main[2], mainY, main[3], mainY));
+  parts.push(commitEdge(main[3], mainY, mergeX, mainY));
+  parts.push(commitEdge(mergeX, mainY, tipX, mainY));
+  parts.push(commitEdge(main[2], mainY, side[0], sideY));
+  parts.push(commitEdge(side[0], sideY, side[1], sideY));
+  parts.push(commitEdge(side[1], sideY, mergeX, mainY));
+
+  main.forEach(function(x) {
+    parts.push(commitNode(x, mainY, COLORS.mainCommit));
+  });
+  side.forEach(function(x) {
+    parts.push(commitNode(x, sideY, COLORS.sideCommit));
+  });
+  parts.push(commitNode(tipX, mainY, COLORS.mainCommit));
+
+  // The merge commit is the hero of the graph, so it gets the gold treatment.
+  parts.push(commitNode(mergeX, mainY, COLORS.mergeCommit, 17));
+
+  // Connector stub from the side branch tip up to its label.
+  parts.push('<path ' + attrs({
+    d: 'M' + side[1] + ',' + (sideY - 16) + ' L' + side[1] + ',' + (sideY - 30),
+    stroke: COLORS.edge,
+    'stroke-width': 2,
+    opacity: 0.6
+  }) + '/>');
+
+  parts.push(refLabel(options.sideBranchName, side[1], sideY - 44, {}));
+  parts.push(refLabel(options.branchName, tipX + 72, mainY, {}));
+  parts.push(refLabel(options.tagName, mergeX, mainY + 58, {
+    fill: COLORS.tagLabel,
+    textFill: '#1A1D23'
+  }));
+
+  return parts.join('\n    ');
+}
+
+/**
+ * The wax-seal-ish badge in the lower right corner.
+ * @param {Object} options  count, top, bottom
+ * @returns {string}
+ */
+function seal(options) {
+  // Leave a comfortable gap beside the now-centered commit graph.
+  var cx = 1030;
+  var cy = 556;
+  var gold = COLORS.mergeCommit;
+
+  return [
+    '<circle ' + attrs({
+      cx: cx, cy: cy, r: 62, fill: 'rgba(227,179,65,0.07)',
+      stroke: gold, 'stroke-width': 2
+    }) + '/>',
+    '<circle ' + attrs({
+      cx: cx, cy: cy, r: 53, fill: 'none', stroke: gold,
+      'stroke-width': 1.5, 'stroke-dasharray': '3 6', opacity: 0.7
+    }) + '/>',
+    '<circle ' + attrs({
+      cx: cx, cy: cy, r: 44, fill: 'rgba(0,0,0,0.25)',
+      stroke: gold, 'stroke-width': 1, opacity: 0.9
+    }) + '/>',
+    text(options.top, {
+      x: cx, y: cy - 14, size: 10, spacing: 2.5, fill: gold, weight: 'bold'
+    }),
+    text(options.count, {
+      x: cx, y: cy + 12, size: 22, weight: 'bold', fill: COLORS.bright
+    }),
+    text(options.bottom, {
+      x: cx, y: cy + 32, size: 10, spacing: 2.5, fill: gold, weight: 'bold'
+    })
+  ].join('\n    ');
+}
+
+/**
+ * Decorative commit nodes tucked into the four corners of the frame.
+ * @returns {string}
+ */
+function cornerOrnaments() {
+  var points = [
+    [40, 40], [WIDTH - 40, 40], [40, HEIGHT - 40], [WIDTH - 40, HEIGHT - 40]
+  ];
+  return points.map(function(point) {
+    return '<circle ' + attrs({
+      cx: point[0], cy: point[1], r: 6,
+      fill: '#0E1117', stroke: COLORS.branchLabel, 'stroke-width': 2,
+      opacity: 0.85
+    }) + '/>';
+  }).join('\n    ');
+}
+
+/**
+ * Pick a font size for the recipient name so that long names still fit
+ * inside the certificate.
+ * @param {string} name
+ * @returns {number}
+ */
+function nameFontSize(name) {
+  var maxWidth = 900;
+  var size = 62;
+  while (size > 24 && monoWidth(name, size, 2) > maxWidth) {
+    size -= 2;
+  }
+  return size;
+}
+
+/**
+ * Format a date the way the certificate wants it, e.g. "March 14, 2026".
+ * Falls back to an ISO-ish string if toLocaleDateString misbehaves.
+ * @param {Date} [date]
+ * @param {string} [locale]
+ * @returns {string}
+ */
+function formatDate(date, locale) {
+  date = date || new Date();
+  try {
+    return date.toLocaleDateString(locale || undefined, {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric'
+    });
+  } catch (e) {
+    return date.toISOString().slice(0, 10);
+  }
+}
+
+/**
+ * Build the certificate as a standalone SVG document string.
+ *
+ * @param {Object} [options]
+ *   name           {string} recipient name (blank shows a placeholder)
+ *   levelsTotal    {number} how many levels exist
+ *   dateString     {string} pre-formatted issue date
+ *   strings        {Object} overrides for any key in DEFAULT_STRINGS
+ *   branchName     {string} label on the main branch in the graph
+ *   sideBranchName {string} label on the side branch in the graph
+ *   tagName        {string} label on the merge commit
+ * @returns {string}
+ */
+function buildCertificateSVG(options) {
+  options = options || {};
+
+  var strings = Object.assign({}, DEFAULT_STRINGS, options.strings || {});
+  var levelsTotal = options.levelsTotal || 0;
+  var rawName = String(options.name || '').trim();
+  var hasName = rawName.length > 0;
+  var name = hasName ? rawName : strings.namePlaceholder;
+  var dateString = options.dateString || formatDate();
+
+  var achievement = String(strings.achievement)
+    .replace('{levels}', String(levelsTotal));
+
+  var nameSize = nameFontSize(name);
+  var underlineWidth = Math.max(
+    360,
+    Math.min(920, monoWidth(name, nameSize, 2) + 90)
+  );
+
+  var parts = [];
+
+  parts.push(
+    '<svg ' + attrs({
+      xmlns: 'http://www.w3.org/2000/svg',
+      'xmlns:xlink': 'http://www.w3.org/1999/xlink',
+      width: WIDTH,
+      height: HEIGHT,
+      viewBox: '0 0 ' + WIDTH + ' ' + HEIGHT,
+      role: 'img'
+    }) + '>'
+  );
+
+  parts.push(
+    '<title>' + escapeXML(strings.title + ' - ' + name) + '</title>'
+  );
+
+  // --- defs -------------------------------------------------------------
+  parts.push([
+    '<defs>',
+    '  <linearGradient id="bg" x1="0" y1="0" x2="0.6" y2="1">',
+    '    <stop offset="0%" stop-color="#191D26"/>',
+    '    <stop offset="55%" stop-color="#12151C"/>',
+    '    <stop offset="100%" stop-color="#0B0D12"/>',
+    '  </linearGradient>',
+    '  <linearGradient id="titleGrad" x1="0" y1="0" x2="1" y2="0">',
+    '    <stop offset="0%" stop-color="#FF66C4"/>',
+    '    <stop offset="50%" stop-color="#C084F5"/>',
+    '    <stop offset="100%" stop-color="#7278FF"/>',
+    '  </linearGradient>',
+    '  <linearGradient id="frameGrad" x1="0" y1="0" x2="1" y2="1">',
+    '    <stop offset="0%" stop-color="#FF66C4" stop-opacity="0.85"/>',
+    '    <stop offset="45%" stop-color="#7278FF" stop-opacity="0.75"/>',
+    '    <stop offset="100%" stop-color="#47B2B2" stop-opacity="0.85"/>',
+    '  </linearGradient>',
+    '  <linearGradient id="ruleGrad" x1="0" y1="0" x2="1" y2="0">',
+    '    <stop offset="0%" stop-color="#FF66C4" stop-opacity="0"/>',
+    '    <stop offset="50%" stop-color="#C084F5" stop-opacity="0.9"/>',
+    '    <stop offset="100%" stop-color="#7278FF" stop-opacity="0"/>',
+    '  </linearGradient>',
+    '  <radialGradient id="glow" cx="0.5" cy="0.5" r="0.5">',
+    '    <stop offset="0%" stop-color="#7278FF" stop-opacity="0.28"/>',
+    '    <stop offset="100%" stop-color="#7278FF" stop-opacity="0"/>',
+    '  </radialGradient>',
+    '  <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">',
+    '    <circle cx="1" cy="1" r="1" fill="#FFFFFF" opacity="0.05"/>',
+    '  </pattern>',
+    '</defs>'
+  ].join('\n  '));
+
+  // --- background -------------------------------------------------------
+  parts.push('<rect ' + attrs({
+    x: 0, y: 0, width: WIDTH, height: HEIGHT, fill: 'url(#bg)'
+  }) + '/>');
+  parts.push('<rect ' + attrs({
+    x: 0, y: 0, width: WIDTH, height: HEIGHT, fill: 'url(#grid)'
+  }) + '/>');
+  parts.push('<ellipse ' + attrs({
+    cx: 600, cy: 180, rx: 620, ry: 300, fill: 'url(#glow)'
+  }) + '/>');
+
+  // --- frame ------------------------------------------------------------
+  parts.push('<rect ' + attrs({
+    x: 28, y: 28, width: WIDTH - 56, height: HEIGHT - 56, rx: 18,
+    fill: 'none', stroke: 'url(#frameGrad)', 'stroke-width': 2.5
+  }) + '/>');
+  parts.push('<rect ' + attrs({
+    x: 40, y: 40, width: WIDTH - 80, height: HEIGHT - 80, rx: 12,
+    fill: 'none', stroke: '#FFFFFF', 'stroke-opacity': 0.09,
+    'stroke-width': 1
+  }) + '/>');
+  parts.push(cornerOrnaments());
+
+  // --- header -----------------------------------------------------------
+  parts.push(text(strings.wordmark, {
+    x: 600, y: 106, size: 15, spacing: 8, fill: COLORS.dim, weight: 'bold'
+  }));
+  parts.push(text(strings.title, {
+    x: 600, y: 172, size: 42, spacing: 5, weight: 'bold',
+    fill: 'url(#titleGrad)'
+  }));
+
+  // Divider with a commit node sitting on it, like a branch point.
+  parts.push('<rect ' + attrs({
+    x: 330, y: 200, width: 540, height: 2, fill: 'url(#ruleGrad)'
+  }) + '/>');
+  parts.push(commitNode(600, 201, COLORS.branchLabel, 7));
+
+  // --- body -------------------------------------------------------------
+  parts.push(text(strings.certifies, {
+    x: 600, y: 262, size: 18, spacing: 1, fill: COLORS.dim
+  }));
+
+  parts.push(text(name, {
+    // A percentage keeps the intent explicit even if the canvas dimensions
+    // change later; text-anchor centers the actual rendered text run.
+    x: '50%',
+    y: 336,
+    size: nameSize,
+    spacing: 2,
+    weight: 'bold',
+    fill: hasName ? COLORS.bright : 'rgba(255,255,255,0.28)'
+  }));
+
+  parts.push('<rect ' + attrs({
+    x: 600 - underlineWidth / 2, y: 360, width: underlineWidth, height: 1,
+    fill: '#FFFFFF', opacity: 0.18
+  }) + '/>');
+
+  parts.push(text(achievement, {
+    x: 600, y: 406, size: 19, fill: COLORS.body
+  }));
+  parts.push(text(strings.flourish, {
+    x: 600, y: 438, size: 15, fill: COLORS.dim
+  }));
+
+  // --- decorative graph + seal -----------------------------------------
+  parts.push(commitGraph({
+    branchName: options.branchName || 'life',
+    sideBranchName: options.sideBranchName || 'learning',
+    tagName: options.tagName || 'v1.0'
+  }));
+
+  parts.push(seal({
+    count: levelsTotal + '/' + levelsTotal,
+    top: strings.sealTop,
+    bottom: strings.sealBottom
+  }));
+
+  // --- footer -----------------------------------------------------------
+  parts.push('<rect ' + attrs({
+    x: 80, y: 716, width: WIDTH - 160, height: 1,
+    fill: '#FFFFFF', opacity: 0.1
+  }) + '/>');
+  parts.push(text(strings.issued + '  ' + dateString, {
+    x: 80, y: 750, size: 14, anchor: 'start', fill: COLORS.dim
+  }));
+  parts.push(text(strings.site, {
+    x: 600, y: 750, size: 14, spacing: 1, fill: COLORS.body
+  }));
+  parts.push(text('git checkout -b career', {
+    x: WIDTH - 80, y: 750, size: 14, anchor: 'end', fill: COLORS.dim
+  }));
+
+  parts.push('</svg>');
+
+  return parts.join('\n  ');
+}
+
+/* ------------------------------------------------------------------ *
+ * Rasterization helpers (browser only)
+ * ------------------------------------------------------------------ */
+
+/**
+ * Encode an SVG string as a data URL. We base64 the UTF-8 bytes so that
+ * non-ASCII names (which are very much expected) survive the trip.
+ * @param {string} svgString
+ * @returns {string}
+ */
+function svgToDataURL(svgString) {
+  var utf8 = window.unescape(window.encodeURIComponent(svgString));
+  return 'data:image/svg+xml;base64,' + window.btoa(utf8);
+}
+
+/**
+ * Rasterize the certificate SVG into a PNG blob.
+ *
+ * The SVG references no external resources (no web fonts, no images), so the
+ * canvas never gets tainted and toBlob() is safe to call.
+ *
+ * @param {string} svgString
+ * @param {Object} [options]  scale (default 2 for retina-ish output)
+ * @returns {Promise<Blob>}
+ */
+function svgToPngBlob(svgString, options) {
+  options = options || {};
+  var scale = options.scale || 2;
+
+  return new Promise(function(resolve, reject) {
+    var image = new window.Image();
+
+    image.onload = function() {
+      var canvas = document.createElement('canvas');
+      canvas.width = WIDTH * scale;
+      canvas.height = HEIGHT * scale;
+
+      var context = canvas.getContext('2d');
+      // Paint an opaque backdrop first; PNG transparency around the rounded
+      // frame looks broken when pasted into chat apps.
+      context.fillStyle = '#0B0D12';
+      context.fillRect(0, 0, canvas.width, canvas.height);
+      context.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+      canvas.toBlob(function(blob) {
+        if (blob) {
+          resolve(blob);
+        } else {
+          reject(new Error('could not encode the certificate as a PNG'));
+        }
+      }, 'image/png');
+    };
+
+    image.onerror = function() {
+      reject(new Error('could not rasterize the certificate SVG'));
+    };
+
+    image.src = svgToDataURL(svgString);
+  });
+}
+
+/**
+ * Whether this browser can put an image on the clipboard.
+ * @returns {boolean}
+ */
+function canCopyImage() {
+  return !!(
+    window.ClipboardItem &&
+    window.navigator &&
+    window.navigator.clipboard &&
+    window.navigator.clipboard.write
+  );
+}
+
+// Chrome never settles clipboard.write() when the document does not have
+// focus, which would otherwise leave the UI waiting forever with no feedback.
+var CLIPBOARD_TIMEOUT = 8000;
+
+/**
+ * Copy a PNG of the certificate to the clipboard.
+ *
+ * Safari requires the ClipboardItem to be constructed synchronously inside
+ * the user gesture, so we hand it the *promise* of a blob rather than
+ * awaiting the blob first.
+ *
+ * @param {Promise<Blob>|Blob} blobOrPromise
+ * @returns {Promise}
+ */
+function copyPngToClipboard(blobOrPromise) {
+  if (!canCopyImage()) {
+    return Promise.reject(new Error('clipboard images are not supported here'));
+  }
+
+  var write;
+  try {
+    var item = new window.ClipboardItem({
+      'image/png': blobOrPromise
+    });
+    write = window.navigator.clipboard.write([item]);
+  } catch (e) {
+    return Promise.reject(e);
+  }
+
+  var timeout = new Promise(function(resolve, reject) {
+    window.setTimeout(function() {
+      reject(new Error('the clipboard did not respond'));
+    }, CLIPBOARD_TIMEOUT);
+  });
+
+  return Promise.race([write, timeout]);
+}
+
+/**
+ * Trigger a browser download of a blob.
+ * @param {Blob} blob
+ * @param {string} filename
+ */
+function downloadBlob(blob, filename) {
+  var url = window.URL.createObjectURL(blob);
+  var anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  // Give the download a tick to start before we drop the object URL.
+  window.setTimeout(function() {
+    window.URL.revokeObjectURL(url);
+  }, 1000);
+}
+
+/**
+ * Turn a recipient name into a safe-ish download filename.
+ * @param {string} name
+ * @returns {string}
+ */
+function filenameForName(name) {
+  var slug = String(name || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return slug ?
+    'learn-git-branching-certificate-' + slug + '.png' :
+    'learn-git-branching-certificate.png';
+}
+
+var api = {
+  WIDTH: WIDTH,
+  HEIGHT: HEIGHT,
+  DEFAULT_STRINGS: DEFAULT_STRINGS,
+  buildCertificateSVG: buildCertificateSVG,
+  formatDate: formatDate,
+  svgToDataURL: svgToDataURL,
+  svgToPngBlob: svgToPngBlob,
+  canCopyImage: canCopyImage,
+  copyPngToClipboard: copyPngToClipboard,
+  downloadBlob: downloadBlob,
+  filenameForName: filenameForName
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = api;
+}

--- a/src/js/util/certificate.js
+++ b/src/js/util/certificate.js
@@ -41,19 +41,15 @@ var COLORS = {
 var DEFAULT_STRINGS = {
   wordmark: 'LEARN GIT BRANCHING',
   title: 'CERTIFICATE OF COMPLETION',
-  certifies: 'This certifies that',
   namePlaceholder: 'YOUR NAME HERE',
   // {levels} is substituted with the level count.
   achievement: 'has completed all {levels} levels of Learn Git Branching',
-  flourish: 'from the basic concepts of a branch to mastery of remote pulls',
   topicsLabel: 'TOPICS COVERED',
-  topics: 'Commits & Branches  •  Merging & Rebasing  •  ' +
-    'Cherry-pick & Relative Refs  •  Undoing Changes  •  ' +
-    'Tags & History  •  Fetch, Pull & Push',
+  topicsFirst: 'Commits & Branches  •  Merging & Rebasing  •  ' +
+    'Cherry-pick & Relative Refs',
+  topicsSecond: 'Undoing Changes  •  Tags & History  •  Fetch, Pull & Push',
   issued: 'ISSUED',
-  site: 'learngitbranching.js.org',
-  sealTop: 'COMPLETED',
-  sealBottom: 'LEVELS'
+  site: 'learngitbranching.js.org'
 };
 
 /**
@@ -216,15 +212,15 @@ function refLabel(label, cx, cy, options) {
  * @returns {string}
  */
 function commitGraph(options) {
-  var mainY = 630;
-  var sideY = 556;
+  var mainY = 625;
+  var sideY = 563;
 
   // Center the visual bounds of the whole graph, including its ref labels.
   // Centering only the merge commit made the diagram read as left-aligned.
-  var main = [300, 390, 480, 570];
-  var side = [570, 660];
-  var mergeX = 720;
-  var tipX = 810;
+  var main = [350, 425, 500, 575];
+  var side = [575, 650];
+  var mergeX = 700;
+  var tipX = 775;
 
   var parts = [];
 
@@ -239,68 +235,32 @@ function commitGraph(options) {
   parts.push(commitEdge(side[1], sideY, mergeX, mainY));
 
   main.forEach(function(x) {
-    parts.push(commitNode(x, mainY, COLORS.mainCommit));
+    parts.push(commitNode(x, mainY, COLORS.mainCommit, 12));
   });
   side.forEach(function(x) {
-    parts.push(commitNode(x, sideY, COLORS.sideCommit));
+    parts.push(commitNode(x, sideY, COLORS.sideCommit, 12));
   });
-  parts.push(commitNode(tipX, mainY, COLORS.mainCommit));
+  parts.push(commitNode(tipX, mainY, COLORS.mainCommit, 12));
 
   // The merge commit is the hero of the graph, so it gets the gold treatment.
-  parts.push(commitNode(mergeX, mainY, COLORS.mergeCommit, 17));
+  parts.push(commitNode(mergeX, mainY, COLORS.mergeCommit, 15));
 
   // Connector stub from the side branch tip up to its label.
   parts.push('<path ' + attrs({
-    d: 'M' + side[1] + ',' + (sideY - 16) + ' L' + side[1] + ',' + (sideY - 30),
+    d: 'M' + side[1] + ',' + (sideY - 14) + ' L' + side[1] + ',' + (sideY - 26),
     stroke: COLORS.edge,
     'stroke-width': 2,
     opacity: 0.6
   }) + '/>');
 
-  parts.push(refLabel(options.sideBranchName, side[1], sideY - 44, {}));
-  parts.push(refLabel(options.branchName, tipX + 72, mainY, {}));
-  parts.push(refLabel(options.tagName, mergeX, mainY + 58, {
+  parts.push(refLabel(options.sideBranchName, side[1], sideY - 40, {}));
+  parts.push(refLabel(options.branchName, tipX + 62, mainY, {}));
+  parts.push(refLabel(options.tagName, mergeX, mainY + 52, {
     fill: COLORS.tagLabel,
     textFill: '#1A1D23'
   }));
 
   return parts.join('\n    ');
-}
-
-/**
- * The wax-seal-ish badge in the lower right corner.
- * @param {Object} options  count, top, bottom
- * @returns {string}
- */
-function seal(options) {
-  // Leave a comfortable gap beside the now-centered commit graph.
-  var cx = 1030;
-  var cy = 576;
-  var gold = COLORS.mergeCommit;
-
-  return [
-    '<circle ' + attrs({
-      cx: cx, cy: cy, r: 62, fill: 'rgba(227,179,65,0.07)',
-      stroke: gold, 'stroke-width': 2
-    }) + '/>',
-    '<circle ' + attrs({
-      cx: cx, cy: cy, r: 53, fill: 'none', stroke: gold,
-      'stroke-width': 1.5, 'stroke-dasharray': '3 6', opacity: 0.7
-    }) + '/>',
-    '<circle ' + attrs({
-      cx: cx, cy: cy, r: 44, fill: 'rgba(0,0,0,0.25)',
-      stroke: gold, 'stroke-width': 1, opacity: 0.9
-    }) + '/>',
-    text(options.top, {
-      x: cx, y: cy - 14, size: 10, spacing: 2.5, fill: gold, weight: 'bold'
-    }),
-    text(options.count, {
-      x: cx, y: cy + 12, size: 22, weight: 'bold', fill: COLORS.bright
-    }),
-    text(options.bottom, {
-      x: cx, y: cy + 32, size: 10, spacing: 2.5, fill: gold, weight: 'bold'
-    })
-  ].join('\n    ');
 }
 
 /**
@@ -462,29 +422,25 @@ function buildCertificateSVG(options) {
 
   // --- header -----------------------------------------------------------
   parts.push(text(strings.wordmark, {
-    x: 600, y: 106, size: 15, spacing: 8, fill: COLORS.dim, weight: 'bold'
+    x: 600, y: 122, size: 42, spacing: 6, weight: 'bold',
+    fill: 'url(#titleGrad)'
   }));
   parts.push(text(strings.title, {
-    x: 600, y: 172, size: 42, spacing: 5, weight: 'bold',
-    fill: 'url(#titleGrad)'
+    x: 600, y: 174, size: 24, spacing: 4, weight: 'bold', fill: COLORS.body
   }));
 
   // Divider with a commit node sitting on it, like a branch point.
   parts.push('<rect ' + attrs({
-    x: 330, y: 200, width: 540, height: 2, fill: 'url(#ruleGrad)'
+    x: 330, y: 202, width: 540, height: 2, fill: 'url(#ruleGrad)'
   }) + '/>');
-  parts.push(commitNode(600, 201, COLORS.branchLabel, 7));
+  parts.push(commitNode(600, 203, COLORS.branchLabel, 7));
 
   // --- body -------------------------------------------------------------
-  parts.push(text(strings.certifies, {
-    x: 600, y: 262, size: 18, spacing: 1, fill: COLORS.dim
-  }));
-
   parts.push(text(name, {
     // A percentage keeps the intent explicit even if the canvas dimensions
     // change later; text-anchor centers the actual rendered text run.
     x: '50%',
-    y: 336,
+    y: 302,
     size: nameSize,
     spacing: 2,
     weight: 'bold',
@@ -492,38 +448,32 @@ function buildCertificateSVG(options) {
   }));
 
   parts.push('<rect ' + attrs({
-    x: 600 - underlineWidth / 2, y: 360, width: underlineWidth, height: 1,
+    x: 600 - underlineWidth / 2, y: 326, width: underlineWidth, height: 1,
     fill: '#FFFFFF', opacity: 0.18
   }) + '/>');
 
   parts.push(text(achievement, {
-    x: 600, y: 406, size: 19, fill: COLORS.body
-  }));
-  parts.push(text(strings.flourish, {
-    x: 600, y: 438, size: 15, fill: COLORS.dim
+    x: 600, y: 371, size: 19, fill: COLORS.body
   }));
 
   // A compact skills summary adds context without competing with the name or
   // turning the certificate into a syllabus.
   parts.push(text(strings.topicsLabel, {
-    x: 600, y: 458, size: 9, spacing: 2, fill: COLORS.mergeCommit,
+    x: 600, y: 411, size: 12, spacing: 2.5, fill: COLORS.mergeCommit,
     weight: 'bold'
   }));
-  parts.push(text(strings.topics, {
-    x: 600, y: 478, size: 10, fill: COLORS.body
+  parts.push(text(strings.topicsFirst, {
+    x: 600, y: 442, size: 15, fill: COLORS.body
+  }));
+  parts.push(text(strings.topicsSecond, {
+    x: 600, y: 470, size: 15, fill: COLORS.body
   }));
 
-  // --- decorative graph + seal -----------------------------------------
+  // --- decorative graph ------------------------------------------------
   parts.push(commitGraph({
     branchName: options.branchName || 'life',
     sideBranchName: options.sideBranchName || 'learning',
     tagName: options.tagName || 'v1.0'
-  }));
-
-  parts.push(seal({
-    count: levelsTotal + '/' + levelsTotal,
-    top: strings.sealTop,
-    bottom: strings.sealBottom
   }));
 
   // --- footer -----------------------------------------------------------

--- a/src/js/util/sharing.js
+++ b/src/js/util/sharing.js
@@ -3,6 +3,8 @@
  * Uses each platform's standard deeplink URL scheme to open the composer.
  */
 
+var intl = require('../intl');
+
 var SITE_URL = 'https://learngitbranching.js.org';
 
 /**
@@ -20,41 +22,76 @@ function buildShareText(levelName) {
 }
 
 /**
- * Returns the Twitter/X share URL for a given level.
- * @param {string} levelName
+ * Build the share text for finishing every level in the game.
+ * @param {number} levelsTotal  How many levels there are
  * @returns {string}
  */
-function getTwitterUrl(levelName) {
-  var text = buildShareText(levelName);
+function buildAllLevelsShareText(levelsTotal) {
+  return 'I just completed all ' + levelsTotal +
+    ' levels of Learn Git Branching and earned my certificate! ' +
+    'Learn git interactively at ' + SITE_URL;
+}
+
+/**
+ * Returns the Twitter/X share URL for a given text.
+ * @param {string} text
+ * @returns {string}
+ */
+function getTwitterUrlForText(text) {
   return 'https://twitter.com/intent/tweet?text=' + encodeURIComponent(text);
 }
 
 /**
- * Returns the LinkedIn share URL for a given level.
+ * Returns the LinkedIn share URL for a given text.
  * The share-offsite endpoint only reads the url param and ignores any
  * text, so we deeplink into the feed composer which supports prefilled text.
- * @param {string} levelName
+ * @param {string} text
  * @returns {string}
  */
-function getLinkedInUrl(levelName) {
-  var text = buildShareText(levelName);
+function getLinkedInUrlForText(text) {
   return 'https://www.linkedin.com/feed/?shareActive=true&text=' +
     encodeURIComponent(text);
 }
 
 /**
- * Returns the Facebook share URL for a given level.
+ * Returns the Facebook share URL for a given text.
  * Facebook policy prohibits prefilling the composer text itself; the quote
  * param is the only sanctioned way to attach a message (shown as a quote
  * block on the post) and even that is honored inconsistently.
+ * @param {string} text
+ * @returns {string}
+ */
+function getFacebookUrlForText(text) {
+  return 'https://www.facebook.com/sharer/sharer.php?u=' +
+    encodeURIComponent(SITE_URL) +
+    '&quote=' + encodeURIComponent(text);
+}
+
+/**
+ * Returns the Twitter/X share URL for a given level.
+ * @param {string} levelName
+ * @returns {string}
+ */
+function getTwitterUrl(levelName) {
+  return getTwitterUrlForText(buildShareText(levelName));
+}
+
+/**
+ * Returns the LinkedIn share URL for a given level.
+ * @param {string} levelName
+ * @returns {string}
+ */
+function getLinkedInUrl(levelName) {
+  return getLinkedInUrlForText(buildShareText(levelName));
+}
+
+/**
+ * Returns the Facebook share URL for a given level.
  * @param {string} levelName
  * @returns {string}
  */
 function getFacebookUrl(levelName) {
-  var text = buildShareText(levelName);
-  return 'https://www.facebook.com/sharer/sharer.php?u=' +
-    encodeURIComponent(SITE_URL) +
-    '&quote=' + encodeURIComponent(text);
+  return getFacebookUrlForText(buildShareText(levelName));
 }
 
 /**
@@ -74,8 +111,114 @@ function openShareWindow(url) {
   );
 }
 
+var SHARE_ICONS = {
+  twitter: '<svg class="share-btn-icon" viewBox="0 0 24 24" aria-hidden="true">' +
+    '<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817' +
+    'L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833' +
+    'L7.084 4.126H5.117z"/></svg>',
+  linkedin: '<svg class="share-btn-icon" viewBox="0 0 24 24" aria-hidden="true">' +
+    '<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0' +
+    '-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 ' +
+    '3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063' +
+    '-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 ' +
+    '0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0' +
+    'H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 ' +
+    '24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>',
+  facebook: '<svg class="share-btn-icon" viewBox="0 0 24 24" aria-hidden="true">' +
+    '<path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 ' +
+    '10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 ' +
+    '4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925' +
+    '-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 ' +
+    '24 12.073z"/></svg>'
+};
+
+/**
+ * Escape a string for use inside a double-quoted HTML attribute.
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeAttr(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Markup for one share button. Clicks are handled by delegation on whatever
+ * container the markup ends up in -- see bindShareButtons.
+ * @param {string} key  twitter | linkedin | facebook
+ * @param {string} url
+ * @param {string} label
+ * @returns {string}
+ */
+function shareButtonHTML(key, url, label) {
+  return '<button class="share-btn share-btn-' + key + '"' +
+    ' data-share-url="' + escapeAttr(url) + '"' +
+    ' aria-label="' + escapeAttr(label) + '">' +
+    SHARE_ICONS[key] +
+    '<span>' + escapeAttr(label) + '</span>' +
+  '</button>';
+}
+
+/**
+ * The whole "share your progress" block: a label plus the three network
+ * buttons, all pointing at the same share text.
+ *
+ * @param {string} shareText  The message to prefill each composer with
+ * @param {Object} [options]  label: heading text above the buttons
+ * @returns {string}
+ */
+function buildShareSectionHTML(shareText, options) {
+  options = options || {};
+  var label = options.label || intl.str('share-progress');
+
+  return '<div class="share-progress-section">' +
+    '<p class="share-progress-label">' + escapeAttr(label) + '</p>' +
+    '<div class="share-progress-buttons">' +
+    shareButtonHTML(
+      'twitter',
+      getTwitterUrlForText(shareText),
+      intl.str('share-progress-twitter')
+    ) +
+    shareButtonHTML(
+      'linkedin',
+      getLinkedInUrlForText(shareText),
+      intl.str('share-progress-linkedin')
+    ) +
+    shareButtonHTML(
+      'facebook',
+      getFacebookUrlForText(shareText),
+      intl.str('share-progress-facebook')
+    ) +
+    '</div>' +
+    '</div>';
+}
+
+/**
+ * Wire up share button clicks inside a container via event delegation.
+ * @param {Object} $container  jQuery-wrapped element
+ */
+function bindShareButtons($container) {
+  if (!$container) { return; }
+  $container.on('click', '[data-share-url]', function(e) {
+    e.preventDefault();
+    var url = $(e.currentTarget).attr('data-share-url');
+    if (url) {
+      openShareWindow(url);
+    }
+  });
+}
+
 exports.buildShareText = buildShareText;
+exports.buildAllLevelsShareText = buildAllLevelsShareText;
 exports.getTwitterUrl = getTwitterUrl;
 exports.getLinkedInUrl = getLinkedInUrl;
 exports.getFacebookUrl = getFacebookUrl;
+exports.getTwitterUrlForText = getTwitterUrlForText;
+exports.getLinkedInUrlForText = getLinkedInUrlForText;
+exports.getFacebookUrlForText = getFacebookUrlForText;
 exports.openShareWindow = openShareWindow;
+exports.buildShareSectionHTML = buildShareSectionHTML;
+exports.bindShareButtons = bindShareButtons;

--- a/src/js/views/certificateView.js
+++ b/src/js/views/certificateView.js
@@ -75,6 +75,8 @@ function certificateStrings(levelsTotal) {
       levels: levelsTotal
     }),
     flourish: intl.str('certificate-svg-flourish'),
+    topicsLabel: intl.str('certificate-svg-topics-label'),
+    topics: intl.str('certificate-svg-topics'),
     issued: intl.str('certificate-svg-issued'),
     sealTop: intl.str('certificate-svg-seal-top'),
     sealBottom: intl.str('certificate-svg-seal-bottom')

--- a/src/js/views/certificateView.js
+++ b/src/js/views/certificateView.js
@@ -1,0 +1,266 @@
+/**
+ * The "you finished every level" certificate modal.
+ *
+ * Shows a live-rendered certificate, lets you type your name onto it, and
+ * offers copy-to-clipboard / download-as-PNG plus the usual social share
+ * buttons.
+ */
+
+var intl = require('../intl');
+var util = require('../util');
+var Views = require('../views');
+var ContainedBase = Views.ContainedBase;
+var ModalTerminal = Views.ModalTerminal;
+var KeyboardListener = require('../util/keyboard').KeyboardListener;
+var { createEvents } = require('../util/eventEmitter');
+var createDeferred = require('../util/promise').createDeferred;
+var LevelStore = require('../stores/LevelStore');
+var sharing = require('../util/sharing');
+var certificate = require('../util/certificate');
+
+var NAME_STORAGE_KEY = 'certificateName';
+var STATUS_TIMEOUT = 3500;
+
+/**
+ * The name typed onto the certificate is remembered between visits so people
+ * do not have to retype it. Storage can throw (private browsing, disabled
+ * cookies), hence the try/catch on both sides.
+ * @returns {string}
+ */
+function readStoredName() {
+  if (!util.isBrowser()) { return ''; }
+  try {
+    return window.localStorage.getItem(NAME_STORAGE_KEY) || '';
+  } catch (e) {
+    return '';
+  }
+}
+
+/**
+ * @param {string} name
+ */
+function writeStoredName(name) {
+  if (!util.isBrowser()) { return; }
+  try {
+    window.localStorage.setItem(NAME_STORAGE_KEY, name);
+  } catch (e) {
+    // Not being able to remember the name is not worth bothering anyone about.
+  }
+}
+
+/**
+ * Escape a string for use inside a double-quoted HTML attribute.
+ * @param {string} value
+ * @returns {string}
+ */
+function escapeAttr(value) {
+  return String(value === undefined || value === null ? '' : value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/**
+ * Collect the translated strings that get baked into the SVG itself.
+ * @param {number} levelsTotal
+ * @returns {Object}
+ */
+function certificateStrings(levelsTotal) {
+  return {
+    title: intl.str('certificate-svg-title'),
+    certifies: intl.str('certificate-svg-certifies'),
+    namePlaceholder: intl.str('certificate-svg-name-placeholder'),
+    achievement: intl.str('certificate-svg-achievement', {
+      levels: levelsTotal
+    }),
+    flourish: intl.str('certificate-svg-flourish'),
+    issued: intl.str('certificate-svg-issued'),
+    sealTop: intl.str('certificate-svg-seal-top'),
+    sealBottom: intl.str('certificate-svg-seal-bottom')
+  };
+}
+
+class CertificateView extends ContainedBase {
+  constructor(options) {
+    options = options || {};
+    options.tagName = 'div';
+    options.className = 'certificateView box vertical';
+    super(options);
+
+    this.deferred = options.deferred || createDeferred();
+    this.levelsTotal = options.levelsTotal || LevelStore.getTotalLevelCount();
+    this.recipientName = options.name === undefined ?
+      readStoredName() :
+      String(options.name);
+    this.statusTimeout = null;
+
+    this.container = options.container || new ModalTerminal({
+      title: intl.str('certificate-title')
+    });
+
+    this.render(this.buildHTML());
+    this.updatePreview();
+
+    this.$('.certificateNameInput').on('input', this.onNameInput.bind(this));
+    this.$('.certificateCopy').on('click', this.onCopy.bind(this));
+    this.$('.certificateDownload').on('click', this.onDownload.bind(this));
+    this.$('.certificateClose').on('click', this.close.bind(this));
+    sharing.bindShareButtons(this.$el);
+
+    // Closing happens through the terminal window's own close control or the
+    // esc key, both of which the keyboard listener funnels into 'esc'. Enter
+    // deliberately does nothing so it stays harmless while typing a name.
+    this.navEvents = createEvents();
+    this.navEvents.on('esc', this.close, this);
+    this.keyboardListener = new KeyboardListener({
+      events: this.navEvents,
+      aliasMap: {}
+    });
+
+    if (!options.wait) {
+      this.show();
+      // Nudge focus into the name field so people can just start typing.
+      window.setTimeout(function() {
+        this.$('.certificateNameInput').focus();
+      }.bind(this), this.getAnimationTime());
+    }
+  }
+
+  /**
+   * @returns {string}
+   */
+  buildHTML() {
+    var shareText = sharing.buildAllLevelsShareText(this.levelsTotal);
+    var canCopy = certificate.canCopyImage();
+
+    return [
+      '<h2 class="certificateHeadline">' +
+        escapeAttr(intl.str('certificate-headline')) +
+      '</h2>',
+      '<p class="certificateSubhead">' +
+        escapeAttr(intl.str('certificate-subhead', {
+          levels: this.levelsTotal
+        })) +
+      '</p>',
+      '<div class="certificateNameRow">',
+      '  <label class="certificateNameLabel" for="certificateNameInput">' +
+          escapeAttr(intl.str('certificate-name-label')) +
+        '</label>',
+      '  <input id="certificateNameInput" class="certificateNameInput"' +
+        ' type="text" maxlength="60" autocomplete="name" spellcheck="false"' +
+        ' placeholder="' + escapeAttr(intl.str('certificate-name-placeholder')) + '"' +
+        ' value="' + escapeAttr(this.recipientName) + '"/>',
+      '</div>',
+      '<div class="certificatePreview"></div>',
+      '<div class="certificateActions">',
+      '  <button type="button" class="certificateButton certificateCopy"' +
+          (canCopy ? '' : ' disabled') + '>' +
+          escapeAttr(intl.str('certificate-copy')) +
+        '</button>',
+      '  <button type="button" class="certificateButton certificateDownload">' +
+          escapeAttr(intl.str('certificate-download')) +
+        '</button>',
+      '  <button type="button" class="certificateButton certificateClose">' +
+          escapeAttr(intl.str('certificate-close')) +
+        '</button>',
+      '</div>',
+      '<p class="certificateStatus" role="status" aria-live="polite"></p>',
+      sharing.buildShareSectionHTML(shareText, {
+        label: intl.str('certificate-share')
+      })
+    ].join('\n');
+  }
+
+  /**
+   * The certificate SVG for the currently typed name.
+   * @returns {string}
+   */
+  currentSVG() {
+    return certificate.buildCertificateSVG({
+      name: this.recipientName,
+      levelsTotal: this.levelsTotal,
+      dateString: certificate.formatDate(new Date()),
+      strings: certificateStrings(this.levelsTotal)
+    });
+  }
+
+  updatePreview() {
+    this.$('.certificatePreview').html(this.currentSVG());
+  }
+
+  onNameInput() {
+    this.recipientName = this.$('.certificateNameInput').val() || '';
+    writeStoredName(this.recipientName);
+    this.updatePreview();
+  }
+
+  /**
+   * @param {string} message
+   * @param {boolean} [isError]
+   */
+  setStatus(message, isError) {
+    var $status = this.$('.certificateStatus');
+    $status.text(message || '');
+    $status.toggleClass('certificateStatusError', !!isError);
+
+    window.clearTimeout(this.statusTimeout);
+    if (message) {
+      this.statusTimeout = window.setTimeout(function() {
+        $status.text('');
+        $status.removeClass('certificateStatusError');
+      }, STATUS_TIMEOUT);
+    }
+  }
+
+  onCopy() {
+    if (!certificate.canCopyImage()) {
+      this.setStatus(intl.str('certificate-copy-unsupported'), true);
+      return;
+    }
+
+    // Safari requires the ClipboardItem to be built synchronously inside the
+    // click handler, so we hand it the promise of a blob rather than awaiting.
+    var blobPromise = certificate.svgToPngBlob(this.currentSVG());
+    certificate.copyPngToClipboard(blobPromise)
+    .then(function() {
+      this.setStatus(intl.str('certificate-copied'));
+    }.bind(this))
+    .catch(function() {
+      this.setStatus(intl.str('certificate-copy-failed'), true);
+    }.bind(this));
+  }
+
+  onDownload() {
+    certificate.svgToPngBlob(this.currentSVG())
+    .then(function(blob) {
+      certificate.downloadBlob(
+        blob,
+        certificate.filenameForName(this.recipientName)
+      );
+      this.setStatus(intl.str('certificate-downloaded'));
+    }.bind(this))
+    .catch(function() {
+      this.setStatus(intl.str('certificate-download-failed'), true);
+    }.bind(this));
+  }
+
+  close() {
+    if (this.closed) { return; }
+    this.closed = true;
+
+    window.clearTimeout(this.statusTimeout);
+    this.keyboardListener.mute();
+    this.die();
+    this.deferred.resolve();
+  }
+
+  /**
+   * @returns {Promise}
+   */
+  getPromise() {
+    return this.deferred.promise;
+  }
+}
+
+exports.CertificateView = CertificateView;

--- a/src/js/views/certificateView.js
+++ b/src/js/views/certificateView.js
@@ -69,17 +69,14 @@ function escapeAttr(value) {
 function certificateStrings(levelsTotal) {
   return {
     title: intl.str('certificate-svg-title'),
-    certifies: intl.str('certificate-svg-certifies'),
     namePlaceholder: intl.str('certificate-svg-name-placeholder'),
     achievement: intl.str('certificate-svg-achievement', {
       levels: levelsTotal
     }),
-    flourish: intl.str('certificate-svg-flourish'),
     topicsLabel: intl.str('certificate-svg-topics-label'),
-    topics: intl.str('certificate-svg-topics'),
+    topicsFirst: intl.str('certificate-svg-topics-first'),
+    topicsSecond: intl.str('certificate-svg-topics-second'),
     issued: intl.str('certificate-svg-issued'),
-    sealTop: intl.str('certificate-svg-seal-top'),
-    sealBottom: intl.str('certificate-svg-seal-bottom')
   };
 }
 

--- a/src/js/views/index.js
+++ b/src/js/views/index.js
@@ -483,58 +483,21 @@ class NextLevelConfirm extends ConfirmCancelTerminal {
     }
 
     var currentLevelName = options.levelName || '';
-    var escapeAttr = function(url) {
-      return url.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-    };
-    var shareIcons = {
-      twitter: '<svg class="share-btn-icon" viewBox="0 0 24 24" aria-hidden="true">' +
-        '<path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817' +
-        'L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833' +
-        'L7.084 4.126H5.117z"/></svg>',
-      linkedin: '<svg class="share-btn-icon" viewBox="0 0 24 24" aria-hidden="true">' +
-        '<path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0' +
-        '-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 ' +
-        '3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063' +
-        '-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 ' +
-        '0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0' +
-        'H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 ' +
-        '24 23.227 24 22.271V1.729C24 .774 23.2 0 22.225 0z"/></svg>',
-      facebook: '<svg class="share-btn-icon" viewBox="0 0 24 24" aria-hidden="true">' +
-        '<path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 ' +
-        '10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 ' +
-        '4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925' +
-        '-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 ' +
-        '24 12.073z"/></svg>'
-    };
-    var shareButton = function(key, url, label) {
-      return '<button class="share-btn share-btn-' + key + '"' +
-        ' data-share-url="' + escapeAttr(url) + '"' +
-        ' aria-label="' + escapeAttr(label) + '">' +
-        shareIcons[key] +
-        '<span>' + label + '</span>' +
-      '</button>';
-    };
 
-    extraHTML += '<div class="share-progress-section">' +
-      '<p class="share-progress-label">' + intl.str('share-progress') + '</p>' +
-      '<div class="share-progress-buttons">' +
-      shareButton(
-        'twitter',
-        sharing.getTwitterUrl(currentLevelName),
-        intl.str('share-progress-twitter')
-      ) +
-      shareButton(
-        'linkedin',
-        sharing.getLinkedInUrl(currentLevelName),
-        intl.str('share-progress-linkedin')
-      ) +
-      shareButton(
-        'facebook',
-        sharing.getFacebookUrl(currentLevelName),
-        intl.str('share-progress-facebook')
-      ) +
-      '</div>' +
-      '</div>';
+    // Finishing the very last remaining level unlocks the certificate, so
+    // offer a way straight to it.
+    if (options.showCertificateCta) {
+      extraHTML += '<div class="certificateCtaSection">' +
+        '<button type="button" class="certificateCtaButton"' +
+        ' data-certificate-cta>' +
+        intl.str('certificate-cta') +
+        '</button>' +
+        '</div>';
+    }
+
+    extraHTML += sharing.buildShareSectionHTML(
+      sharing.buildShareText(currentLevelName)
+    );
 
     options = Object.assign(
       {},
@@ -550,13 +513,17 @@ class NextLevelConfirm extends ConfirmCancelTerminal {
     // Wire up share button clicks via event delegation on the modal container
     var modalEl = this.modalAlert && this.modalAlert.$el;
     if (modalEl) {
-      modalEl.on('click', '[data-share-url]', function(e) {
-        e.preventDefault();
-        var url = $(e.currentTarget).attr('data-share-url');
-        if (url) {
-          sharing.openShareWindow(url);
-        }
-      });
+      sharing.bindShareButtons(modalEl);
+
+      if (options.onCertificateRequest) {
+        modalEl.on('click', '[data-certificate-cta]', function(e) {
+          e.preventDefault();
+          options.onCertificateRequest();
+          // Dismiss without advancing to a next level; the caller opens the
+          // certificate once this dialog has finished animating away.
+          this.negative();
+        }.bind(this));
+      }
     }
   }
 }

--- a/src/style/main.css
+++ b/src/style/main.css
@@ -1667,3 +1667,154 @@ div.gitDemonstrationView {
   border-color: #6ea9f7;
   background: rgba(24, 119, 242, 0.15);
 }
+
+/* Certificate of completion modal */
+.certificateView {
+  padding: 4px 0 8px;
+  text-align: center;
+}
+
+.certificateHeadline {
+  margin: 0 0 6px;
+  font-size: 22px;
+  letter-spacing: 1px;
+  color: #f2f5f8;
+}
+
+.certificateSubhead {
+  margin: 0 0 18px !important;
+  font-size: 13px;
+  line-height: 1.5 !important;
+  color: #8a8a8a;
+}
+
+.certificateNameRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+}
+
+.certificateNameLabel {
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: #8a8a8a;
+}
+
+.certificateNameInput {
+  font-family: Menlo, Monaco, Consolas, 'Droid Sans Mono', monospace;
+  font-size: 15px;
+  color: #f2f5f8;
+  background: rgba(0, 0, 0, 0.35);
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  border-radius: 6px;
+  padding: 8px 14px;
+  min-width: 260px;
+  max-width: 100%;
+}
+
+.certificateNameInput::placeholder {
+  color: #6b6b6b;
+}
+
+.certificateNameInput:focus {
+  outline: none;
+  border-color: rgb(253, 152, 209);
+}
+
+.certificatePreview {
+  margin: 0 auto;
+  max-width: 760px;
+  line-height: 0;
+}
+
+.certificatePreview svg {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: 10px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.55);
+}
+
+.certificateActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+  margin-top: 18px;
+}
+
+.certificateButton {
+  font-family: Menlo, Monaco, Consolas, 'Droid Sans Mono', monospace;
+  font-size: 13px;
+  color: #d8d8d8;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: 999px;
+  padding: 8px 20px;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.certificateButton:hover:not(:disabled) {
+  color: #fff;
+  border-color: rgb(253, 152, 209);
+  background: rgba(253, 152, 209, 0.14);
+}
+
+.certificateButton:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.certificateStatus {
+  margin: 12px 0 0 !important;
+  min-height: 18px;
+  font-size: 12px;
+  line-height: 18px !important;
+  color: #7fd1a0;
+}
+
+.certificateStatus.certificateStatusError {
+  color: #f08a8a;
+}
+
+/* "View your certificate" call to action in the level complete dialog */
+.certificateCtaSection {
+  margin-top: 18px;
+  text-align: center;
+}
+
+.certificateCtaButton {
+  font-family: Menlo, Monaco, Consolas, 'Droid Sans Mono', monospace;
+  font-size: 14px;
+  font-weight: bold;
+  color: #1a1d23;
+  background: linear-gradient(90deg, #ff66c4, #c084f5, #7278ff);
+  border: none;
+  border-radius: 999px;
+  padding: 10px 26px;
+  cursor: pointer;
+  box-shadow: 0 6px 20px rgba(192, 132, 245, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.certificateCtaButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 26px rgba(192, 132, 245, 0.5);
+}
+
+@media (max-width: 700px) {
+  .certificateNameInput {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .certificateHeadline {
+    font-size: 18px;
+  }
+}


### PR DESCRIPTION
## Summary

- show a dynamically rendered completion certificate after all levels are solved
- let learners add their name, copy the certificate image, or download it as a PNG
- summarize six concepts covered by the curriculum without crowding the certificate
- keep the existing X, LinkedIn, and Facebook sharing options
- center the recipient name and commit graph, and provide an explicit Close button
- remember whether the automatic celebration has already been shown
- expose a `certificate` preview command only when the app is opened from a local `file://` URL

Closes discussion https://github.com/pcottle/learnGitBranching/discussions/1443

## Testing

- `npm test` (376 specs)
- `npm run build` (production bundle, tests, lint, and string validation)