### PR TITLE
Clear certificate name when resetting solved progress

### DIFF
--- a/__tests__/LevelStore.spec.js
+++ b/__tests__/LevelStore.spec.js
@@ -47,6 +47,19 @@ describe('this store', function() {
       .toEqual(false);
   });
 
+  it('clears all certificate state when solved progress is reset', function() {
+    LevelStore.markCertificateSeen();
+    LevelStore.setCertificateName('Previous Learner');
+
+    expect(LevelStore.hasSeenCertificate()).toBe(true);
+    expect(LevelStore.getCertificateName()).toBe('Previous Learner');
+
+    LevelActions.resetLevelsSolved();
+
+    expect(LevelStore.hasSeenCertificate()).toBe(false);
+    expect(LevelStore.getCertificateName()).toBe('');
+  });
+
 
   it('can export and import solved progress', function() {
     var sequenceMap = LevelStore.getSequenceToLevels();

--- a/src/js/stores/LevelStore.js
+++ b/src/js/stores/LevelStore.js
@@ -11,6 +11,7 @@ var ActionTypes = AppConstants.ActionTypes;
 var SOLVED_MAP_STORAGE_KEY = 'solvedMap';
 var ALIAS_STORAGE_KEY = 'aliasMap';
 var CERTIFICATE_SEEN_STORAGE_KEY = 'certificateSeen';
+var CERTIFICATE_NAME_STORAGE_KEY = 'certificateName';
 
 var _levelMap = {};
 var _solvedMap = {};
@@ -147,6 +148,31 @@ function markCertificateSeen() {
   }
 }
 
+/**
+ * The name typed onto the completion certificate. Keeping the certificate's
+ * persisted state together ensures a progress reset can clear it all for the
+ * next learner.
+ * @returns {string}
+ */
+function getCertificateName() {
+  try {
+    return localStorage.getItem(CERTIFICATE_NAME_STORAGE_KEY) || '';
+  } catch (e) {
+    return '';
+  }
+}
+
+/**
+ * @param {string} name
+ */
+function setCertificateName(name) {
+  try {
+    localStorage.setItem(CERTIFICATE_NAME_STORAGE_KEY, name);
+  } catch (e) {
+    // Not being able to remember the name is not worth bothering anyone about.
+  }
+}
+
 var validateLevel = function(level) {
   level = level || {};
   var requiredFields = [
@@ -209,6 +235,8 @@ AppConstants.StoreSubscribePrototype,
 
   hasSeenCertificate: hasSeenCertificate,
   markCertificateSeen: markCertificateSeen,
+  getCertificateName: getCertificateName,
+  setCertificateName: setCertificateName,
 
   getSequenceToLevels: function() {
     return levelSequences;
@@ -314,6 +342,7 @@ AppConstants.StoreSubscribePrototype,
         _syncToStorage();
         try {
           localStorage.removeItem(CERTIFICATE_SEEN_STORAGE_KEY);
+          localStorage.removeItem(CERTIFICATE_NAME_STORAGE_KEY);
         } catch (e) {
           console.warn('local storage failed on remove', e);
         }

--- a/src/js/views/certificateView.js
+++ b/src/js/views/certificateView.js
@@ -7,7 +7,6 @@
  */
 
 var intl = require('../intl');
-var util = require('../util');
 var Views = require('../views');
 var ContainedBase = Views.ContainedBase;
 var ModalTerminal = Views.ModalTerminal;
@@ -18,35 +17,7 @@ var LevelStore = require('../stores/LevelStore');
 var sharing = require('../util/sharing');
 var certificate = require('../util/certificate');
 
-var NAME_STORAGE_KEY = 'certificateName';
 var STATUS_TIMEOUT = 3500;
-
-/**
- * The name typed onto the certificate is remembered between visits so people
- * do not have to retype it. Storage can throw (private browsing, disabled
- * cookies), hence the try/catch on both sides.
- * @returns {string}
- */
-function readStoredName() {
-  if (!util.isBrowser()) { return ''; }
-  try {
-    return window.localStorage.getItem(NAME_STORAGE_KEY) || '';
-  } catch (e) {
-    return '';
-  }
-}
-
-/**
- * @param {string} name
- */
-function writeStoredName(name) {
-  if (!util.isBrowser()) { return; }
-  try {
-    window.localStorage.setItem(NAME_STORAGE_KEY, name);
-  } catch (e) {
-    // Not being able to remember the name is not worth bothering anyone about.
-  }
-}
 
 /**
  * Escape a string for use inside a double-quoted HTML attribute.
@@ -90,7 +61,7 @@ class CertificateView extends ContainedBase {
     this.deferred = options.deferred || createDeferred();
     this.levelsTotal = options.levelsTotal || LevelStore.getTotalLevelCount();
     this.recipientName = options.name === undefined ?
-      readStoredName() :
+      LevelStore.getCertificateName() :
       String(options.name);
     this.statusTimeout = null;
 
@@ -190,7 +161,7 @@ class CertificateView extends ContainedBase {
 
   onNameInput() {
     this.recipientName = this.$('.certificateNameInput').val() || '';
-    writeStoredName(this.recipientName);
+    LevelStore.setCertificateName(this.recipientName);
     this.updatePreview();
   }
 


### PR DESCRIPTION
### Motivation
- Fix a bug where running a solved-progress reset cleared the `certificateSeen` flag but left the stored certificate recipient name around, allowing the next learner to inherit the previous name.
- Keep existing certificate UX (name prefill, live preview, copy/download behavior) while ensuring all per-learner certificate state is cleared on `reset`.

### Description
- Centralize certificate-name persistence into `LevelStore` with a new storage key `certificateName` and accessor functions `getCertificateName` / `setCertificateName`.
- Update `CertificateView` to read and write the recipient name via `LevelStore.getCertificateName()` and `LevelStore.setCertificateName()` instead of touching localStorage directly.
- Clear both `certificateSeen` and `certificateName` from storage when `RESET_LEVELS_SOLVED` is handled so a reset fully removes certificate-related state.
- Add a regression test in `__tests__/LevelStore.spec.js` that verifies both `hasSeenCertificate()` and `getCertificateName()` are cleared after `LevelActions.resetLevelsSolved()`.

### Testing
- Ran `yarn test` and all specs passed (377/377 succeeded).
- Ran `yarn build` which runs the Jasmine suite and build tasks; the build and its test steps completed successfully.
- Ran focused store tests (`gulp test --grep LevelStore`) confirming the new `LevelStore` behaviors passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa55b8f75e0832dacd528abe57ca66b)