### PR TITLE
Fix stale autocomplete hints after programmatic prompt updates

### DIFF
--- a/src/js/views/commandViews.js
+++ b/src/js/views/commandViews.js
@@ -435,6 +435,13 @@ class CommandPromptView {
 
   setTextField(value) {
     this.$('#commandTextField').val(value);
+
+    // This method is also used by command-history navigation, submissions,
+    // and `show solution`, none of which dispatch an input event. Keep the
+    // autocomplete overlay in sync here so a hint for the previously typed
+    // command cannot remain painted over the new value.
+    const { lastCommand } = splitCommands(value);
+    this._updateShadowHint(value, lastCommand);
   }
 
   // Drop some text into the command box and focus it, without submitting --


### PR DESCRIPTION
### Motivation
- Programmatic updates to the command input (history navigation, `show solution`, submissions, etc.) did not refresh the inline autocomplete hint overlay, leaving stale suggestion text visible over the new prompt value.

### Description
- Keep the autocomplete shadow synchronized when the prompt value is changed programmatically by updating `setTextField()` to compute the current `lastCommand` (via `splitCommands`) and call `this._updateShadowHint(value, lastCommand)` in `src/js/views/commandViews.js`.

### Testing
- Ran `yarn test` and all specs passed (377/377 SUCCESS).
- Ran `yarn gulp lint` and the lint task completed successfully.
- Ran `git diff --check` with no issues and performed a local `yarn build` which completed.
- Committed the change and verified working-tree status was clean after the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa55d69d3fc832db5c5ffa0f677225d)